### PR TITLE
Create _field_string.htm File

### DIFF
--- a/modules/backend/widgets/form/partials/_field_string.htm
+++ b/modules/backend/widgets/form/partials/_field_string.htm
@@ -1,0 +1,16 @@
+<!-- Partial String -->
+<?php if ($this->previewMode): ?>
+    <span class="form-control"><?= $field->value ? e($field->value) : '&nbsp;' ?></span>
+<?php else: ?>
+    <input
+        type="text"
+        name="<?= $field->getName() ?>"
+        id="<?= $field->getId() ?>"
+        value="<?= e($field->value) ?>"
+        placeholder="<?= e(trans($field->placeholder)) ?>"
+        class="form-control"
+        autocomplete="off"
+        maxlength="255"
+        <?= $field->getAttributes() ?>
+    />
+<?php endif ?>


### PR DESCRIPTION
To have the ability of creating a string field (as it is shown in the video : Extending the User plugin - guide on adding extra fields to the RainLab.User plugin by Samuel Georges).