### PR TITLE
Make initTwigEnvironment public

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -208,7 +208,7 @@ class Controller extends BaseController
      * Registers the \Cms\Twig\Extension object with Twig.
      * @return \Twig_Environment Returns the Twig environment object.
      */
-    protected function initTwigEnvironment()
+    public function initTwigEnvironment()
     {
         $this->loader = new TwigLoader();
 


### PR DESCRIPTION
I'm trying to render a cms Partial (and soon Content too) from a random method and am using the following code

``` php
$theme = Theme::getEditTheme();
$controller = new Controller($theme);
$controller->initTwigEnvironment();

return $controller->renderPartial('foo');
```

Unfortunately this isn't currently possible due to `initTwigEnvironment()` being protected. This pull request fixes that.

Unless there is a better way?
