### PR TITLE
Set more CSV parameters

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -340,7 +340,9 @@ class ListController extends ControllerBehavior
          * Parse options
          */
         $defaultOptions = [
-            'filename' => 'export.csv'
+            'filename' => 'export.csv',
+            'delimiter' => ',',
+            'enclosure' => '"'
         ];
 
         $options = array_merge($defaultOptions, $options);
@@ -350,6 +352,8 @@ class ListController extends ControllerBehavior
          * Prepare CSV
          */
         $csv = Writer::createFromFileObject(new SplTempFileObject);
+        $csv->setDelimiter($options['delimiter']);
+        $csv->setEnclosure($options['enclosure']);
 
         /*
          * Add headers


### PR DESCRIPTION
Set more params for CSV builder.

**Reason:** I needed to set `;` as a delimiter.