### PR TITLE
Respect radio-button value in form triggers

### DIFF
--- a/modules/backend/assets/js/october.triggerapi.js
+++ b/modules/backend/assets/js/october.triggerapi.js
@@ -78,7 +78,12 @@
             this.updateTarget($(this.options.trigger + ':checked', this.triggerParent).length > 0)
         }
         else if (this.triggerCondition == 'value') {
-            this.updateTarget($(this.options.trigger, this.triggerParent).val() == this.triggerConditionValue)
+            var trigger = $(this.options.trigger + ':checked', this.triggerParent);
+            if (trigger.length) {
+                this.updateTarget(trigger.val() == this.triggerConditionValue)
+            } else {
+                this.updateTarget($(this.options.trigger, this.triggerParent).val() == this.triggerConditionValue)
+            }
         }
     }
 


### PR DESCRIPTION
When I tried to use form triggers for radio button I found that this is impossible:

    field1:
        type: radio
        options:
            val1: ...
            val2: ...
    field2:
        type: ...
        trigger:
            action: hide
            field: field1
            condition: value[val1]

Proposed fix allows conditions like that.