### PR TITLE
Fix formwidget IDs for nested fields

### DIFF
--- a/modules/backend/classes/FormWidgetBase.php
+++ b/modules/backend/classes/FormWidgetBase.php
@@ -66,6 +66,7 @@ abstract class FormWidgetBase extends WidgetBase
     {
         $id = parent::getId($suffix);
         $id .= '-' . $this->columnName;
+        $id = rtrim(str_replace(['[', ']'], '-', $id), '-');
         return $id;
     }
 


### PR DESCRIPTION
This removes [ and ] characters from FormWidget field IDs. This is the same as #474 ([your modified version](https://github.com/octobercms/october/blob/master/modules/backend/classes/WidgetBase.php#L134)) but for FormWidgets.

[Demonstration repo](https://github.com/Flynsarmy/oc-badfileupload-plugin)
