### PR TITLE
Display drag handles in any HTML element

### DIFF
--- a/modules/backend/assets/css/october.css
+++ b/modules/backend/assets/css/october.css
@@ -11170,32 +11170,32 @@ div[data-control="balloon-selector"]:not(.control-disabled) ul li:hover {
   display: inline-block;
   padding: 7px 15px 7px 5px;
 }
-.control-treelist li.dragged {
+.control-treelist .dragged {
   position: absolute;
   z-index: 2000;
   width: auto !important;
   height: auto !important;
 }
-.control-treelist li.dragged > div.record {
+.control-treelist .dragged > .record {
   opacity: 0.5;
   filter: alpha(opacity=50);
   background: #4da7e8 !important;
 }
-.control-treelist li.dragged > div.record > a.move:before,
-.control-treelist li.dragged > div.record > span {
+.control-treelist .dragged > .record > a.move:before,
+.control-treelist .dragged > .record > span {
   color: white;
 }
-.control-treelist li.dragged > div.record:before {
+.control-treelist .dragged > .record:before {
   display: none;
 }
-.control-treelist li.placeholder {
+.control-treelist .placeholder {
   display: inline-block;
   position: relative;
   background: #4da7e8 !important;
   height: 25px;
   margin-bottom: 5px;
 }
-.control-treelist li.placeholder:before {
+.control-treelist .placeholder:before {
   display: block;
   position: absolute;
   font-family: FontAwesome;


### PR DESCRIPTION
A minor CSS tweak to display draggable handles in any HTML element. Previously they were only visible inside lists. Made the same change for the span element so we get consistent padding.
