### PR TITLE
Typo in oc-icon-paperclip class

### DIFF
--- a/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
@@ -66,7 +66,7 @@
                         <?php endif ?>
                         <a
                             href="{{path}}"
-                            class="uploader-file-link oc-icon-paper-clip"
+                            class="uploader-file-link oc-icon-paperclip"
                             target="_blank"></a>
                     </div>
                 </div>


### PR DESCRIPTION
Fixed type in oc-icon-paperclip class (from paper-clip to paperclip) which meant that the attachment link wasn't showing in backed.
