### PR TITLE
Fix csrf in framework js

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -11,6 +11,21 @@ if (window.jQuery === undefined)
 
 +function ($) { "use strict";
 
+    /*
+     * Get XSRF-TOKEN from cookie
+     */
+    function getXsrfToken() {
+        var cookies = document.cookie.split(';')
+        var xsrfToken
+
+        cookies.forEach(function (cookieRow) {
+            var cookie = cookieRow.split('=')
+            cookie[0] === 'XSRF-TOKEN' ? xsrfToken = cookie[1] : null
+        })
+
+        return xsrfToken
+    }
+
     var Request = function (element, handler, options) {
         var $el = this.$el = $(element);
         this.options = options || {};
@@ -84,7 +99,8 @@ if (window.jQuery === undefined)
             context: context,
             headers: {
                 'X-OCTOBER-REQUEST-HANDLER': handler,
-                'X-OCTOBER-REQUEST-PARTIALS': this.extractPartials(options.update)
+                'X-OCTOBER-REQUEST-PARTIALS': this.extractPartials(options.update),
+                'X-XSRF-TOKEN': getXsrfToken() // inject encoded CSRF token into AJAX requests as header
             },
             success: function(data, textStatus, jqXHR) {
                 /*

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -20,10 +20,10 @@ if (window.jQuery === undefined)
 
         cookies.forEach(function (cookieRow) {
             var cookie = cookieRow.split('=')
-            cookie[0] === 'XSRF-TOKEN' ? xsrfToken = cookie[1] : null
+            cookie[0] === 'XSRF-TOKEN' ? xsrfToken = (''+cookie[1]).trim() : null
         })
 
-        return xsrfToken
+        return decodeURIComponent(xsrfToken)
     }
 
     var Request = function (element, handler, options) {


### PR DESCRIPTION
Related to: https://github.com/octobercms/library/issues/105, extracts XSRF token from cookie and injects it into AJAX request as a X-XSRF-TOKEN header (works exactly the same as in angular.js).