### PR TITLE
Fix relation controller JS issue on Chrome

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -943,7 +943,7 @@ class RelationController extends ControllerBehavior
             $config->showCheckboxes = $this->getConfig('view[showCheckboxes]', !$this->readOnly);
 
             $defaultOnClick = sprintf(
-                "$.oc.relationBehavior.clickViewListRecord(:id, '%s', '%s')",
+                "$.oc.relationBehavior.clickViewListRecord(':id', '%s', '%s')",
                 $this->field,
                 $this->relationGetSessionKey()
             );


### PR DESCRIPTION
When loading a relation, an "Uncaught token :" javascript error is thrown when using Chrome, which makes the select all checkbox not to work and most of the JS on the page to fail.