### PR TITLE
Correction: change $relatedLabel variable to $relationLabel in pivot for...

### DIFF
--- a/modules/backend/behaviors/relationcontroller/partials/_pivot_form.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_pivot_form.htm
@@ -7,7 +7,7 @@
 
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
-            <h4 class="modal-title"><?= e(trans('backend::lang.relation.related_data', ['name'=>$relatedLabel])) ?></h4>
+            <h4 class="modal-title"><?= e(trans('backend::lang.relation.related_data', ['name'=>$relationLabel])) ?></h4>
         </div>
         <div class="modal-body">
             <?= $relationPivotWidget->render() ?>
@@ -38,7 +38,7 @@
 
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
-            <h4 class="modal-title"><?= e(trans('backend::lang.relation.related_data', ['name'=>$relatedLabel])) ?></h4>
+            <h4 class="modal-title"><?= e(trans('backend::lang.relation.related_data', ['name'=>$relationLabel])) ?></h4>
         </div>
         <div class="modal-body">
             <?= $relationPivotWidget->render() ?>


### PR DESCRIPTION
In working with a pivot table using controller relations I found that the `_pivot_form.htm` partial used the `$relatedLabel` variable, while the RelationController class used `$relationLabel`. This causes an error when trying to add or create pivot data. This request corrects the partial so that it can use the variable defined in the controller. Thank you. 
