### PR TITLE
Add support for request-before-update, request-success attribs on popup fields

### DIFF
--- a/modules/backend/assets/js/october.popup.js
+++ b/modules/backend/assets/js/october.popup.js
@@ -1,6 +1,6 @@
 /*
  * Ajax Popup plugin
- * 
+ *
  * Data attributes:
  * - data-control="popup" - enables the ajax popup plugin
  * - data-ajax="popup-content.htm" - ajax content to load
@@ -99,9 +99,19 @@
             this.$el.request(this.options.handler, {
                 data: this.options.extraData,
                 success: function(data, textStatus, jqXHR) {
+                    var context = { handler: this.handler, options: this.options }
+
+                    /*
+                     * Halt here if beforeUpdate() or data-request-before-update returns false
+                     */
+                    if (this.options.beforeUpdate.apply(this, [data, textStatus, jqXHR]) === false) return
+                    if (this.options.evalBeforeUpdate && eval('(function($el, context, data, textStatus, jqXHR) {'+this.options.evalBeforeUpdate+'}($el, context, data, textStatus, jqXHR))') === false) return
+
                     self.setContent(data.result)
                     $(window).trigger('ajaxUpdateComplete', [this, data, textStatus, jqXHR])
                     self.triggerEvent('popupComplete')
+
+                    this.options.evalSuccess && eval('(function($el, context, data, textStatus, jqXHR) {'+this.options.evalSuccess+'}(this.$el, context, data, textStatus, jqXHR))')
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     alert(jqXHR.responseText.length ? jqXHR.responseText : jqXHR.statusText)
@@ -168,7 +178,7 @@
             this.$backdrop = null;
         }
     }
-    
+
     Popup.prototype.setLoading = function(val) {
         if (!this.$backdrop)
             return;


### PR DESCRIPTION
This PR adds support for `data-request-success` and `data-before-update` attributes on elements that open popup data controls so they're more in line with the rest of the october JS framework.
## Example usage

``` html
<a href="#" data-control="popup" data-handler="onOpenModal" data-request-success="alert('hi')" class="btn btn-default btn-sm oc-icon-plus">Test</a>
```
