### PR TITLE
Adds "required" component properties

### DIFF
--- a/modules/backend/assets/js/october.inspector.js
+++ b/modules/backend/assets/js/october.inspector.js
@@ -815,11 +815,15 @@
     }
 
     InspectorEditorString.prototype.validate = function() {
+        var val = $.trim($(this.selector).val())
+
+        if (this.fieldDef.required && !val)
+            return this.fieldDef.requiredMessage || 'Required fields were left blank.'
+
         if (this.fieldDef.validationPattern === undefined)
             return
 
-        var val = $.trim($(this.selector).val()),
-            re = new RegExp(this.fieldDef.validationPattern, 'm')
+        var re = new RegExp(this.fieldDef.validationPattern, 'm')
 
         if (!val.match(re))
             return this.fieldDef.validationMessage

--- a/modules/backend/assets/js/october.inspector.js
+++ b/modules/backend/assets/js/october.inspector.js
@@ -817,8 +817,8 @@
     InspectorEditorString.prototype.validate = function() {
         var val = $.trim($(this.selector).val())
 
-        if (this.fieldDef.required && !val)
-            return this.fieldDef.requiredMessage || 'Required fields were left blank.'
+        if (this.fieldDef.required && val.length === 0)
+            return this.fieldDef.validationMessage || 'Required fields were left blank.'
 
         if (this.fieldDef.validationPattern === undefined)
             return


### PR DESCRIPTION
Adds a "required" and "requiredMessage" key to component properties. If a required field does not have a requiredMessage, a default message of "Required fields were left blank." will be used.

Example usage...
```php
public function defineProperties()
{
    return [
        'maxItems' => [
             'title'             => 'Max items',
             'description'       => 'The most amount of todo items allowed',
             'type'              => 'string',
             'required'          => true,
             'requiredMessage'   => 'You must set the maximum todo items allowed!'
        ]
    ];
}
```