### PR TITLE
fixed language reference in dialog box for plugin disable form

### DIFF
--- a/modules/system/controllers/updates/_disable_form.htm
+++ b/modules/system/controllers/updates/_disable_form.htm
@@ -41,7 +41,7 @@
             type="submit"
             class="btn btn-primary"
             data-request="onDisablePlugins"
-            data-request-confirm="<?= e(trans('backend::lang.plugins.disable_confirm')) ?>"
+            data-request-confirm="<?= e(trans('system::lang.plugins.disable_confirm')) ?>"
             data-stripe-load-indicator>
             <?= e(trans('backend::lang.form.apply')) ?>
         </button>


### PR DESCRIPTION
The dialog box made a call to the language in the improper namespace....this resolves that
