### PR TITLE
Remove width for accountmenu

### DIFF
--- a/modules/backend/assets/less/layout/mainmenu.less
+++ b/modules/backend/assets/less/layout/mainmenu.less
@@ -98,7 +98,6 @@ nav#layout-mainmenu.navbar ul li .mainmenu-accountmenu {
     position: fixed;
     top: 63px;
     right: 0;
-    width: 225px;
     background: @color-accountmenu-bg;
     z-index: 900;
     display: none;


### PR DESCRIPTION
In some languages the width is too small for see the full text