### PR TITLE
insert-cropped event in mediamanager.js on mediafinder fields

### DIFF
--- a/modules/cms/widgets/mediamanager/assets/js/mediamanager.js
+++ b/modules/cms/widgets/mediamanager/assets/js/mediamanager.js
@@ -811,8 +811,10 @@
     }
 
     MediaManager.prototype.onImageCropped = function(imageUrl) {
+        var pathIndex = imageUrl.indexOf("/cropped-images/");
         var item = {
             documentType: 'image',
+            path: imageUrl.substr(pathIndex),
             publicUrl: imageUrl
         }
 


### PR DESCRIPTION
Crop and insert button in the media manager is not working on mediafinder fields in the backend, because when firing the insert-cropped event the path field was missing.

Adding the cropped-images/ path resolved the issue.

The issue where the missing path in the items object was causing problems was [mediafinder.js line 74](https://github.com/octobercms/october/blob/master/modules/cms/formwidgets/mediafinder/assets/js/mediafinder.js#L74). Lines 91 and 97 with a path of undefined would result in isPopulated false and prevent the image from displaying in mediafinder field.