### PR TITLE
Force trailing slash

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -63,5 +63,11 @@
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
+    
+    ##
+    ## Force trailing slash
+    ##
+    RewriteCond %{REQUEST_URI} !(/$|\.)
+    RewriteRule ^(.*)$ http://%{HTTP_HOST}/$1/ [R=301,L]
 
 </IfModule>


### PR DESCRIPTION
Do a 301 redirect if no trailing slash is present, to improve SEO.