### PR TITLE
Fix two minor media manager bugs

### DIFF
--- a/modules/cms/classes/MediaLibrary.php
+++ b/modules/cms/classes/MediaLibrary.php
@@ -61,8 +61,11 @@ class MediaLibrary
     {
         $this->storageFolder = self::validatePath(Config::get('cms.storage.media.folder', 'media'), true);
         $this->storagePath = rtrim(Config::get('cms.storage.media.path', '/storage/app/media'), '/');
+
         if (!preg_match("/(\/\/|http|https)/", $this->storagePath)) {
             $this->storagePath = Request::getBasePath() . $this->storagePath;
+        } else {
+            $this->storagePath .= '/';
         }
 
         $this->ignoreNames = Config::get('cms.storage.media.ignore', $this->defaultIgnoreNames);

--- a/modules/cms/widgets/mediamanager/partials/_item-sidebar-preview.htm
+++ b/modules/cms/widgets/mediamanager/partials/_item-sidebar-preview.htm
@@ -9,7 +9,7 @@
 </script>
 
 <script type="text/template" data-control="video-template">
-    <video src="{src}" controls poster="<?= URL::to('modules/cms/Widgets/mediamanager/assets/images/video-poster.png') ?>">
+    <video src="{src}" controls poster="<?= URL::to('modules/cms/widgets/mediamanager/assets/images/video-poster.png') ?>">
         <div class="panel media-player-fallback">Your browser doesn't support HTML5 video.</div>
     </video>
 </script>


### PR DESCRIPTION
* Fixed wrong link to video poster (`widgets` instead of `Widgets`).
* Fixed wrong link to public URL (add slash if it is external, e.g. `https://google.de/`).