### PR TITLE
added to mail settings, to send emails to log file, useful for debuging

### DIFF
--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -97,6 +97,7 @@ return [
         'search' => 'Search'
     ],
     'mail' => [
+        'log'           => 'Log file',
         'menu_label' => 'Mail configuration',
         'menu_description' => 'Manage email configuration.',
         'general' => 'General',

--- a/modules/system/models/MailSettings.php
+++ b/modules/system/models/MailSettings.php
@@ -16,6 +16,7 @@ class MailSettings extends Model
     public $settingsCode = 'system_mail_settings';
     public $settingsFields = 'fields.yaml';
 
+    const MODE_LOG      = 'log';
     const MODE_MAIL     = 'mail';
     const MODE_SENDMAIL = 'sendmail';
     const MODE_SMTP     = 'smtp';
@@ -38,6 +39,7 @@ class MailSettings extends Model
     public function getSendModeOptions()
     {
         return [
+            static::MODE_LOG      => 'system::lang.mail.log',
             static::MODE_MAIL     => 'system::lang.mail.php_mail',
             static::MODE_SENDMAIL => 'system::lang.mail.sendmail',
             static::MODE_SMTP     => 'system::lang.mail.smtp',


### PR DESCRIPTION
When you creating the send form, or other functionality,which requires mailing - can set in CMS settings to use LOG as a storage, to debug the emails.
