### PR TITLE
Update Laravel link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please follow the following guides and code standards:
 
 ### Foundation library
 
-The CMS uses [Laravel](http://four.laravel.com) as a foundation PHP framework.
+The CMS uses [Laravel](http://laravel.com) as a foundation PHP framework.
 
 ### Contact
 


### PR DESCRIPTION
The Laravel link pointed to [four.laravel.com](http://four.laravel.com) which doesn't work. Updated it to the main laravel.com site.
