### PR TITLE
Valid strtotime() format when time is left empty

### DIFF
--- a/modules/backend/formwidgets/DatePicker.php
+++ b/modules/backend/formwidgets/DatePicker.php
@@ -126,8 +126,8 @@ class DatePicker extends FormWidgetBase
             return null;
         }
 
-        if ($this->mode == 'datetime') {
-            $value .= ' ' . post(self::TIME_PREFIX.$this->formField->getName(false)) . ':00';
+        if ($this->mode == 'datetime' && $timeValue = post(self::TIME_PREFIX.$this->formField->getName(false))) {
+            $value .= ' ' . $timeValue . ':00';
         }
         elseif ($this->mode == 'time') {
             $value .= ':00';


### PR DESCRIPTION
Date-type laravel validation ("date", "before", and "after") may not be used with datetime widgets containing empty time fields because they are not in a valid strtotime() format (example: 2014-12-27 :00).

This extra check ensures a valid strtotime() format by only adding the ":00" seconds value when a time value is present.