### PR TITLE
added CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing Guidelines
+All pull requests should be send to the `develop` branch.
+
+Also ensure that your PR satisfies the following coding standards:
+
+- [PSR 2 Coding Style Guide](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
+- [PSR 1 Coding Style Guide](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md)
+- [PSR 0 Coding Style Guide](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md)

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ You can communicate with us using the following mediums:
 ### Licence
 
 The OctoberCMS platform is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).
+
+### Contributing
+
+Before sending a PR, be sure to review the [Contributing Guidelines](CONTRIBUTING.md) first.


### PR DESCRIPTION
I noticed you often have to repeat that PR's should be send to `develop` branch. Instead of doing that, I've created a `CONTRIBUTING.md` which allows you to settle it once and for all, to redirect PR's to the right branch.

You can read more information about adding a CONTRIBUTING file [here](https://help.github.com/articles/how-do-i-set-up-guidelines-for-contributors).

PS: I don't think this PR is worth to send to `develop` branch :)
