### PR TITLE
Remove empty tabs when removing form fields

### DIFF
--- a/modules/backend/classes/FormTabs.php
+++ b/modules/backend/classes/FormTabs.php
@@ -118,6 +118,10 @@ class FormTabs implements IteratorAggregate, ArrayAccess
                 if ($fieldName == $name) {
                     unset($this->fields[$tab][$fieldName]);
 
+                    if (!sizeof($this->fields[$tab])) {
+                        unset($this->fields[$tab]);
+                    }
+
                     return true;
                 }
             }


### PR DESCRIPTION
When removing a form field with `$form->removeField(...)`, the tab that field belonged to isn't removed if there are no fields left for that tab - resulting in the form not rendering correctly. See the image below:
![](http://i.imgur.com/I2z0qUD.png)

This patch simply checks if the tab has no fields left and removes it if that's the case so forms will always show their first tab correctly.