### PR TITLE
Fix issue getting extending form field's options

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -887,7 +887,9 @@ class Form extends WidgetBase
          * Refer to the model method or any of its behaviors
          */
         if (!is_array($fieldOptions) && !$fieldOptions) {
-            $methodName = 'get'.studly_case($field->fieldName).'Options';
+            $fieldName = str_replace('[', '', $field->fieldName);
+            $fieldName = str_replace(']', '', $fieldName);
+            $methodName = 'get'.studly_case($fieldName).'Options';
             if (
                 !$this->methodExists($this->model, $methodName) &&
                 !$this->methodExists($this->model, 'getDropdownOptions')


### PR DESCRIPTION
Issue reproduction:

Plugin.php:
```
...
public function boot()
{
	UserController::extendFormFields(function($form, $model, $context)
	{
	    if (!$model instanceof UserModel)
	        return;

	    if (!$model->exists)
	    	return;

	    // Add tabs fields
	    $form->addTabFields([
	        'profile[country]' =>
	        [
	            'label'   => 'Country',
	            'tab'     => 'Profile',
	            'span'    => 'left',
	            'type'    => 'dropdown'
	        ]
	    ]);
	});
}

```

This return the error:
```
The model class Sylvert\Profile\Models\Profile must define a method getProfile[country]Options() returning options for the 'profile[country]' form field.
```

Instead of getProfile[country]Options() must be getProfileCountryOptions().