### PR TITLE
Change sort by fileName on cms template directory list.

### DIFF
--- a/modules/cms/widgets/TemplateList.php
+++ b/modules/cms/widgets/TemplateList.php
@@ -161,7 +161,7 @@ class TemplateList extends WidgetBase
         }
 
         usort($normalizedItems, function ($a, $b) {
-            return strcmp($a->title, $b->title);
+            return strcmp($a->fileName, $b->fileName);
         });
 
         /*


### PR DESCRIPTION
Changed to sort a directory list under the CMS pages over by a file name base.

before)
+91_errors
+01_blog
...

after)
+01_blog
+91_errors
...
