### PR TITLE
Update pagination for Bootstrap v3

### DIFF
--- a/app/config/view.php
+++ b/app/config/view.php
@@ -26,6 +26,6 @@ return array(
 	|
 	*/
 
-	'pagination' => 'pagination::slider',
+	'pagination' => 'pagination::slider-3',
 
 );


### PR DESCRIPTION
This is an update in accordance to #601

Laravel made an update for pagination to work with Bootstrap v3. October also uses Bootstrap v3.1.1, so it would make sense for this version to be the default pagination output.

Reference: https://github.com/laravel/docs/pull/421
