### PR TITLE
Add support for sorting sideMenu items

### DIFF
--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -47,6 +47,7 @@ class NavigationManager
         'url'         => null,
         'counter'     => null,
         'counterLabel'=> null,
+        'order'       => 100,
         'attributes'  => [],
         'permissions' => []
     ];
@@ -99,13 +100,7 @@ class NavigationManager
         /*
          * Sort menu items
          */
-        usort($this->items, function ($a, $b) {
-            if ($a->order == $b->order) {
-                return 0;
-            }
-
-            return $a->order > $b->order ? 1 : -1;
-        });
+        usort($this->items, 'self::sortMenu');
 
         /*
          * Filter items user lacks permission for
@@ -118,8 +113,26 @@ class NavigationManager
                 continue;
             }
 
+            usort($item->sideMenu, 'self::sortMenu');
+
             $item->sideMenu = $this->filterItemPermissions($user, $item->sideMenu);
         }
+    }
+
+    /**
+     * Callback method used by usort() to compare menu items.
+     * Should be referenced with 'self::sortMenu' as the second parameter to usort().
+     * @param object $a First menu item to compare
+     * @param object $b Second menu item to compare
+     * @return integer Returns 1, 0 or -1 depending on order
+     */
+    protected static function sortMenu($a, $b)
+    {
+        if ($a->order < $b->order) {
+            return -1;
+        }
+
+        return (int) $a->order > $b->order;
     }
 
     /**
@@ -141,8 +154,8 @@ class NavigationManager
 
     /**
      * Registers the back-end menu items.
-     * The argument is an array of the main menu items. The array keys represent the 
-     * menu item codes, specific for the plugin/module. Each element in the 
+     * The argument is an array of the main menu items. The array keys represent the
+     * menu item codes, specific for the plugin/module. Each element in the
      * array should be an associative array with the following keys:
      * - label - specifies the menu label localization string key, required.
      * - icon - an icon name from the Font Awesome icon collection, required.
@@ -151,7 +164,7 @@ class NavigationManager
      *   The item will be displayed if the user has any of the specified permissions.
      * - order - a position of the item in the menu, optional.
      * - sideMenu - an array of side menu items, optional. If provided, the array items
-     *   should represent the side menu item code, and each value should be an associative 
+     *   should represent the side menu item code, and each value should be an associative
      *   array with the following keys:
      * - label - specifies the menu label localization string key, required.
      * - icon - an icon name from the Font Awesome icon collection, required.

--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -39,6 +39,7 @@ class ServiceProvider extends ModuleServiceProvider
                             'label'        => 'cms::lang.page.menu_label',
                             'icon'         => 'icon-copy',
                             'url'          => 'javascript:;',
+                            'order'        => 100,
                             'attributes'   => ['data-menu-item' => 'pages'],
                             'permissions'  => ['cms.manage_pages'],
                             'counterLabel' => 'cms::lang.page.unsaved_label'
@@ -47,6 +48,7 @@ class ServiceProvider extends ModuleServiceProvider
                             'label'        => 'cms::lang.partial.menu_label',
                             'icon'         => 'icon-tags',
                             'url'          => 'javascript:;',
+                            'order'        => 200,
                             'attributes'   => ['data-menu-item' => 'partials'],
                             'permissions'  => ['cms.manage_partials'],
                             'counterLabel' => 'cms::lang.partial.unsaved_label'
@@ -55,6 +57,7 @@ class ServiceProvider extends ModuleServiceProvider
                             'label'        => 'cms::lang.layout.menu_label',
                             'icon'         => 'icon-th-large',
                             'url'          => 'javascript:;',
+                            'order'        => 300,
                             'attributes'   => ['data-menu-item' => 'layouts'],
                             'permissions'  => ['cms.manage_layouts'],
                             'counterLabel' => 'cms::lang.layout.unsaved_label'
@@ -63,6 +66,7 @@ class ServiceProvider extends ModuleServiceProvider
                             'label'        => 'cms::lang.content.menu_label',
                             'icon'         => 'icon-file-text-o',
                             'url'          => 'javascript:;',
+                            'order'        => 400,
                             'attributes'   => ['data-menu-item' => 'content'],
                             'permissions'  => ['cms.manage_content'],
                             'counterLabel' => 'cms::lang.content.unsaved_label'
@@ -71,6 +75,7 @@ class ServiceProvider extends ModuleServiceProvider
                             'label'        => 'cms::lang.asset.menu_label',
                             'icon'         => 'icon-picture-o',
                             'url'          => 'javascript:;',
+                            'order'        => 500,
                             'attributes'   => ['data-menu-item' => 'assets'],
                             'permissions'  => ['cms.manage_assets'],
                             'counterLabel' => 'cms::lang.asset.unsaved_label'
@@ -79,6 +84,7 @@ class ServiceProvider extends ModuleServiceProvider
                             'label'       => 'cms::lang.component.menu_label',
                             'icon'        => 'icon-puzzle-piece',
                             'url'         => 'javascript:;',
+                            'order'        => 600,
                             'attributes'  => ['data-menu-item' => 'components'],
                             'permissions' => ['cms.manage_pages', 'cms.manage_layouts', 'cms.manage_partials']
                         ]


### PR DESCRIPTION
Up until now, only main menu items have supported the 'order' parameter to set the sort order. This PR adds the same support to side menus as well.

This is especially useful when one plugin extends the side menu of another. With the existing functionality, if you were to use `$manager->addSideMenuItems()`, and menu items that you add will automatically be appended to the end of the existing ones provided by the plugin you're extending.

By adding the `order` parameter to side menus, plugin authors will be able to inject their extra menu item(s) wherever they want. However, this functionality comes at a small cost.

All existing plugins that have multiple items in their side menu are likely to find they now appear out of order. I've updated the `cms` module as part of this PR to maintain existing order. Plugin authors will need to manually update their `Plugin.php@registerNavigation()` methods if they don't want PHP to decide how their items should be sorted.