### PR TITLE
Extend query of the filter options lists

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -216,6 +216,13 @@ class ListController extends ControllerBehavior
                 return $widget->onRefresh();
             });
 
+            /*
+             * Extend the query of the list of options
+             */
+            $filterWidget->bindEvent('filter.extendQuery', function($query, $scope) {
+                $this->controller->listFilterExtendQuery($query, $scope);
+            });
+
             // Apply predefined filter values
             $widget->addFilter([$filterWidget, 'applyAllScopesToQuery']);
 
@@ -347,6 +354,16 @@ class ListController extends ControllerBehavior
      * @param October\Rain\Database\Builder $query
      */
     public function listExtendQuery($query, $definition = null)
+    {
+    }
+
+    /**
+     * Controller override: Extend the query used for populating the filter 
+     * options before the default query is processed.
+     * @param October\Rain\Database\Builder $query
+     * @param array $scope
+     */
+    public function listFilterExtendQuery($query, $scope)
     {
     }
 

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -208,12 +208,16 @@ class Filter extends WidgetBase
     protected function getOptionsFromModel($scope, $searchQuery = null)
     {
         $model = $this->scopeModels[$scope->scopeName];
+        $query = $model->newQuery();
+
+        $this->fireEvent('filter.extendQuery', [$query, $scope]);
+        
         if (!$searchQuery) {
-            return $model->all();
+            return $query->get();
         }
 
         $searchFields = [$model->getKeyName(), $this->getScopeNameColumn($scope)];
-        return $model->searchWhere($searchQuery, $searchFields)->get();
+        return $query->searchWhere($searchQuery, $searchFields)->get();
     }
 
     /**


### PR DESCRIPTION
For example if you want to exclude an element from filter options

```php
public function listFIlterExtendQuery($query, $scope)
{
    if ($scope->scopeName == 'status') {
        $query->where('status', '<>', 'all');
    }
}
```