### PR TITLE
fixes getComponentProperties foreach iteration overriding method argument name

### DIFF
--- a/modules/cms/classes/CmsCompoundObject.php
+++ b/modules/cms/classes/CmsCompoundObject.php
@@ -329,10 +329,10 @@ class CmsCompoundObject extends CmsObject
     /**
      * Returns component property names and values.
      * This method implements caching and can be used in the run-time on the front-end.
-     * @param string $componentName Specifies the component name.
+     * @param string $requestedComponentName Specifies the component name.
      * @return array Returns an associative array with property names in the keys and property values in the values.
      */
-    public function getComponentProperties($componentName)
+    public function getComponentProperties($requestedComponentName)
     {
         $key = crc32($this->theme->getPath()).'component-properties';
 
@@ -351,8 +351,8 @@ class CmsCompoundObject extends CmsObject
         $objectCode = $this->getBaseFileName();
 
         if (array_key_exists($objectCode, $objectComponentMap)) {
-            if (array_key_exists($componentName, $objectComponentMap[$objectCode])) {
-                return $objectComponentMap[$objectCode][$componentName];
+            if (array_key_exists($requestedComponentName, $objectComponentMap[$objectCode])) {
+                return $objectComponentMap[$objectCode][$requestedComponentName];
             }
 
             return [];
@@ -387,8 +387,8 @@ class CmsCompoundObject extends CmsObject
 
         Cache::put($key, serialize($objectComponentMap), Config::get('cms.parsedPageCacheTTL', 10));
 
-        if (array_key_exists($componentName, $objectComponentMap[$objectCode])) {
-            return $objectComponentMap[$objectCode][$componentName];
+        if (array_key_exists($requestedComponentName, $objectComponentMap[$objectCode])) {
+            return $objectComponentMap[$objectCode][$requestedComponentName];
         }
 
         return [];


### PR DESCRIPTION
Caused bug where properties of another page component where returned if cache was empty.

Problem was: argument name for method is $componentName and also foreach iteration key name is $componentName on line 365. Therefore, if cache was empty and method went into iteration part to retrieve full objectComponentPropertyMap, it was overriding method argument with iterator key and then tried to return properties for last component in iteration, not for requested component. Also, whole method could be separated into finder and obtainer methods to separate their responsibilities and lower method complexity (which obviously suffered from scoping issue due to size).