### PR TITLE
Incorrect requried argument default value

### DIFF
--- a/modules/backend/classes/ControllerBehavior.php
+++ b/modules/backend/classes/ControllerBehavior.php
@@ -74,7 +74,7 @@ class ControllerBehavior extends ExtensionBase
      * @param mixed $config   Config object or array
      * @param array $required Required config items
      */
-    public function setConfig($config, $required = null)
+    public function setConfig($config, $required = [])
     {
         $this->config = $this->makeConfig($config, $required);
     }


### PR DESCRIPTION
When calling `$this->asBehavior('FormController')->setConfig($myConfig)` you get an error *Invalid argument supplied for foreach()* [here](https://github.com/octobercms/october/blob/master/modules/system/traits/ConfigMaker.php#L83) because ControllerBehavior's [setConfig method](https://github.com/octobercms/october/blob/master/modules/backend/classes/ControllerBehavior.php#L77-L79) defaults $required to null - whereas ConfigMaker [requires an array](https://github.com/octobercms/october/blob/master/modules/system/traits/ConfigMaker.php#L29).