### PR TITLE
Add Mandrill support patch

### DIFF
--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -121,7 +121,10 @@ return [
         'mailgun_domain' => 'Mailgun Domain',
         'mailgun_domain_comment' => 'Please specify the Mailgun domain name.',
         'mailgun_secret' => 'Mailgun Secret',
-        'mailgun_domain_secret' => 'Enter your Mailgun API key.'
+        'mailgun_domain_secret' => 'Enter your Mailgun API key.',
+        'mandrill' => 'Mandrill',
+        'mandrill_secret' => 'Mandrill Secret',
+        'mandrill_secret_comment' => 'Enter your Mandrill API key.'
     ],
     'mail_templates' => [
         'menu_label' => 'Mail templates',

--- a/modules/system/models/MailSettings.php
+++ b/modules/system/models/MailSettings.php
@@ -21,6 +21,7 @@ class MailSettings extends Model
     const MODE_SENDMAIL = 'sendmail';
     const MODE_SMTP     = 'smtp';
     const MODE_MAILGUN  = 'mailgun';
+    const MODE_MANDRILL = 'mandrill';
 
     public function initSettingsData()
     {
@@ -44,6 +45,7 @@ class MailSettings extends Model
             static::MODE_SENDMAIL => 'system::lang.mail.sendmail',
             static::MODE_SMTP     => 'system::lang.mail.smtp',
             static::MODE_MAILGUN  => 'system::lang.mail.mailgun',
+            static::MODE_MANDRILL => 'system::lang.mail.mandrill',
         ];
     }
 
@@ -77,6 +79,10 @@ class MailSettings extends Model
             case self::MODE_MAILGUN:
                 $config->set('services.mailgun.domain', $settings->mailgun_domain);
                 $config->set('services.mailgun.secret', $settings->mailgun_secret);
+                break;
+
+            case self::MODE_MANDRILL:
+                $config->set('services.mandrill.secret', $settings->mandrill_secret);
                 break;
         }
 

--- a/modules/system/models/mailsettings/fields.yaml
+++ b/modules/system/models/mailsettings/fields.yaml
@@ -63,3 +63,8 @@ tabs:
       label: system::lang.mail.mailgun_secret
       commentAbove: system::lang.mail.mailgun_domain_secret
       tab: system::lang.mail.mailgun
+      
+    mandrill_secret:
+      label: system::lang.mail.mandrill_secret
+      commentAbove: system::lang.mail.mandrill_secret_comment
+      tab: system::lang.mail.mandrill


### PR DESCRIPTION
Added support for Mandrill option in backend settings.

Additional translations will have to be added in backend translation files.