### PR TITLE
Artisan commands related to themes

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -310,7 +310,7 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerConsoleCommand('october.update', 'System\Console\OctoberUpdate');
         $this->registerConsoleCommand('october.util', 'System\Console\OctoberUtil');
         $this->registerConsoleCommand('october.mirror', 'System\Console\OctoberMirror');
-        $this->registerConsoleCommand('october.mirror', 'System\Console\OctoberFresh');
+        $this->registerConsoleCommand('october.fresh', 'System\Console\OctoberFresh');
 
         $this->registerConsoleCommand('plugin.install', 'System\Console\PluginInstall');
         $this->registerConsoleCommand('plugin.remove', 'System\Console\PluginRemove');

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -310,9 +310,16 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerConsoleCommand('october.update', 'System\Console\OctoberUpdate');
         $this->registerConsoleCommand('october.util', 'System\Console\OctoberUtil');
         $this->registerConsoleCommand('october.mirror', 'System\Console\OctoberMirror');
+        $this->registerConsoleCommand('october.mirror', 'System\Console\OctoberFresh');
+
         $this->registerConsoleCommand('plugin.install', 'System\Console\PluginInstall');
         $this->registerConsoleCommand('plugin.remove', 'System\Console\PluginRemove');
         $this->registerConsoleCommand('plugin.refresh', 'System\Console\PluginRefresh');
+
+        $this->registerConsoleCommand('theme.use', 'System\Console\ThemeUse');
+        $this->registerConsoleCommand('theme.list', 'System\Console\ThemeList');
+        $this->registerConsoleCommand('theme.install', 'System\Console\ThemeInstall');
+        $this->registerConsoleCommand('theme.delete', 'System\Console\ThemeDelete');
 
         /*
          * Register the sidebar for the System main menu

--- a/modules/system/console/OctoberFresh.php
+++ b/modules/system/console/OctoberFresh.php
@@ -1,0 +1,69 @@
+<?php namespace System\Console;
+
+use Artisan;
+use File;
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Cms\Classes\Theme;
+use Cms\Classes\ThemeManager;
+
+class OctoberFresh extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     */
+    protected $name = 'october:fresh';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Removes the demo included with October.';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function fire()
+    {
+        if (!$this->confirmToProceed('Are you sure?')) {
+            return;
+        }
+
+        $demoThemePath = themes_path().'/demo';
+
+        if (File::exists($demoThemePath)) {
+            Artisan::call('plugin:remove', ['name' => 'October.Demo', '--force' => true]);
+            File::deleteDirectory($demoThemePath);
+
+            $this->info('Demo has been removed! Enjoy a fresh start.');
+        }
+        else {
+            $this->error('Demo theme is already removed.');
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+    /**
+     * Get the console command options.
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/modules/system/console/ThemeDelete.php
+++ b/modules/system/console/ThemeDelete.php
@@ -1,0 +1,76 @@
+<?php namespace System\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Cms\Classes\Theme;
+use Cms\Classes\ThemeManager;
+
+class ThemeDelete extends Command
+{
+    /**
+     * The console command name.
+     * @var string
+     */
+    protected $name = 'theme:delete';
+
+    /**
+     * The console command description.
+     * @var string
+     */
+    protected $description = 'Delete an existing theme.';
+
+    /**
+     * Create a new command instance.
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     * @return void
+     */
+    public function fire()
+    {
+        $themeName = $this->argument('name');
+
+        if (!Theme::exists($themeName)) {
+            return $this->error(sprintf('The theme %s does not exist.', $themeName));
+        }
+
+        if (!$this->confirm(sprintf('Do you really wish to delete the theme %s? YOU CAN NOT UNDO THIS! [y|N]', $themeName), false)) {
+            return;
+        }
+
+        try {
+            ThemeManager::instance()->deleteTheme($themeName);
+
+            $this->info(sprintf('The theme %s has been deleted.', $themeName));
+        }
+        catch (\October\Rain\Exception\ApplicationException $e) {
+            $this->error($e->getMessage());
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the theme. (directory name)'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/modules/system/console/ThemeInstall.php
+++ b/modules/system/console/ThemeInstall.php
@@ -1,0 +1,116 @@
+<?php namespace System\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use System\Classes\UpdateManager;
+use Cms\Classes\ThemeManager;
+use File;
+
+class ThemeInstall extends Command
+{
+    /**
+     * The console command name.
+     * @var string
+     */
+    protected $name = 'theme:install';
+
+    /**
+     * The console command description.
+     * @var string
+     */
+    protected $description = 'Install a theme from the October marketplace.';
+
+    /**
+     * Create a new command instance.
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     * @return void
+     */
+    public function fire()
+    {
+        $argDirName = $this->argument('dirName');
+
+        if ($argDirName && !preg_match('/^[a-z0-9\_\-]+$/i', $argDirName)) {
+            return $this->error('Invalid destination directory name.');
+        }
+
+        $themeName = $this->argument('name');
+        $updateManager = UpdateManager::instance();
+
+        try {
+            $themeDetails = $updateManager->requestThemeDetails($themeName);
+
+            if (ThemeManager::instance()->isInstalled($themeDetails['code'])) {
+                $this->error(sprintf('The theme %s is already installed.', $themeDetails['code']));
+                return;
+            }
+
+            $this->info(sprintf(
+                "Name: %s\nDescription: %s\nAuthor: %s\nURL: %s\n",
+                $themeDetails['code'],
+                $themeDetails['description'],
+                $themeDetails['author'],
+                $themeDetails['product_url']));
+
+            if (!$this->confirm('Do you wish to continue? [Y|n]', true)) {
+                return;
+            }
+
+            $this->info('Downloading theme...');
+            $updateManager->downloadTheme($themeDetails['code'], $themeDetails['hash']);
+
+            $this->info('Extracting theme...');
+            $updateManager->extractTheme($themeDetails['code'], $themeDetails['hash']);
+
+            $dirName = $this->themeCodeToDir($themeDetails['code']);
+            if ($argDirName) {
+                File::move(themes_path().'/'.$dirName, themes_path().'/'.$argDirName);
+                $dirName = $argDirName;
+            }
+
+            $this->info(sprintf('The theme %s has been installed. (now %s)', $dirName));
+        }
+        catch (\October\Rain\Exception\ApplicationException $e) {
+            $this->error($e->getMessage());
+        }
+    }
+
+    /**
+     * Theme code to dir.
+     *
+     * @param string $themeCode
+     * @return string
+     */
+    protected function themeCodeToDir($themeCode)
+    {
+        return strtolower(str_replace('.', '-', $themeCode));
+    }
+
+    /**
+     * Get the console command arguments.
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the theme. Eg: AuthorName.ThemeName'],
+            ['dirName', InputArgument::OPTIONAL, 'Destination directory name for the theme installation.'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/modules/system/console/ThemeInstall.php
+++ b/modules/system/console/ThemeInstall.php
@@ -75,7 +75,7 @@ class ThemeInstall extends Command
                 $dirName = $argDirName;
             }
 
-            $this->info(sprintf('The theme %s has been installed. (now %s)', $dirName));
+            $this->info(sprintf('The theme %s has been installed. (now %s)', $themeDetails['code'], $dirName));
         }
         catch (\October\Rain\Exception\ApplicationException $e) {
             $this->error($e->getMessage());

--- a/modules/system/console/ThemeList.php
+++ b/modules/system/console/ThemeList.php
@@ -68,7 +68,7 @@ class ThemeList extends Command
     protected function getOptions()
     {
         return [
-            ['include-marketplace', 'm', InputOption::VALUE_NONE, 'Whether or not to include downloadable themes from the October marketplace.']
+            ['include-marketplace', 'm', InputOption::VALUE_NONE, 'Include downloadable themes from the October marketplace.']
         ];
     }
 }

--- a/modules/system/console/ThemeList.php
+++ b/modules/system/console/ThemeList.php
@@ -1,0 +1,74 @@
+<?php namespace System\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Cms\Classes\Theme;
+use Cms\Classes\ThemeManager;
+use System\Classes\UpdateManager;
+
+class ThemeList extends Command
+{
+    /**
+     * The console command name.
+     */
+    protected $name = 'theme:list';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'List available themes.';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function fire()
+    {
+        $loadedThemes = Theme::all();
+        for ($i = 0, $c = count($loadedThemes); $i < $c; $i++) {
+            $ln = $loadedThemes[$i]->isActiveTheme() ? '[*] ' : '[-] ';
+            $this->info($ln.$loadedThemes[$i]->getId());
+        }
+
+        if ($this->option('include-marketplace')) {
+
+            // @todo List everything in the marketplace - not just popular.
+
+            $popularThemes = UpdateManager::instance()->requestPopularProducts('theme');
+            $themeManager = ThemeManager::instance();
+
+            for ($i = 0, $c = count($popularThemes); $i < $c; $i++) {
+                if (!$themeManager->isInstalled($popularThemes[$i]['code'])) {
+                    $this->info('[ ] '.$popularThemes[$i]['code']);
+                }
+            }
+        }
+
+        $this->info("\n[*] Active    [-] Installed    [ ] Not installed");
+    }
+
+    /**
+     * Get the console command arguments.
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+    /**
+     * Get the console command options.
+     */
+    protected function getOptions()
+    {
+        return [
+            ['include-marketplace', 'm', InputOption::VALUE_NONE, 'Whether or not to include downloadable themes from the October marketplace.']
+        ];
+    }
+}

--- a/modules/system/console/ThemeUse.php
+++ b/modules/system/console/ThemeUse.php
@@ -1,0 +1,81 @@
+<?php namespace System\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Symfony\Component\Console\Input\InputArgument;
+use Cms\Classes\Theme;
+
+class ThemeUse extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     * @var string
+     */
+    protected $name = 'theme:use';
+
+    /**
+     * The console command description.
+     * @var string
+     */
+    protected $description = 'Switch the active theme.';
+
+    /**
+     * Create a new command instance.
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     * @return void
+     */
+    public function fire()
+    {
+        if (!$this->confirmToProceed('Do you really want to change the active theme?')) {
+            return;
+        }
+
+        $newThemeName = $this->argument('name');
+        $newTheme = Theme::load($newThemeName);
+
+        if (!$newTheme->exists($newThemeName)) {
+            return $this->error(sprintf('The theme %s does not exist.', $newThemeName));
+        }
+
+        if ($newTheme->isActiveTheme()) {
+            return $this->error(sprintf('%s is already the active theme.', $newTheme->getId()));
+        }
+
+        $activeTheme = Theme::getActiveTheme();
+        $from = $activeTheme ? $activeTheme->getId() : 'nothing';
+
+        $this->info(sprintf('Switching theme from %s to %s', $from, $newTheme->getId()));
+
+        Theme::setActiveTheme($newThemeName);
+    }
+
+    /**
+     * Get the console command arguments.
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the theme. (directory name)'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
- Adds artisan command `october:fresh` for removing the demo included with October.

- Adds new artisan commands related to themes:
  `theme:list`     List all available themes (in marketplace.)
  `theme:use`      Switch the active theme.
  `theme:install`  Install a theme from the marketplace.
  `theme:delete`   Delete an existing theme.

This could make the development workflow for setting up a new project alot quicker.
For instance, take a look at https://github.com/krisawzm/blank-theme
This is just a blank scaffolding theme that you can build on. You could install it by simply running
`php artisan theme:install krisawzm.blank` - after running `october:fresh`, of course.