### PR TITLE
Allow to pass 0 as column value in List widgets

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -763,11 +763,11 @@ class Lists extends WidgetBase
         /*
          * Extensibility
          */
-        if ($response = Event::fire('backend.list.overrideColumnValue', [$this, $record, $column, $value], true)) {
+        if (!is_null($response = Event::fire('backend.list.overrideColumnValue', [$this, $record, $column, $value], true))) {
             $value = $response;
         }
 
-        if ($response = $this->fireEvent('list.overrideColumnValue', [$record, $column, $value], true)) {
+        if (!is_null($response = $this->fireEvent('list.overrideColumnValue', [$record, $column, $value], true))) {
             $value = $response;
         }
 


### PR DESCRIPTION
**Problem**: When overriden the columns value, if we pass 0 or '0', the condition is not met and therefore the column has a null value.

**Solution**: Check for not null in the condtion