### PR TITLE
When building a relationship Belongs to Many with Pivot Data the lack of...

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -604,7 +604,7 @@ class RelationController extends ControllerBehavior
         /*
          * Check for existing relation
          */
-        $foreignKeyName = $this->relationModel->getKeyName();
+        $foreignKeyName = $this->relationModel->getQualifiedKeyName();
         $existing = $this->relationObject->where($foreignKeyName, $foreignId)->count();
 
         if (!$existing) {


### PR DESCRIPTION
... a table name causes an sql ambiguous ID error.
