### PR TITLE
Add .env.*.php files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ nginx-ssl.error.log
 php-errors.log
 sftp-config.json
 selenium.php
+.env.*.php
+.env.php


### PR DESCRIPTION
It's undoubtedly a best practice to use .env.*.php files to store db credentials, api keys etc. We should make sure that these files do not get version controlled.
