### PR TITLE
Extend query on relation behavior

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -682,6 +682,10 @@ class RelationController extends ControllerBehavior
              */
             $widget = $this->makeWidget('Backend\Widgets\Lists', $config);
             $widget->bindEvent('list.extendQuery', function ($query) {
+                if (method_exists($this->controller, $this->alias .'_listExtendQuery')) {
+                    call_user_func_array([$this->controller, $this->alias .'_listExtendQuery'], [$query]);
+                }
+                
                 $this->relationObject->setQuery($query);
                 if ($this->model->exists) {
                     $this->relationObject->addConstraints();
@@ -801,6 +805,9 @@ class RelationController extends ControllerBehavior
          */
         if ($this->manageMode == 'pivot' || $this->manageMode == 'list') {
             $widget->bindEvent('list.extendQuery', function ($query) {
+                if (method_exists($this->controller, $this->alias .'_listExtendQuery')) {
+                    call_user_func_array([$this->controller, $this->alias .'_listExtendQuery'], [$query]);
+                }
 
                 /*
                  * Where not in the current list of related records


### PR DESCRIPTION
From a relation behavior config file like this

checks:
    label: Status
    list: @/plugins/path/to/your/relation/config/columns.yaml
    emptyMessage: backend::lang.list.no_records

You can extend the list query with this method :

relationStatus_listExtendQuery($query)
{
    // Here you can extend query definitions
    return $query;
}
