### PR TITLE
allow context to be set on construct

### DIFF
--- a/modules/backend/widgets/ReportContainer.php
+++ b/modules/backend/widgets/ReportContainer.php
@@ -73,8 +73,11 @@ class ReportContainer extends WidgetBase
     /**
      * Constructor.
      */
-    public function __construct($controller)
+    public function __construct($controller, $context=null)
     {
+        if($context){
+            $this->context = $context;
+        }
         $configFile = 'config_' . snake_case($this->alias) . '.yaml';
         $path = $controller->getConfigPath($configFile);
         if (File::isFile($path)) {


### PR DESCRIPTION
currently the report container can no longer be utilized on other backend pages. (this used to work).  If context is not set on instantiation, the context reverts to 'dashboard' and cannot be set after initialization.  This code passively allows other controllers to utilize the widget and properly contextualize the use.

http://laravel.io/bin/E338m