### PR TITLE
Rewind RecursiveIteratorIterator before use

### DIFF
--- a/modules/cms/classes/CmsObject.php
+++ b/modules/cms/classes/CmsObject.php
@@ -385,6 +385,7 @@ class CmsObject implements ArrayAccess
 
         $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dirPath));
         $it->setMaxDepth(1); // Support only a single level of subdirectories
+        $it->rewind();
 
         while($it->valid()) {
             if ($it->isFile() && in_array($it->getExtension(), static::$allowedExtensions)) {


### PR DESCRIPTION
Fixes #157, #158, #163, #268 and #288.

More info: https://bugs.php.net/bug.php?id=62914

> As a reminder, all iterators have been designed in a way that you need to call rewind before using.
