### PR TITLE
Refs #485, #504 - Allow adding nested FileUpload files

### DIFF
--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -81,7 +81,6 @@ class FileUpload extends FormWidgetBase
 
     protected function getFileList()
     {
-        $columnName = $this->columnName;
         $list = $this->getColumn()->withDeferred($this->sessionKey)->orderBy('sort_order')->get();
 
         /*
@@ -113,7 +112,6 @@ class FileUpload extends FormWidgetBase
     public function onRemoveAttachment()
     {
         if (($file_id = post('file_id')) && ($file = File::find($file_id))) {
-            $columnName = $this->columnName;
             $this->getColumn()->remove($file, $this->sessionKey);
         }
     }
@@ -205,7 +203,6 @@ class FileUpload extends FormWidgetBase
             if (!$uploadedFile->isValid())
                 throw new SystemException('File is not valid');
 
-            $columnName = $this->columnName;
             $fileRelation = $this->getColumn();
 
             $file = new File();


### PR DESCRIPTION
With a YAML field of `defaultOptions[images]` the new `getColumn()` method returns `$this->model->defaultOptions->images()` as expected. Works infinitely deep.
- This PR is backwards compatible.
- PR #578 is required for adding to work correctly.
- PR #580 is required for removing to work correctly.
- This PR only allows fixes the FileUpload formwidget. Saving forms with nested FileUpload fields still fail due to SQL error _SQLSTATE[42S22]: Column not found: 1054 Unknown column 'defaultOptions[images]' in 'field list'_ which is a bug in a different part of October.

[Demonstration repo](https://github.com/Flynsarmy/oc-badfileupload-plugin)
