### PR TITLE
[DataGrid widget] Add getGrid method

### DIFF
--- a/modules/backend/formwidgets/DataGrid.php
+++ b/modules/backend/formwidgets/DataGrid.php
@@ -39,6 +39,14 @@ class DataGrid extends FormWidgetBase
     }
 
     /**
+     * @return Backend\Widgets\Grid   The grid to be displayed.
+     */
+    public function getGrid()
+    {
+        return $this->grid;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function render()


### PR DESCRIPTION
When you create a `DataGrid` widget, there is currently no way to communicate with the `Grid` it uses. This allows you to do stuff like:

``` php
$datagrid = $this->makeWidget('Backend\FormWidgets\DataGrid', $config);
$datagrid->getGrid()->bindEvent('grid.dataChanged', function($changes) {
    ...
});
```
