### PR TITLE
Fix backend search

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -407,9 +407,19 @@ class Lists extends WidgetBase
          * Apply a supplied search term for primary columns
          */
         if (count($primarySearchable) > 0) {
-            $query->orWhere(function ($innerQuery) use ($primarySearchable) {
+            $whereBool = 'or';
+            $wheres = $query->getQuery()->wheres;
+            if(is_array($wheres) && count($wheres)) {
+                $lastWhere = array_pop($wheres);
+                if(is_string($lastWhere['column'])){
+                    if(strstr($lastWhere['column'], 'deleted_at')){
+                        $whereBool = 'and';
+                    }
+                }
+            }
+            $query->where(function ($innerQuery) use ($primarySearchable) {
                 $innerQuery->searchWhere($this->searchTerm, $primarySearchable);
-            });
+            }, null, null, $whereBool);
         }
 
         /*


### PR DESCRIPTION
Backend search doesn't work properly if exists a previous where sentence of `deleted_at`.
The problem is on the use of `orWhere`, without validate for previous wheres, making a final SQL like this

    `table_name`.`deleted_at` is null or (((lower(table_name.column_one) LIKE '%term%')

I don't know if my solution is the correct one. It work fine on my tests.

Thanks