### PR TITLE
Solves issue #1108

### DIFF
--- a/modules/backend/assets/js/october.chartbar.js
+++ b/modules/backend/assets/js/october.chartbar.js
@@ -1,6 +1,6 @@
 /*
- * The bar chart plugin. 
- * 
+ * The bar chart plugin.
+ *
  * Data attributes:
  * - data-control="chart-bar" - enables the bar chart plugin
  * - data-height="200" - optional, height of the graph
@@ -9,7 +9,7 @@
  * JavaScript API:
  * $('.scoreboard .chart').barChart()
  *
- * Dependences: 
+ * Dependences:
  * - Raphaël (raphael-min.js)
  * - October chart utilities (october.chartutils.js)
  */
@@ -18,7 +18,7 @@
     var BarChart = function (element, options) {
         this.options = options || {};
 
-        var 
+        var
             $el = this.$el = $(element),
             size = this.size = $el.height(),
             total = 0,
@@ -42,10 +42,10 @@
             self.paper.customAttributes.bar = function (start, height) {
                 return {
                     path: [
-                        ["M", start, chartWidth], 
+                        ["M", start, chartHeight],
                         ["L", start, chartHeight-height],
                         ["L", start + barWidth, chartHeight-height],
-                        ["L", start + barWidth, chartWidth],
+                        ["L", start + barWidth, chartHeight],
                         ["Z"]
                     ]
                 }
@@ -62,7 +62,7 @@
                 start += barWidth + self.options.gap
 
                 path.hover(function(ev){
-                    $.oc.chartUtils.showTooltip(ev.pageX, ev.pageY, 
+                    $.oc.chartUtils.showTooltip(ev.pageX, ev.pageY,
                         $.trim($.oc.chartUtils.getLegendLabel($legend, index)) + ': <strong>'+valueInfo.value+'</stong>')
                 }, function() {
                     $.oc.chartUtils.hideTooltip()


### PR DESCRIPTION
Finally found what was causing this issue. The base of the bars was being calculated using the chart width rather than the height. When the chart is wider than the height, this isn't a problem because the bottom of the bars will just extend beyond the bottom of the chart. But when the height is the larger value, the bottom of the bars was being shifted upwards.

Now we can have bar charts taller than they are wide =)

![skinny-bar-chart](https://cloud.githubusercontent.com/assets/7980426/7741159/ca0b51ae-ff49-11e4-9674-ab17ffe2225b.png)