### PR TITLE
Set twigs debug state to the same as Octobers

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -257,7 +257,7 @@ class Controller extends BaseController
 
         $options = [
             'auto_reload' => true,
-            'debug' => Config::get('app.debug', false)
+            'debug' => Config::get('app.debug', false),
         ];
         if (!Config::get('cms.twigNoCache'))
             $options['cache'] =  storage_path().'/twig';


### PR DESCRIPTION
When app.debug is set to true, Twig should be set to debug state too.
