### PR TITLE
Only change "modified" counter on successful save

### DIFF
--- a/modules/cms/assets/js/october.cmspage.js
+++ b/modules/cms/assets/js/october.cmspage.js
@@ -221,7 +221,7 @@
 
             updateFormEditorMode($(this).closest('.tab-pane'), false)
 
-            if (context.handler == 'onSave') {
+            if (context.handler == 'onSave' && (!data['X_OCTOBER_ERROR_FIELDS'] && !data['X_OCTOBER_ERROR_MESSAGE'])) {
                 $(this).trigger('unchange.oc.changeMonitor')
             }
         })


### PR DESCRIPTION
The modified counter in the CMS module (the red box in the sidebar)
always changes when saving, even when an error is returned.

This fix will only change the "modified" counter in the CMS module on a
successful change.
