### PR TITLE
Fire extendQuery hook after select()

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -412,13 +412,14 @@ class Lists extends WidgetBase
             $callback($query);
         }
 
+        $query->select($selects);
+
         /*
          * Extensibility
          */
         Event::fire('backend.list.extendQuery', [$this, $query]);
         $this->fireEvent('list.extendQuery', [$query]);
 
-        $query->select($selects);
         return $query;
     }
 
@@ -1042,7 +1043,7 @@ class Lists extends WidgetBase
     //
     // Helpers
     //
-    
+
     /**
      * Check if column refers to a relation of the model
      * @param  ListColumn  $column List column object


### PR DESCRIPTION
I'm trying to call `$query->addSelect()` inside the Lists widget's `extendQuery` event however you currently call `$query->select($selects);` [after extendQuery](https://github.com/octobercms/october/blob/master/modules/backend/widgets/Lists.php#L421) - removing my added select fields. `extendQuery` always allow for complete customisation of the query by running last.
