### PR TITLE
Allow setting 'options' for a scope in filter config

### DIFF
--- a/modules/backend/classes/FilterScope.php
+++ b/modules/backend/classes/FilterScope.php
@@ -114,7 +114,7 @@ class FilterScope
     protected function evalConfig($config)
     {
         if (isset($config['options'])) {
-            $this->options($config['options']);
+            $this->options = $config['options'];
         }
         if (isset($config['context'])) {
             $this->context = $config['context'];

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -170,6 +170,10 @@ class Filter extends WidgetBase
      */
     protected function getAvailableOptions($scope, $searchQuery = null)
     {
+        if (count($scope->options)) {
+            return $scope->options;
+        }
+
         $available = [];
         $nameColumn = $this->getScopeNameColumn($scope);
         $options = $this->getOptionsFromModel($scope, $searchQuery);
@@ -210,7 +214,7 @@ class Filter extends WidgetBase
         $query = $model->newQuery();
 
         $this->fireEvent('filter.extendQuery', [$query, $scope]);
-        
+
         if (!$searchQuery) {
             return $query->get();
         }


### PR DESCRIPTION
Suppose you have a filter config like:
```
scopes:
    category:
        label: Category
        conditions: category in (:filtered)
        options:
            cat1: First Category
            cat2: Second Category
```

Currently, trying to do so raises a fatal error (call to undefined function).