### PR TITLE
Support passing custom contexts to relationcontroller

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -506,7 +506,7 @@ class RelationController extends ControllerBehavior
 
         return $results->lists($foreignKeyName);
     }
-    
+
     //
     // Overrides
     //
@@ -1027,10 +1027,12 @@ class RelationController extends ControllerBehavior
          * Form
          */
         elseif ($this->manageMode == 'form' && isset($this->config->form)) {
+            $context = !empty($this->config->manage['context']) ? $this->config->manage['context'] : 'relation';
+
             $config = $this->makeConfig($this->config->form);
             $config->model = $this->relationModel;
             $config->arrayName = class_basename($this->relationModel);
-            $config->context = 'relation';
+            $config->context = is_string($context) ? $context : 'relation';
             $config->alias = $this->alias . 'ManageForm';
 
             /*
@@ -1042,6 +1044,15 @@ class RelationController extends ControllerBehavior
                     throw new ApplicationException(Lang::get('backend::lang.model.not_found', [
                         'class' => get_class($config->model), 'id' => $this->manageId
                     ]));
+                }
+
+                if (is_array($context) && isset($context['create'])) {
+                    $config->context = $context['create'];
+                }
+            }
+            else {
+                if (is_array($context) && isset($context['update'])) {
+                    $config->context = $context['update'];
                 }
             }
 

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1045,14 +1045,16 @@ class RelationController extends ControllerBehavior
                         'class' => get_class($config->model), 'id' => $this->manageId
                     ]));
                 }
-
-                if (is_array($context) && isset($context['create'])) {
-                    $config->context = $context['create'];
+                else {
+                    if (is_array($context) && isset($context['update'])) {
+                        $config->context = $context['update'];
+                    }
                 }
+
             }
             else {
-                if (is_array($context) && isset($context['update'])) {
-                    $config->context = $context['update'];
+                if (is_array($context) && isset($context['create'])) {
+                    $config->context = $context['create'];
                 }
             }
 


### PR DESCRIPTION
In response to https://github.com/octobercms/october/pull/931#issuecomment-73653220 this PR lets you specify the context of the form generated with RelationController.

You can now do the following with *config_relation.yaml*:
```yaml
fields:
  manage:
    context:
      create: myCreateContext
      update: myUpdateContext
```
or
```yaml
fields:
  manage:
    context: myCustomContext
```
or just leave it off and the current default (relation) will be used.

This PR is backwards compatible.