### PR TITLE
Apply backend colour scheme to loading-indicator-container

### DIFF
--- a/modules/backend/models/brandsettings/custom.less
+++ b/modules/backend/models/brandsettings/custom.less
@@ -105,7 +105,8 @@ body.outer .layout > .layout-row.layout-head {
         }
     }
 
-    .form-tabless-fields {
+    .form-tabless-fields,
+    .form-tabless-fields .loading-indicator-container .loading-indicator {
         background: @color-fancy-form-tabless-fields-bg;
     }
 }


### PR DESCRIPTION
This is just a quick fix to use the correct colour on the loading indicator, within the backend when saving a page or layout. I did look at adding a test case, however couldn't find any existing tests of this nature.

**To replicate:** 
1. Change colour scheme in backend
2. Go to "Cms", "Pages" and edit a page
3. Click "Save"

**Original Problem:** 
![screen recording 2014-11-10 at 08 29 pm](https://cloud.githubusercontent.com/assets/1923094/4983258/1a3d48fc-6919-11e4-8177-634e431c7e8e.gif)

**With fix:**
![screen recording 2014-11-10 at 08 30 pm](https://cloud.githubusercontent.com/assets/1923094/4983267/2aeac468-6919-11e4-9a85-b5d81e1b055c.gif)
