### PR TITLE
Fix an issue when searching an asset in CMS backend

### DIFF
--- a/modules/cms/widgets/AssetList.php
+++ b/modules/cms/widgets/AssetList.php
@@ -640,7 +640,7 @@ class AssetList extends WidgetBase
                 if ($this->pathMatchesSearch($words, $path)) {
                     $result[] = (object)[
                         'type'=>'file',
-                        'path'=>$path,
+                        'path'=>File::normalizePath($path),
                         'name'=>$item->getFilename(),
                         'editable'=>in_array(strtolower($item->getExtension()), $editableAssetTypes)
                     ];


### PR DESCRIPTION
On Windows, searching for a file returns the path with the "\" separator, and throws an error when selecting the file for editing.
