### PR TITLE
Correctly sanitize number fields

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -706,7 +706,7 @@ class Form extends WidgetBase
             $columnParts = Str::evalHtmlArray($field->columnName);
             $columnDotted = implode('.', $columnParts);
             $columnValue = array_get($data, $columnDotted, 0);
-            if ($field->type == 'number') $columnValue = (int) $columnValue;
+            if ($field->type == 'number') $columnValue = (float) $columnValue;
             array_set($data, $columnDotted, $columnValue);
         }
 


### PR DESCRIPTION
You're currently treating all number fields as integers, however a number can be more than just an integer. This PR ensures a valid number while allowing for more than just integers to exist.

See also #380 - perhaps this would be a good place to truncate to a given number of decimals (default 0?)
