### PR TITLE
Fix to allow default values to populate even if model is present.

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -486,8 +486,11 @@ class Form extends WidgetBase
 
         if (!$this->model->exists)
             $defaultValue = strlen($field->defaults) ? $field->defaults : null;
-        else
-            $defaultValue = (isset($this->data->{$columnName})) ? $this->data->{$columnName} : null;
+        elseif (!isset($this->data->{$columnName})) {
+            $defaultValue = strlen($field->defaults) ? $field->defaults : null;
+        } else {
+            $defaultValue = $this->data->{$columnName};
+        }
 
         /*
          * Array field name, eg: field[key][key2][key3]


### PR DESCRIPTION
This accompanies commit 8359baa71989d96cfafcf957c4a36a8a1150146a. To fix the default values bug. Previously if the model existed on the object the default value would not be used even if the value coming from the model was blank. This allows a model to be returned to the form and blank values which have a default set in the config to still populate those fields.
