### PR TITLE
Make backend auto closing option label translatable

### DIFF
--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -260,6 +260,7 @@ return [
         'code_folding' => 'Code folding',
         'word_wrap' => 'Word wrap',
         'highlight_active_line' => 'Highlight active line',
+        'auto_closing' => 'Auto close tags and special characters',
         'show_invisibles' => 'Show invisible characters',
         'show_gutter' => 'Show gutter',
         'theme' => 'Color scheme'

--- a/modules/backend/models/editorpreferences/fields.yaml
+++ b/modules/backend/models/editorpreferences/fields.yaml
@@ -53,7 +53,7 @@ fields:
         type: dropdown
 
     auto_closing:
-        label: Auto close tags and special characters
+        label: backend::lang.editor.auto_closing
         type: checkbox
 
     show_invisibles:


### PR DESCRIPTION
`Auto close tags and special characters` option in Code Editor preferences is currently non-translatable. This pull request fixed this and provides English translation as well, which serves as a fallback for all other languages.