### PR TITLE
Fix height issues introduced in Chrome 45

### DIFF
--- a/modules/backend/assets/css/october.css
+++ b/modules/backend/assets/css/october.css
@@ -385,7 +385,7 @@
 .control-treeview ol > li.drop-target.has-subitems > div:before{background-position:0px -102px}
 }
 .sidenav-tree{width:280px;background:#34495e}
-.sidenav-tree .control-toolbar{padding:20px 0 20px 20px}
+.sidenav-tree .control-toolbar{height:auto;padding:20px 0 20px 20px}
 .sidenav-tree .control-toolbar input.form-control{border:none}
 .sidenav-tree ul{padding:0;margin:0;list-style:none}
 .sidenav-tree div.scrollbar-thumb{background:#2b3e50 !important}
@@ -3119,7 +3119,7 @@ body.slim-container .layout.layout-container,body.slim-container .layout .layout
 .layout.responsive-sidebar > .layout-cell:last-child .layout-absolute{position:static}
 }
 body.mainmenu-open{overflow:hidden}
-nav#layout-mainmenu.navbar{background-color:#111111;padding:0 0 0 20px;line-height:0;white-space:nowrap}
+nav#layout-mainmenu.navbar{background-color:#111111;height:auto;padding:0 0 0 20px;line-height:0;white-space:nowrap}
 nav#layout-mainmenu.navbar a{text-decoration:none}
 nav#layout-mainmenu.navbar a:focus{background:transparent}
 nav#layout-mainmenu.navbar ul{margin:0;padding:0;list-style:none;float:left;font-weight:600;white-space:nowrap;overflow:hidden}

--- a/modules/backend/assets/less/controls/sidenav-tree.less
+++ b/modules/backend/assets/less/controls/sidenav-tree.less
@@ -3,6 +3,7 @@
     background: @color-sidebarnav-bg;
 
     .control-toolbar {
+        height: auto;
         padding: 20px 0 20px 20px;
 
         input.form-control {

--- a/modules/backend/assets/less/layout/mainmenu.less
+++ b/modules/backend/assets/less/layout/mainmenu.less
@@ -10,6 +10,7 @@ nav#layout-mainmenu.navbar {
     // .clearfix();
     // position: relative;
     background-color: @color-mainmenu;
+    height: auto;
     padding: 0 0 0 20px;
     line-height: 0;
     white-space: nowrap;


### PR DESCRIPTION
The `height:100%` rule applied to .layout is inherited by both the backend navbar, and the search box of the settings sidebar.

This fixes the issue by specifically applying `height:auto` to the affected elements.

![2015-07-30-084236_960x512_scrot](https://cloud.githubusercontent.com/assets/1521802/8978121/ff216b42-3696-11e5-99dd-93a4de44d8c0.png)
