### PR TITLE
Ensure versions history are retrieved by id ASC (bug introduced by PR #1304)

### DIFF
--- a/modules/system/classes/VersionManager.php
+++ b/modules/system/classes/VersionManager.php
@@ -390,13 +390,8 @@ class VersionManager
             return $this->databaseHistory[$code];
         }
 
-        $historyInfo = Db::table('system_plugin_history')->where('code', $code)->get();
+        $historyInfo = Db::table('system_plugin_history')->where('code', $code)->orderBy('id','ASC')->get();
 
-        if (is_array($historyInfo)) {
-            usort($historyInfo, function ($a, $b) {
-                return version_compare($a->version, $b->version);
-            });
-        }
         return $this->databaseHistory[$code] = $historyInfo;
     }
 


### PR DESCRIPTION
Fix issue #1356 introduced by previous PR #1304.

We can't just use `version_compare` because there are multiple entries for the same version number (comments and scripts). The items should have been inserted in the correct, so forcing sort order by `id ASC` should prevent strange default sort order from RDBMS