### PR TITLE
Support custom currency formats in Grid widget

### DIFF
--- a/modules/backend/widgets/Grid.php
+++ b/modules/backend/widgets/Grid.php
@@ -226,7 +226,7 @@ class Grid extends WidgetBase
 
             case 'currency':
                 $item['type'] = 'numeric';
-                $item['format'] = '$0,0.00';
+                $item['format'] = isset($column['format']) ? $column['format'] : '$0,0.00';
                 break;
 
             case 'checkbox':


### PR DESCRIPTION
Grid widget currently forces dollar values for the `currency` format type. This PR allows custom currency formats to be accepted.
## Usage

``` yaml
price:
    title: Price
    type: currency
    format: 0,0[.]00 $
```

Defaults to the current `$0,0.00` dollar values.
