### PR TITLE
Fix in detecting production env

### DIFF
--- a/bootstrap/start.php
+++ b/bootstrap/start.php
@@ -25,7 +25,7 @@ $app = new Illuminate\Foundation\Application;
 */
 
 $env = $app->detectEnvironment(function(){
-	return isset($_SERVER['CMS_ENV']) ? $_SERVER['CMS_ENV'] : null;
+	return isset($_SERVER['CMS_ENV']) ? $_SERVER['CMS_ENV'] : 'production';
 });
 
 /*


### PR DESCRIPTION
By default `detectEnvironment()` returns `production` when environment is not detected.

However when `Closure` is passed the value returned by it will be set as environment.
In this case returning `null` means that Laravel won't recognize any environment. In such situation any `production` configs won't be loaded.
