### PR TITLE
Accept any valid number, positive or negative. Fixes #959

### DIFF
--- a/modules/backend/widgets/form/partials/_field_number.htm
+++ b/modules/backend/widgets/form/partials/_field_number.htm
@@ -11,7 +11,7 @@
         class="form-control"
         autocomplete="off"
         maxlength="255"
-        pattern="\d+"
+        pattern="-?\d+(\.\d+)?"
         <?= $field->getAttributes() ?>
     />
 <?php endif ?>


### PR DESCRIPTION
The regex you had for numbers only worked for positive integers as seen on http://jsfiddle.net/3o77o8n5/

This fixes #959 

I would also like to see *pattern* YAML option support for number fields so we can specify just integers, positives, negatives, floating points etc.