### PR TITLE
Add pattern to number field to only allow for numbers

### DIFF
--- a/modules/backend/widgets/form/partials/_field_number.htm
+++ b/modules/backend/widgets/form/partials/_field_number.htm
@@ -11,6 +11,7 @@
         class="form-control"
         autocomplete="off"
         maxlength="255"
+        pattern="\d+"
         <?= HTML::attributes($field->attributes) ?>
     />
 <?php endif ?>


### PR DESCRIPTION
This adds a pattern to the number field to only allow for numbers as requested by #384.
