### PR TITLE
Define the list of options by yourself

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -208,11 +208,17 @@ class Filter extends WidgetBase
     protected function getOptionsFromModel($scope, $searchQuery = null)
     {
         $model = $this->scopeModels[$scope->scopeName];
+        $primaryKey = $model->getKeyName();
+
+        if (method_exists($model, 'scopeExtendQueryFilterOptions')) {
+            $model = $model->extendQueryFilterOptions();
+        }
+        
         if (!$searchQuery) {
-            return $model->all();
+            return $model->get();
         }
 
-        $searchFields = [$model->getKeyName(), $this->getScopeNameColumn($scope)];
+        $searchFields = [$primaryKey, $this->getScopeNameColumn($scope)];
         return $model->searchWhere($searchQuery, $searchFields)->get();
     }
 


### PR DESCRIPTION
For example if you want to exclude an element from list

public function scopeExtendQueryFilterOptions($query)
{
     return $query->where('status', '<>', 'all');
}

If you want to fetch the filtered elements by anything but id

public function scopeExtendQueryFilterOptions($query)
{
     return $query->select('status as id');
}
