### PR TITLE
Only read permission is required for imports

### DIFF
--- a/modules/backend/models/ImportModel.php
+++ b/modules/backend/models/ImportModel.php
@@ -91,7 +91,7 @@ abstract class ImportModel extends Model
             'firstRowTitles' => true
         ], $options));
 
-        $reader = CsvReader::createFromPath($filePath);
+        $reader = CsvReader::createFromPath($filePath, 'r');
 
         if ($firstRowTitles) {
             $reader->setOffset(1);


### PR DESCRIPTION
Default permission when calling `createFromPath` is `r+` but we don't need write permission for imports - so only requre *read*.