### PR TITLE
Ensuring version order of database histroy.

### DIFF
--- a/modules/system/classes/VersionManager.php
+++ b/modules/system/classes/VersionManager.php
@@ -391,6 +391,12 @@ class VersionManager
         }
 
         $historyInfo = Db::table('system_plugin_history')->where('code', $code)->get();
+
+        if (is_array($historyInfo)) {
+            usort($historyInfo, function ($a, $b) {
+                return version_compare($a->version, $b->version);
+            });
+        }
         return $this->databaseHistory[$code] = $historyInfo;
     }
 


### PR DESCRIPTION
Currently there's nothing that ensures the order that migrations are run when refreshing a plugin. I discovered this when working with a postgres database that returned the history records in a completely different order than the mysql database did. 