### PR TITLE
Add Event trigger to the signin form

### DIFF
--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -13,7 +13,7 @@ use System\Classes\VersionManager;
 use System\Classes\ApplicationException;
 use October\Rain\Support\ValidationException;
 use Exception;
-
+use Event;
 /**
  * Authentication controller
  *
@@ -44,6 +44,7 @@ class Auth extends Controller
      */
     public function signin()
     {
+        Event::fire('backend.admin.signinform', [$this]);
         $this->bodyClass = 'signin';
 
         try {


### PR DESCRIPTION
Added the Event backend.admin.signinform in order to trigger an event upon the rendering of the admin sign in form. This is useful when trying to customize the look and feel of the sign in form through a plugin.
