### PR TITLE
Send a 0 value when a checkbox is unchecked

### DIFF
--- a/modules/backend/widgets/form/partials/_field_checkbox.htm
+++ b/modules/backend/widgets/form/partials/_field_checkbox.htm
@@ -1,6 +1,11 @@
 <!-- Checkbox -->
 <div class="checkbox custom-checkbox">
     <input
+        type="hidden"
+        name="<?= $field->getName() ?>"
+        value="0"
+        <?= $this->previewMode ? 'disabled="disabled"' : '' ?>>    
+    <input
         type="checkbox"
         id="<?= $field->getId() ?>"
         name="<?= $field->getName() ?>"


### PR DESCRIPTION
Someone [on the forum](http://octobercms.com/plugin/flynsarmy-menu/disabled-menuitems) noticed my checkboxes weren't staying unchecked after saving a form. This is because when a checkbox is checked a '1' POST value is sent, but when unchecked no value at all is sent and so the field isn't updated in the database. This PR sends a 0 unless the field is checked.
