### PR TITLE
Only output result of a cms.beforeDsiplay if it has a output to return

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -112,7 +112,11 @@ class Controller extends BaseController
          * Extensibility
          */
         if (($event = Event::fire('cms.beforeDisplay', [$this, $url, $page])) && is_array($event))
-            return array_pop($event);
+        {
+            while ( $output = array_pop($event) )
+                if ( $output )
+                    return $output;
+        }
 
         /*
          * If the page was not found, render the 404 page - either provided by the theme or the built-in one.


### PR DESCRIPTION
cms.beforeDsiplay is currently used to output the results of the latest binding to the screen. This patch will only return the output to the screen if the event hook returned output to display.

<h4>Example use case</h4>

I have a plugin that uses cms.beforeDisplay to potentially trigger a redirect, however if I don't trigger a redirect, I want the page to continue loading as normal. Here is the basic pseudocode:

``` php
Event::listen('cms.beforeDisplay', function($controller, $url, $page) {
    if ( $url == $a_given_url )
    {
        header("Location: ".$match->to_url, true, $match->redirect_code);
        exit;
    }
});
```

The provided patch will allow this sort of thing to work. If a match isn't found, my event hook returns no output so the listener will continue the page load as normal.
