### PR TITLE
Add getTwig controller method

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -265,6 +265,16 @@ class Controller extends BaseController
     }
 
     /**
+     * Returns the Twig environment.
+     *
+     * @return Twig_Environment
+     */
+    public function getTwig()
+    {
+        return $this->twig;
+    }
+
+    /**
      * Initializes the custom layout and page objects.
      */
     protected function initCustomObjects()


### PR DESCRIPTION
A simple method to provide the current twig environment to plugins. Useful for things such as adding [this](https://github.com/barryvdh/laravel-debugbar/blob/master/src/Barryvdh/Debugbar/Twig/Extension/Debug.php#L57).
