### PR TITLE
Add support for getting all config

### DIFF
--- a/modules/backend/classes/ControllerBehavior.php
+++ b/modules/backend/classes/ControllerBehavior.php
@@ -85,8 +85,15 @@ class ControllerBehavior extends ExtensionBase
      * @param $default Default value if nothing is found
      * @return string
      */
-    public function getConfig($name, $default = null)
+    public function getConfig($name = null, $default = null)
     {
+        /*
+         * Return all config
+         */
+        if (is_null($name)) {
+            return $this->config;
+        }
+
         /*
          * Array field name, eg: field[key][key2][key3]
          */


### PR DESCRIPTION
This PR lets you do `$this->getConfig()` in a Controller to get all config. 

## Use case

Currently `setConfig()` overwrites the config rather than updating it - so the only way to update is to get all config, modify as desired then `setConfig`. 