### PR TITLE
Richeditor - html preview tab

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/css/richeditor.css
+++ b/modules/backend/formwidgets/richeditor/assets/css/richeditor.css
@@ -1434,7 +1434,6 @@ body .redactor-box-fullscreen .redactor-editor {
   top: 0;
   bottom: 0;
   position: absolute;
-  height: auto !important;
 }
 .field-richeditor.stretch .redactor-box .redactor-editor {
   height: auto !important;

--- a/modules/backend/formwidgets/richeditor/assets/less/richeditor.less
+++ b/modules/backend/formwidgets/richeditor/assets/less/richeditor.less
@@ -134,7 +134,6 @@ body .redactor-box-fullscreen {
             top: 0;
             bottom: 0;
             position: absolute;
-            height: auto !important;
         }
 
         .redactor-editor {


### PR DESCRIPTION
Textarea field is small by default. I removed auto height CSS property.
I don't understand why it was set earlier.