### PR TITLE
Add .editorconfig to encourage pretty and uniform code!

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Every time I go to edit anything in the core for a PR or whatever reason, my default editor settings often conflict with October's standards (PSR-2).

Argue with my preferences all you want, but this makes it much easier to write conforming code for the project without having to overwrite my own preferences in my .vimrc.

Don't know if you're familiar, but it's an awesome little config that will probably be helpful to quite a few people: http://editorconfig.org/

Plugins available for various editors (http://editorconfig.org/#download)
