### PR TITLE
Route parameters isn't filling when enableRoutesCache is enabled

### DIFF
--- a/modules/cms/classes/Router.php
+++ b/modules/cms/classes/Router.php
@@ -96,6 +96,10 @@ class Router
 
             if ($cacheable) {
                 $fileName = $this->getCachedUrlFileName($url, $urlList);
+                $router = $this->getRouterObject();
+                if ($router->match($url)) {
+                    $this->parameters = $router->getParameters();
+                }
             }
 
             /*


### PR DESCRIPTION
This PR fixes the empty parameters when __enableRoutesCache__ is enabled.

I was testing my site with production configs and found this problem.