### PR TITLE
Add missing comma to array language definition

### DIFF
--- a/modules/system/lang/ro/lang.php
+++ b/modules/system/lang/ro/lang.php
@@ -14,7 +14,7 @@ return [
         'de' => 'Germana',
         'ru' => 'Rusa',
         'fr' => 'Franceza',
-        'ro' => 'Romana'
+        'ro' => 'Romana',
         'pt-br' => 'Portugheza (Brazilia)',
     ],
     'directory' => [


### PR DESCRIPTION
Line 17 - there was a missing comma between the items of the 'locale' array
