### PR TITLE
fixes HHVM relation formfield 

### DIFF
--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -1,7 +1,7 @@
 <?php namespace Backend\Classes;
 
 use Html;
-use Model;
+use October\Rain\Database\Model;
 use October\Rain\Html\Helper as HtmlHelper;
 
 /**


### PR DESCRIPTION
Aliased Model class fails type check on hhvm, therefore relation data is not loaded. Affects belongsToMany in particular - checkbox list is not populated, ever.

Line 535 of FormField class is main the culprit:
if ($result instanceof Model && $result->hasRelation($key)) {

HHVM cannot resolve type if aliased dynamically, therefore use statement has to mention FQCN.