### PR TITLE
when building belongsToMany relationships in controllers, the lack of a ...

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -414,7 +414,7 @@ class RelationController extends ControllerBehavior
      */
     protected function findExistingRelationIds($checkIds = null)
     {
-        $foreignKeyName = $this->relationModel->getKeyName();
+        $foreignKeyName = $this->relationModel->table . '.' . $this->relationModel->getKeyName();
 
         $results = $this->relationObject
             ->getBaseQuery()


### PR DESCRIPTION
...table name

alias causes an sql ambigious Id error
