### PR TITLE
Add support for request-before-update, request-success attribs on popup ...

### DIFF
--- a/modules/backend/assets/js/october.popup.js
+++ b/modules/backend/assets/js/october.popup.js
@@ -105,7 +105,7 @@
                      * Halt here if beforeUpdate() or data-request-before-update returns false
                      */
                     if (this.options.beforeUpdate.apply(this, [data, textStatus, jqXHR]) === false) return
-                    if (this.options.evalBeforeUpdate && eval('(function($el, context, data, textStatus, jqXHR) {'+this.options.evalBeforeUpdate+'}($el, context, data, textStatus, jqXHR))') === false) return
+                    if (this.options.evalBeforeUpdate && eval('(function($el, context, data, textStatus, jqXHR) {'+this.options.evalBeforeUpdate+'}(self.$el, context, data, textStatus, jqXHR))') === false) return
 
                     self.setContent(data.result)
                     $(window).trigger('ajaxUpdateComplete', [this, data, textStatus, jqXHR])


### PR DESCRIPTION
This PR adds support for `data-request-success` and `data-before-update` attributes on elements that open popup data controls so they're more in line with the rest of the october JS framework.
## Example usage

``` html
<a href="#" data-control="popup" data-handler="onOpenModal" data-request-success="alert('hi')" class="btn btn-default btn-sm oc-icon-plus">Test</a>
```
