### PR TITLE
Fixed custom error pages outputting headers

### DIFF
--- a/modules/system/classes/ErrorHandler.php
+++ b/modules/system/classes/ErrorHandler.php
@@ -49,7 +49,7 @@ class ErrorHandler extends ErrorHandlerBase
 
         // Route to the CMS error page.
         $controller = new Controller($theme);
-        return $controller->run('/error');
+        return $controller->run('/error')->getContent();
     }
 
     /**


### PR DESCRIPTION
The bug:
![screen shot 2015-04-02 at 09 55 05](https://cloud.githubusercontent.com/assets/886567/6959242/4ebb4a7c-d91f-11e4-8594-b97d7c239a2e.png)

If we don't have this method called, then the controller returns an object. From then on, [Symfony converts this object in to a string](https://github.com/symfony/HttpFoundation/blob/master/Response.php#L406). This string is **not just the content** of the view, but headers as well.

After attaching this method, `handleCustomError()` returns a string and everything works as expected.