### PR TITLE
Support multiple form contexts

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -474,7 +474,7 @@ class Form extends WidgetBase
              */
             if ($fieldObj->context !== null) {
                 $context = (is_array($fieldObj->context)) ? $fieldObj->context : [$fieldObj->context];
-                if (!in_array($this->getContext(), $context)) {
+                if (!array_intersect((array)$this->getContext(), $context)) {
                     continue;
                 }
             }


### PR DESCRIPTION
The RelationController creates a form with context 'relation' whether it's a create OR update form so it's impossible to target fields for one or the other. This PR allows you to do the following:

```php
$form->context = ['relation', 'create'];
```

It's fully backwards compatible. 