### PR TITLE
Update _image_single.htm

### DIFF
--- a/modules/backend/formwidgets/fileupload/partials/_image_single.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_image_single.htm
@@ -65,7 +65,7 @@
 
                 <a
                     href="{{path}}"
-                    class="uploader-file-link oc-icon-paper-clip"
+                    class="uploader-file-link oc-icon-paperclip"
                     target="_blank"></a>
             </div>
         </div>


### PR DESCRIPTION
Paperclip icon with a href was not displayed on the already uploaded image, due to error in icon name.
