### PR TITLE
Use Redactor in iframe mode

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -41,7 +41,7 @@
          * Initialize Redactor editor
          */
         this.$textarea.redactor({
-            fullpage: true,
+            iframe: true,
             css: this.options.iframeCss,
             focusCallback: function() { self.$el.addClass('editor-focus') },
             blurCallback: function() { self.$el.removeClass('editor-focus') }


### PR DESCRIPTION
I've been attempting to use the richeditor (Redactor) on a few fields in my plugin and have realized that Redactor seems to be hard coded to be in 'fullpage' mode.

Docs for this mode can be seen [here](http://imperavi.com/redactor/docs/settings/#set-fullpage)

In this mode it creates markup for an entire page (includes `<html></html>` tags) rather than just the markup for a content block. I wasn't able to find anywhere in October utilizing Redactor in this way, so I'm not sure why this mode is implemented.

Maybe a better solution is to be able to change how Redactor is initialized, but this commit makes the richeditor field type useable for simple content block editing.
