### PR TITLE
A delay added to CMS side menu tab change event to avoid the annoying tab changes

### DIFF
--- a/modules/backend/assets/js/october.sidepaneltab.js
+++ b/modules/backend/assets/js/october.sidepaneltab.js
@@ -12,6 +12,8 @@
 
     SidePanelTab.prototype.init = function() {
         var self = this
+        this.tabOpenDelay = 200
+        this.tabOpenTimeout = undefined
         this.$sideNavItems = $('#layout-sidenav ul li')
         this.$sidePanelItems = $('[data-content-id]', this.$el)
         this.sideNavWidth = $('#layout-sidenav ul li').outerWidth()
@@ -51,9 +53,18 @@
             })
 
             self.$sideNavItems.mouseenter(function(){
-                if ($(window).width() < self.options.breakpoint || !self.panelFixed())
-                    self.displayTab(this)
+                if ($(window).width() < self.options.breakpoint || !self.panelFixed()) {
+                    var _this = this
+                    self.tabOpenTimeout = setTimeout(function () {
+                        self.displayTab(_this)
+                    }, self.tabOpenDelay)
+                }
             })
+
+            self.$sideNavItems.mouseleave(function (){
+                clearTimeout(self.tabOpenTimeout)
+            })
+
 
             $(window).resize(function() {
                 self.updatePanelPosition()


### PR DESCRIPTION
When you hover on a menu item on CMS side nav the corresponding side nav will appear next to it. You may want to click on something inside that side nav but because there is no delay if you accidentally cross the edge of below or above menu item the side menu will change and it's really annoying.
I just added a delay so that user have enough time to correct his/her mistake and move the mouse to the correct area.
This is a common technique and I hope it improves the users experience. 
