### PR TITLE
Display active plugin count on updates page

### DIFF
--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -52,6 +52,7 @@ class Updates extends Controller
         $this->vars['projectId'] = Parameters::get('system::project.id');
         $this->vars['projectName'] = Parameters::get('system::project.name');
         $this->vars['projectOwner'] = Parameters::get('system::project.owner');
+        $this->vars['pluginsActiveCount'] = PluginVersion::isEnabled()->count();
         $this->vars['pluginsCount'] = PluginVersion::count();
         return $this->asExtension('ListController')->index();
     }

--- a/modules/system/controllers/updates/index.htm
+++ b/modules/system/controllers/updates/index.htm
@@ -32,7 +32,11 @@
         <?php endif ?>
         <div class="scoreboard-item title-value">
             <h4><?= e(trans('system::lang.updates.plugins')) ?></h4>
-            <p><?= $pluginsCount ?></p>
+            <?php if ( $pluginsCount == $pluginsActiveCount ): ?>
+                <p><?= $pluginsCount ?></p>
+            <?php else: ?>
+                <p><?= $pluginsActiveCount, ' (', $pluginsCount, ')' ?></p>
+            <?php endif; ?>
         </div>
     </div>
 </div>

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -82,7 +82,7 @@ class PluginVersion extends Model
      * @param $query
      * @return mixed
      */
-    public function scopeEnabled($query)
+    public function scopeIsEnabled($query)
     {
         return $query->where('is_disabled', '!=', 1);
     }

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -78,6 +78,16 @@ class PluginVersion extends Model
     }
 
     /**
+     * Only include enabled plugins
+     * @param $query
+     * @return mixed
+     */
+    public function scopeEnabled($query)
+    {
+        return $query->where('is_disabled', '!=', 1);
+    }
+
+    /**
      * Returns the current version for a plugin
      * @param  string $pluginCode Plugin code. Eg: Acme.Blog
      * @return string


### PR DESCRIPTION
If you have disabled plugins, the plugin counter will now show `activeCount (totalCount)` like so:
![](http://i.imgur.com/BXpfHql.png)