### PR TITLE
Fix the modified items counter in the backend sidenav

### DIFF
--- a/modules/backend/layouts/_sidenav.htm
+++ b/modules/backend/layouts/_sidenav.htm
@@ -21,7 +21,7 @@
                                 </a>
                                 <span
                                     class="counter <?= $item->counter === null ? 'empty' : null ?>"
-                                    data-menu-id="<?= e($context->mainMenuCode.'/'.$sideItemCode) ?>"
+                                    data-menu-id="<?= e($context->mainMenuCode.'/'.$item->code) ?>"
                                     <?php if ($item->counterLabel): ?>title="<?= e(trans($item->counterLabel)) ?>"<?php endif ?>
                                     >
                                     <?= e($item->counter) ?>


### PR DESCRIPTION
When a user edit an item in the CMS module, a red counter should appear.
The `_sidenav.htm` partial used the 0-indexed key `$sideItemCode` but the javascript (and documentation) uses the *string* code (the key in the configuration array of the plugin).
When changing `$sideItemCode` to `$item->code`, the counter shows up. - Fixes #1309 