### PR TITLE
Fix 'File was changed' modal

### DIFF
--- a/modules/cms/assets/js/october.cmspage.js
+++ b/modules/cms/assets/js/october.cmspage.js
@@ -484,13 +484,13 @@
 
             var popup = $form.data('oc.popup')
 
-            $(popup.$target).on('click', 'button[data-action=reload]', function(){
+            $(popup.$content).on('click', 'button[data-action=reload]', function(){
                 popup.hide()
 
                 reloadForm(form)
             })
 
-            $(popup.$target).on('click', 'button[data-action=save]', function(){
+            $(popup.$content).on('click', 'button[data-action=save]', function(){
                 popup.hide()
 
                 $('input[name=templateForceSave]', $form).val(1)


### PR DESCRIPTION
I haven't seen any issue filed for this, but if you are editing a template in the backend, change the file on disk and then attempt to save the template in the backend, a modal pops up asking if you want to reload the template from disk or overwrite it.

Unfortunately, neither of those options worked. This fix ensures the correct target is used in the JS click handlers so they actually fire.
