### PR TITLE
Respect the directory settings inside the config when checking if they are writable.

### DIFF
--- a/modules/backend/controllers/index/_warnings.htm
+++ b/modules/backend/controllers/index/_warnings.htm
@@ -1,11 +1,14 @@
 <?php
 
+$themesDir = Config::get('cms.themesDir');
+$uploadsDir = Config::get('cms.uploadsDir');
+
 $warnings = [];
 $writablePaths = [
-    '/themes',
-    '/uploads',
-    '/uploads/public',
-    '/uploads/protected',
+    $themesDir,
+    $uploadsDir,
+    $uploadsDir.'/public',
+    $uploadsDir.'/protected',
     '/app/storage',
     '/app/storage/logs',
     '/app/storage/cache',


### PR DESCRIPTION
Currently the warnings assume you are using the /uploads/ and /themes/ directory, which isn't always the case if you've changed this inside the config.
