### PR TITLE
add mailgun support patch

### DIFF
--- a/modules/system/models/MailSettings.php
+++ b/modules/system/models/MailSettings.php
@@ -19,6 +19,7 @@ class MailSettings extends Model
     const MODE_MAIL     = 'mail';
     const MODE_SENDMAIL = 'sendmail';
     const MODE_SMTP     = 'smtp';
+    const MODE_MAILGUN  = 'mailgun';
 
     public function initSettingsData()
     {
@@ -40,6 +41,7 @@ class MailSettings extends Model
             static::MODE_MAIL     => 'PHP mail',
             static::MODE_SENDMAIL => 'Sendmail',
             static::MODE_SMTP     => 'SMTP',
+            static::MODE_MAILGUN  => 'Mailgun',
         ];
     }
 
@@ -68,6 +70,11 @@ class MailSettings extends Model
 
             case self::MODE_SENDMAIL:
                 $config->set('mail.sendmail', $settings->sendmail_path);
+                break;
+
+            case self::MODE_MAILGUN:
+                $config->set('services.mailgun.domain', $settings->mailgun_domain);
+                $config->set('services.mailgun.secret', $settings->mailgun_secret);
                 break;
         }
     }

--- a/modules/system/models/mailsettings/fields.yaml
+++ b/modules/system/models/mailsettings/fields.yaml
@@ -53,3 +53,13 @@ tabs:
       label: system::lang.mail.sendmail_path
       commentAbove: system::lang.mail.sendmail_path_comment
       tab: system::lang.mail.sendmail
+
+    mailgun_domain:
+      label: system::lang.mail.mailgun_domain
+      commentAbove: system::lang.mail.mailgun_domain_comment
+      tab: system::lang.mail.mailgun
+
+    mailgun_secret:
+      label: system::lang.mail.mailgun_secret
+      commentAbove: system::lang.mail.mailgun_domain_secret
+      tab: system::lang.mail.mailgun


### PR DESCRIPTION
October overrides basic file-based mail settings with those from database, which is a good thing for usability, but brakes Laravel mailgun / mandrill drivers and ends up as 500 on HHVM (which doesn't support swiftmailer SMTP). Added support for Mailgun option in backend settings, mailgun now works fine.

Additional translations will have to be added in backend translation files.
