### PR TITLE
Fix-- antialias issue where font renders bold on mac webkit browsers */

### DIFF
--- a/modules/backend/assets/less/layout/layout.less
+++ b/modules/backend/assets/less/layout/layout.less
@@ -29,6 +29,8 @@ body {
 
 body {
     background: @color-body-bg;
+    /* fix antialias issue where font renders bold on mac browsers */
+    webkit-font-smoothing: antialiased !important;font-size:14px !important;
 }
 
 #layout-canvas {


### PR DESCRIPTION
FIX --
This is a known Webkit bug — any text with @font-face applied will be rendered without anti-aliasing if there is a text element without anti-aliasing applied preceding it. Usually those are fonts smaller than 5px or monospaced fonts at small sizes which are rendered without anti-aliasing.
