### PR TITLE
Disable SweetAlert forced focus when a Bootstrap modal is already open in back-end

### DIFF
--- a/modules/backend/assets/vendor/sweet-alert/sweet-alert.js
+++ b/modules/backend/assets/vendor/sweet-alert/sweet-alert.js
@@ -386,7 +386,13 @@
     function handleOnBlur(e) {
       var $targetElement = e.target || e.srcElement,
           $focusElement = e.relatedTarget,
-          modalIsVisible = hasClass(modal, 'visible');
+          modalIsVisible = hasClass(modal, 'visible'),
+          bootstrapModalIsVisible = document.querySelector('.control-popup.modal') || false;
+
+      if(bootstrapModalIsVisible) {
+        // Bootstrap will enforce focus on the existing model, so don't do anything here to prevent infinite loop
+        return;
+      }
 
       if (modalIsVisible) {
         var btnIndex = -1; // Find the button - note, this is a nodelist, not an array.


### PR DESCRIPTION
Bootstrap is enforcing focus on it's modal box, sweet alert too. Focus on sweet alert buttons is not really important, keyboard actions are still available. 

This patch prevents SweetAlert from requesting focus if Bootstrap modal is present in DOM (checking presence of an element with `.control-popup.modal` selector).

![capture d ecran 2015-08-08 20 30 11](https://cloud.githubusercontent.com/assets/1851314/9152009/d1ee62c2-3e18-11e5-823e-8ad101bd57b7.png)

Assets must be recompiled

     php artisan october:util compile assets