### PR TITLE
Refs #568 - Inherit the parent framework error function

### DIFF
--- a/modules/backend/assets/js/october.popup.js
+++ b/modules/backend/assets/js/october.popup.js
@@ -1,6 +1,6 @@
 /*
  * Ajax Popup plugin
- * 
+ *
  * Data attributes:
  * - data-control="popup" - enables the ajax popup plugin
  * - data-ajax="popup-content.htm" - ajax content to load
@@ -104,9 +104,11 @@
                     self.triggerEvent('popupComplete')
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
-                    alert(jqXHR.responseText.length ? jqXHR.responseText : jqXHR.statusText)
-                    self.hide()
-                    self.triggerEvent('popupError')
+                    this.error(jqXHR, textStatus, errorThrown).done(function(){
+                        alert(jqXHR.responseText.length ? jqXHR.responseText : jqXHR.statusText)
+                        self.hide()
+                        self.triggerEvent('popupError')
+                    })
                 }
             })
 
@@ -168,7 +170,7 @@
             this.$backdrop = null;
         }
     }
-    
+
     Popup.prototype.setLoading = function(val) {
         if (!this.$backdrop)
             return;


### PR DESCRIPTION
The error function also needs to inherit parent error function so we get things like validation errors appearing.

Even with this change, if a validation error occurs in a form in a modal, the modal will disappear and an alert containing the XHR response displays. This is obviously not a good thing. I'm not sure how you'd solve it.

This PR at least gets the validation error displaying and adds support for all the error-related stuff framework.js currently supports.
