### PR TITLE
Fix DocBlock

### DIFF
--- a/modules/system/classes/ExceptionBase.php
+++ b/modules/system/classes/ExceptionBase.php
@@ -91,7 +91,7 @@ class ExceptionBase extends Exception
      * and Php errors.
      * @param string $message Error message.
      * @param int $code Error code.
-     * @param closure $closure Closure function containing code to execute.
+     * @param \closure $closure Closure function containing code to execute.
      * @param array $params Parameters passed to the function as the first parameter.
      * @return mixed Returned value from the closure function.
      */


### PR DESCRIPTION
Being in a namespace of it's own, the type hint for $closure should be \closure (otherwise it assumes that it belongs in the `System\Classes` namespace)

(sorry for the diff on the last line of the file, the GitHub online editor changed that!)
