### PR TITLE
Remove list columns

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -651,6 +651,18 @@ class Lists extends WidgetBase
     }
 
     /**
+     * Programatically remove a column, used for extensibility.
+     *
+     * @param string $column Column Column name
+     */
+    public function removeColumn($columnName)
+    {
+        if (isset($this->allColumns[$columnName])) {
+            unset($this->allColumns[$columnName]);
+        }
+    }
+
+    /**
      * Creates a list column object from it's name and configuration.
      */
     protected function makeListColumn($name, $config)


### PR DESCRIPTION
[Extending list columns](https://octobercms.com/docs/backend/lists#extend-list-columns) allows to add new columns to a list, but not to remove them.

This PR allows it, so in controllers now its possible (for example) to do something like I needed:

```php
public function listExtendColumns($list)
{
    // Permisions
    if (!$this->user->hasAccess('acme.plugin.acces_clients')) {
        $list->removeColumn('client');
    }
}
```