### PR TITLE
Removed select from columns.yaml for User.php

### DIFF
--- a/modules/backend/models/user/columns.yaml
+++ b/modules/backend/models/user/columns.yaml
@@ -14,7 +14,6 @@ columns:
         searchable: true
     full_name:
         label: backend::lang.user.full_name
-        select: concat(first_name, ' ', last_name)
         searchable: true
     email:
         label: backend::lang.user.email


### PR DESCRIPTION
SQLite doesn't support concat() and using it goes against Laravel's database abstraction. The getFullNameAttribute() in User.php already does this task well.

Also, removing this line fixed the issue where a SQLite based install of OctoberCMS threw gave this [error page](http://i.imgur.com/H8wGTmU.png) everything and prevented access to Administrator tab in backend and also overtime a new avatar was uploaded to user page.