### PR TITLE
Add support for removing form fields

### DIFF
--- a/modules/backend/classes/FormTabs.php
+++ b/modules/backend/classes/FormTabs.php
@@ -85,6 +85,26 @@ class FormTabs implements IteratorAggregate, ArrayAccess
     }
 
     /**
+     * Remove a field from all tabs by name.
+     * @param string    $name
+     * @return True on success, False on failure
+     */
+    public function removeField($name)
+    {
+        foreach ($this->fields as $tab => $fields) {
+            foreach ($fields as $fieldName => $field) {
+                if ($fieldName == $name) {
+                    unset($this->fields[$tab][$fieldName]);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Add a field to the collection of tabs.
      * @param string    $name
      * @param FormField $field

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -460,6 +460,27 @@ class Form extends WidgetBase
     }
 
     /**
+     * Programatically remove a field.
+     * @return True on success, False on failure
+     */
+    public function removeField($name)
+    {
+        if (!isset($this->fields[$name])) {
+            return false;
+        }
+
+        // Remove from tabs
+        $this->primaryTabs->removeField($name);
+        $this->secondaryTabs->removeField($name);
+        $this->outsideTabs->removeField($name);
+
+        // Remove from form
+        unset($this->fields[$name]);
+
+        return true;
+    }
+
+    /**
      * Programatically add fields, used internally and for extensibility.
      */
     public function addFields(array $fields, $addToArea = null)


### PR DESCRIPTION
Example Usage:

```php
    /**
     * Called after the form fields are defined.
     * @param \Backend\Widgets\Form $host The hosting form widget
     * @return void
     */
    public function formExtendFields($host, $fields)
    {
        $host->removeField('person');
    }
```