### PR TITLE
Filter out empty CSV rows before import

### DIFF
--- a/modules/backend/models/ImportModel.php
+++ b/modules/backend/models/ImportModel.php
@@ -93,6 +93,11 @@ abstract class ImportModel extends Model
 
         $reader = CsvReader::createFromPath($filePath);
 
+        // Filter out empty rows
+        $reader->addFilter(function(array $row) {
+            return count($row) > 1 || reset($row) !== null;
+        });
+
         if ($firstRowTitles) {
             $reader->setOffset(1);
         }


### PR DESCRIPTION
CSVs with an empty line at the end result in an import error. As this is a relatively common occurrence in the CSV world, we should filter out empty rows before hitting our import models `importData` method.