### PR TITLE
Fix component partials not being rendered with multiple components and nested partials

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -898,12 +898,6 @@ class Controller
         $result = $template->render(array_merge($this->vars, $parameters));
         CmsException::unmask();
 
-        if ($partial instanceof Partial) {
-            if ($this->partialComponentStack) {
-                array_pop($this->partialComponentStack);
-            }
-        }
-
         $this->vars = $vars;
         $this->componentContext = null;
         return $result;

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -781,9 +781,9 @@ class Controller
                         return false;
                     }
                 }
-                /*
-                 * Component alias is supplied
-                 */
+            /*
+             * Component alias is supplied
+             */
             }
             else {
                 if (($componentObj = $this->findComponentByName($componentAlias)) === null) {


### PR DESCRIPTION
There was a bug when, in a partial, the user includes multiple component.

__theme/partials/header.htm__
```htm
[Menu menu]
code = "main-menu"

[account]
paramCode = "code"
==
{% component 'menu' %}
{% component 'account' %}
```

__theme/partials/menu/default.htm__
```htm
<ul id="nav-main">
    {% partial __SELF__ ~ "::items" items=__SELF__.menuItems %}
</ul>
```

__theme/partials/account/default.htm__
```htm
{% if not user %}
{% partial __SELF__ ~ '::signin' %}
{% else %}
{% partial __SELF__ ~ '::activation_check' %}
{% partial __SELF__ ~ '::logout' %}
{% endif %}
```

`renderPartial()` in `Cmd\Classes\Controller` is called for `theme/partials/header.htm`, the `partialComponentStack` is built like this :
- Component `menu` is push
- Component `account` is push

Then `menu` component is rendered, and recursively, `renderPartial` is called with the same controller instance on nested partials. The last `renderPartials` of nested elements calls `array_pop` (but we are in a nested partial rendering not the root) this will pop `account` (not `menu` so menu is not rendered because it is not fount in the stack anymore), the the call is going up the stack and the another call to `array_pop` is made at the end of `menu` rendering (the stack is empty).

![xdebug](https://cloud.githubusercontent.com/assets/1851314/9279287/bfa6259e-42b6-11e5-8d11-7f3219f1f97e.png)

There is two point here : 
- the components are added in the settings order, but the markup can reference them in any order so we can't just `array_pop` or `array_shift`
- the nested partials must not remove elements from the stack as they did not push element to the stack.

The proposed patch keeps track of the root partial of a component (the first time it encounters the alias), then let nested partials render and removed itself from the stack at the end.