### PR TITLE
Better form context for RelationController forms

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -506,7 +506,7 @@ class RelationController extends ControllerBehavior
 
         return $results->lists($foreignKeyName);
     }
-    
+
     //
     // Overrides
     //
@@ -1030,7 +1030,7 @@ class RelationController extends ControllerBehavior
             $config = $this->makeConfig($this->config->form);
             $config->model = $this->relationModel;
             $config->arrayName = class_basename($this->relationModel);
-            $config->context = ['relation', $config->model->exists ? 'update' : 'create'];
+            $config->context = ['relation'];
             $config->alias = $this->alias . 'ManageForm';
 
             /*
@@ -1043,6 +1043,12 @@ class RelationController extends ControllerBehavior
                         'class' => get_class($config->model), 'id' => $this->manageId
                     ]));
                 }
+                else {
+                    $config->context[] = 'update';
+                }
+            }
+            else {
+                $config->context[] = 'create';
             }
 
             $widget = $this->makeWidget('Backend\Widgets\Form', $config);

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1030,7 +1030,7 @@ class RelationController extends ControllerBehavior
             $config = $this->makeConfig($this->config->form);
             $config->model = $this->relationModel;
             $config->arrayName = class_basename($this->relationModel);
-            $config->context = 'relation';
+            $config->context = ['relation', $config->model->exists ? 'update' : 'create'];
             $config->alias = $this->alias . 'ManageForm';
 
             /*


### PR DESCRIPTION
Requires accepting #932.

The RelationController creates a form with context 'relation' whether it's a create OR update form so it's impossible to target fields for one or the other. This PR combined with #932 allows for context-aware form fields in RelationController forms.