### PR TITLE
Allow overriding number field pattern attribute

### DIFF
--- a/modules/backend/widgets/form/partials/_field_number.htm
+++ b/modules/backend/widgets/form/partials/_field_number.htm
@@ -10,7 +10,7 @@
         placeholder="<?= e(trans($field->placeholder)) ?>"
         class="form-control"
         autocomplete="off"
-        pattern="-?\d+(\.\d+)?"
+        <?= $field->hasAttribute('pattern') ? '' : 'pattern="-?\d+(\.\d+)?"' ?>
         <?= $field->hasAttribute('maxlength') ? '' : 'maxlength="255"' ?>
         <?= $field->getAttributes() ?>
     />


### PR DESCRIPTION
This PR allows you to set a custom pattern for number fields using:
```yaml
myField:
    label: My Field
    attributes:
        pattern: [0-9]+
```

This is helpful for example if you only want positive integers entered, or only a 2 digit currency value etc. It's fully backwards compatible and will default back to the current `-?\d+(\.\d+)` if not specified.