### PR TITLE
Allow complex sortable columns

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -402,6 +402,16 @@ class Lists extends WidgetBase
          * Apply sorting
          */
         if ($sortColumn = $this->getSortColumn()) {
+            // Determine if the column has an sqlSelect
+            foreach ($this->getListColumns() as $column) {
+                if ($column->columnName == $sortColumn) {
+                    if ($column->sqlSelect) {
+                        $sortColumn = $column->sqlSelect;
+                    }
+                    break;
+                }
+            }
+
             $query->orderBy($sortColumn, $this->sortDirection);
         }
 
@@ -1042,7 +1052,7 @@ class Lists extends WidgetBase
     //
     // Helpers
     //
-    
+
     /**
      * Check if column refers to a relation of the model
      * @param  ListColumn  $column List column object


### PR DESCRIPTION
When attempting to sort by one of my columns I was getting the error

> SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'weight' in order clause is ambiguous

This was due to my _weight_ column having a `select: fooTable.weight` property but it not being reflected in the `order by` clause of the SQL being generated by the Lists widget.

This PR allows for columns that use a custom `select` to be sortable.
