### PR TITLE
Adds isHidden check to backend components widget

### DIFF
--- a/modules/cms/widgets/ComponentList.php
+++ b/modules/cms/widgets/ComponentList.php
@@ -112,6 +112,11 @@ class ComponentList extends WidgetBase
                 $className = $componentInfo->className;
                 $alias = $componentInfo->alias;
                 $component = new $className();
+                
+                if ($component->isHidden) {
+                    continue;
+                }
+                
                 $componentDetails = $component->componentDetails();
                 $component->alias = '--alias--';
 


### PR DESCRIPTION
Allows components to be hidden from the backend components widget by checking their isHidden value
https://github.com/octobercms/october/blob/master/modules/cms/classes/ComponentBase.php#L41