### PR TITLE
Fixed error when using {% flash type %}

### DIFF
--- a/modules/cms/twig/FlashNode.php
+++ b/modules/cms/twig/FlashNode.php
@@ -52,7 +52,7 @@ class FlashNode extends Twig_Node
                 ->write(';')
                 ->write('foreach (Flash::')
                 ->raw($attrib)
-                ->write('() as $messages) {'.PHP_EOL)
+                ->write('() as $message) {'.PHP_EOL)
                 ->indent()
                     ->write('$context["message"] = $message;')
                     ->subcompile($this->getNode('body'))


### PR DESCRIPTION
While `{% flash %}` works fine for displaying all flash messages, if a user wants to show only a certain type with `{% flash success %}` or `{% flash error %}` for example, it errors with **Undefined variable: message**.

This fixes that error (reported in IRC by user *lowerends*)