### PR TITLE
Replace [ and ] characters in aliases with underscores for nested fields

### DIFF
--- a/modules/backend/classes/WidgetBase.php
+++ b/modules/backend/classes/WidgetBase.php
@@ -71,7 +71,10 @@ abstract class WidgetBase
          * If no alias is set by the configuration.
          */
         if (!isset($this->alias))
+        {
             $this->alias = (isset($this->config->alias)) ? $this->config->alias : $this->defaultAlias;
+            $this->alias = rtrim(str_replace(['[', ']'], '_', $this->alias), '_');
+        }
 
         /*
          * Prepare assets used by this widget.


### PR DESCRIPTION
With a YAML field of `defaultOptions[images]`, `$this->getEventHandler('onRemoveAttachment')` returns _formDefaultOptions[images]::onRemoveAttachment_ which is invalid and just results in a Javascript error. This PR fixes the field alias so it uses underscores instead of [ and ].

[Demonstration repo](https://github.com/Flynsarmy/oc-badfileupload-plugin)
