### PR TITLE
Ability to add and override redactor settings.

### DIFF
--- a/app/config/cms.php
+++ b/app/config/cms.php
@@ -216,4 +216,20 @@ return array(
 
     'convertLineEndings' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Richeditor (redactor) settings file path
+    |--------------------------------------------------------------------------
+    |
+    | If you want to override the default settings, add your redactor settings in a js
+    |   file in a public path, then and add the path below.  Something like '/uploads/public/richeditorSettings.js'
+    |
+    | The js file should contain a single variable with all your settings within it like so:
+    |    var redactorSettings = {convertImageLinks: true,imageFloatMargin: '30px'};
+    |
+    | You can find the redactor settings located here: http://imperavi.com/redactor/docs/settings
+    |
+    */
+    'richeditorSettings' => 'js/richeditorSettings.js',
+
 );

--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -1,6 +1,7 @@
 <?php namespace Backend\FormWidgets;
 
 use Backend\Classes\FormWidgetBase;
+use Config;
 
 /**
  * Rich Editor
@@ -60,6 +61,7 @@ class RichEditor extends FormWidgetBase
         $this->addJs('vendor/redactor/redactor.js', 'core');
 
         // Rich editor
+        $this->addJs(Config::get('cms.richeditorSettings', 'js/richeditorSettings.js'), 'core');
         $this->addCss('css/richeditor.css', 'core');
         $this->addJs('js/richeditor.js', 'core');
 

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -76,6 +76,12 @@
         // redactorOptions.plugins = ['cleanup', 'fullscreen', 'figure', 'table', 'quote']
         redactorOptions.plugins = ['cleanup', 'fullscreen', 'figure', 'quote']
 
+        /*
+         * Combine the redactor settings (possibly custom) with the options above
+         * This allows you to override any of the above settings as well.
+         */
+        for (var redactorSetting in redactorSettings) { redactorOptions[redactorSetting] = redactorSettings[redactorSetting]; }
+
         this.$textarea.redactor(redactorOptions)
     }
 

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditorSettings.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditorSettings.js
@@ -1,0 +1,11 @@
+var redactorSettings = {
+    /*
+     *  This is left blank intentionally.
+     *
+     *  An example of how to use this file might be like:
+     *  fileUpload: '/file_upload.php',
+     *  imageUpload: '/image_upload.php'
+     *
+     *  ... copy this file to a public location and set the path within cms.php, flush your cache and reload the browser.
+     */
+}


### PR DESCRIPTION
I needed the ability to easily add redactor settings (ie, from http://imperavi.com/redactor/docs/settings) so I added a simple way to do that.

The basic workflow:
* create a js file in a public location with all your redactor settings in it
* set the path to the file within your cms.php file.
* flush cache and the new settings will be added to your redactor settings.

Any setting you add that is already existing in the richeditor.js will overwrite the richeditor.js setting.
