### PR TITLE
Attempt to display error message in event log list

### DIFF
--- a/modules/system/controllers/eventlogs/_message_column.htm
+++ b/modules/system/controllers/eventlogs/_message_column.htm
@@ -1,1 +1,6 @@
-<?= Str::limit($value, 100) ?>
+<?php
+	if (preg_match("/with message '(.+)' in/", $value, $matches))
+		echo $matches[1];
+	else
+		echo Str::limit($value, 100);
+?>


### PR DESCRIPTION
This PR cleans up the error log by showing the actual error message where possible. Screenshots below to demonstrate.
## Before

![before](http://i.imgur.com/3BSfOoO.png)
## After

![after](http://i.imgur.com/TWksLmQ.png)
