### PR TITLE
Use CmsObjectCollection in listInTheme

### DIFF
--- a/modules/cms/classes/CmsObject.php
+++ b/modules/cms/classes/CmsObject.php
@@ -378,7 +378,7 @@ class CmsObject implements ArrayAccess
             throw new ApplicationException(Lang::get('cms::lang.theme.active.not_set'));
 
         $dirPath = $theme->getPath().'/'.static::getObjectTypeDirName();
-        $result = [];
+        $result = new CmsObjectCollection;
 
         if (!File::isDirectory($dirPath))
             return $result;
@@ -394,7 +394,7 @@ class CmsObject implements ArrayAccess
                     $filePath = basename($it->getPath()).'/'.$filePath;
 
                 $page = $skipCache ? static::load($theme, $filePath) : static::loadCached($theme, $filePath);
-                $result[] = $page;
+                $result->add($page);
             }
 
             $it->next();

--- a/modules/cms/classes/CmsObjectCollection.php
+++ b/modules/cms/classes/CmsObjectCollection.php
@@ -11,4 +11,16 @@ use System\Classes\ApplicationException;
  */
 class CmsObjectCollection extends CollectionBase
 {
+    /**
+     * Add an item to the collection.
+     *
+     * @param  mixed  $item
+     * @return Cms\Classes\CmsObjectCollection
+     */
+    public function add($item)
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
 }

--- a/tests/unit/cms/classes/ThemeTest.php
+++ b/tests/unit/cms/classes/ThemeTest.php
@@ -2,7 +2,7 @@
 
 use Cms\Classes\Theme;
 
-class ThemeTest extends TestCase 
+class ThemeTest extends TestCase
 {
     public function setUp()
     {
@@ -41,10 +41,10 @@ class ThemeTest extends TestCase
         $theme->load('test');
 
         $pages = $theme->listPages();
-        $this->assertInternalType('array', $pages);
+        $this->assertInstanceOf('\Cms\Classes\CmsObjectCollection', $pages);
 
         $expectedPageNum = $this->countThemePages(base_path().'/tests/fixtures/Cms/themes/test/pages');
-        $this->assertEquals($expectedPageNum, count($pages));
+        $this->assertEquals($expectedPageNum, $pages->count());
 
         $this->assertInstanceOf('\Cms\Classes\Page', $pages[0]);
         $this->assertNotEmpty($pages[0]->url);


### PR DESCRIPTION
This will implement the CmsObjectCollection for the listInTheme call. This alows the usage of the ->sort() method for page. 

Also this was a question as to the usage of the CmsObjectCollection at large. I see it in CmsObjectQuery but no where else, instead arrays are being passed around. Is this just not completely implemented yet or is there something else going on here?

Also included are updated unit tests.
