### PR TITLE
Turn off replaceDivs

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/vendor/redactor/redactor.js
+++ b/modules/backend/formwidgets/richeditor/assets/vendor/redactor/redactor.js
@@ -119,7 +119,7 @@
 		maxHeight: false,
 
 		linebreaks: false,
-		replaceDivs: true,
+		replaceDivs: false,
 		paragraphize: true,
 		cleanStyleOnEnter: false,
 		enterKey: true,


### PR DESCRIPTION
Hi,

One of the most anoying problem, can be saved easily. When we make code, we should be able to save it as **original** and not as the editor one.

See issue [#47 in `rainlab/pages-plugin`](https://github.com/rainlab/pages-plugin/issues/47)