### PR TITLE
Don't allow [ or ] characters in field IDs

### DIFF
--- a/modules/backend/classes/WidgetBase.php
+++ b/modules/backend/classes/WidgetBase.php
@@ -131,7 +131,7 @@ abstract class WidgetBase
         if ($suffix !== null)
             $id .= '-' . $suffix;
 
-	$id = str_replace(['[', ']'], '__', $id);
+        $id = str_replace(['[', ']'], '__', $id);
 
         return $id;
     }


### PR DESCRIPTION
When I add a nested field to a form, its ID is created with an invalid value resulting in potential javascript errors.
## Example

Add the following config to your `fields.yaml`

``` yaml
config_data[rates]:
    label: Rates
    type: datagrid
    tab: Rates
```

The field will be rendered like so:

``` html
<div
    id="Grid-formConfigData[rates]Grid"
    style="width:100%"
    class="control-datagrid"
    data-control="datagrid"
    data-allow-remove="true"
    data-autocomplete-handler="formConfigData[rates]Grid::onAutocomplete"
    data-data-locker="#DataGrid-formConfigData[rates]-dataLocker-config_data[rates]"                data-change-handler="formConfigData[rates]Grid::onDataChanged"        ></div>

</div>
<script>
    $('#Grid-formConfigData[rates]Grid')
```

Notice both the div's ID attribute and the JQuery selector are invalid. This results in a javascript error and the data grid not working.
