### PR TITLE
Fix location of mediafinder comments

### DIFF
--- a/modules/cms/formwidgets/mediafinder/assets/less/mediafinder.base.less
+++ b/modules/cms/formwidgets/mediafinder/assets/less/mediafinder.base.less
@@ -58,6 +58,8 @@
 
 .field-mediafinder {
 
+    overflow: hidden;
+    
     .find-object {
 
         .border-radius(3px);


### PR DESCRIPTION
Without the overflow, mediafinder comments render in a weird location (see before / after screenshots)

https://www.dropbox.com/s/ogxfcaky6tdkki4/before_overflow.png?dl=0
https://www.dropbox.com/s/bsn0s0fjpj7j9iz/after_overflow.png?dl=0