### PR TITLE
Reload relations in RelationsController::relationRefresh()

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -393,6 +393,10 @@ class RelationController extends ControllerBehavior
     {
         $field = $this->validateField($field);
 
+        if(is_object($this->relationModel)) {
+            $this->relationModel->reloadRelations();
+        }
+
         $result = ['#'.$this->relationGetId('view') => $this->relationRenderView($field)];
         if ($toolbar = $this->relationRenderToolbar($field)) {
             $result['#'.$this->relationGetId('toolbar')] = $toolbar;

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -877,17 +877,15 @@ class RelationController extends ControllerBehavior
         $this->forceManageMode = 'form';
         $this->beforeAjax();
         $saveData = $this->manageWidget->getSaveData();
+        $sessionKey = $this->deferredBinding ? $this->relationGetSessionKey(true) : null;
 
         if ($this->viewMode == 'multi') {
-            $sessionKey = $this->deferredBinding ? $this->relationGetSessionKey(true) : null;
-
             if ($this->relationType == 'hasMany') {
                 $newModel = $this->relationObject->create($saveData, $sessionKey);
             }
             elseif ($this->relationType == 'belongsToMany') {
                 $newModel = $this->relationObject->create($saveData, [], $sessionKey);
             }
-
             $newModel->commitDeferred($this->manageWidget->getSessionKey());
         }
         elseif ($this->viewMode == 'single') {
@@ -896,8 +894,12 @@ class RelationController extends ControllerBehavior
 
             if ($this->relationType == 'belongsTo') {
                 $newModel->save();
-                $this->relationObject->associate($newModel);
-                $this->relationObject->getParent()->save();
+                if($this->deferredBinding) {
+                    $this->relationObject->getParent()->bindDeferred($this->relationName,$newModel,$sessionKey);
+                } else {
+                    $this->relationObject->associate($newModel);
+                    $this->relationObject->getParent()->save();
+                }
             }
             elseif ($this->relationType == 'hasOne') {
                 $this->relationObject->add($newModel);


### PR DESCRIPTION
This pull request contains some changes from a previous pull request, on which I believe this change is dependent for this fix to work.

I'm not opening a new issue for this because it's so closely related to: https://github.com/octobercms/october/issues/1329

What this change does is reload the relations that wouldn't otherwise get updated before the slave preview form partial is regenerated. My specific example:

Exhibition relation:
  belongsTo => DigitalAsset

DigitalAsset relation:
  attachOne => SystemFile

The attached file information was not being updated when the re-rendering of the relation controller preview of the slave, so no thumbnail would appear based on the system file. By reloading the relations, I have access to the system file and can generate a thumbnail, even when the Exhibition itself hasn't been saved.
