### PR TITLE
Fix Repeater widget behavior.

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -99,6 +99,8 @@ class Repeater extends FormWidgetBase
             $loadValue = array_keys($loadValue);
         }
 
+        if (!$loadValue) return;
+
         $itemIndexes = post(self::INDEX_PREFIX.$this->formField->getName(false), $loadValue);
 
         if (!is_array($itemIndexes)) return;


### PR DESCRIPTION
Bug's demonstration:
fields.yaml
```yaml
fields:
    testcol:
        type: repeater
        form:
            fields:
                title:
                    label: ITEM
                item:
                    type: repeater
                    prompt: Add new subitem
                    form:
                        fields:
                            subtitle:
                                span: left
                                label: subitem
```
I create item with two subitems:
![repeater1](https://cloud.githubusercontent.com/assets/13226461/9292987/935c6d1c-441f-11e5-9230-0d90d6794601.PNG)
When if I add a new item, I get the following picture:
![repeater2](https://cloud.githubusercontent.com/assets/13226461/9293001/5d5c724c-4420-11e5-9ef0-a41967db4f7c.PNG)
But I expected get the following:
![repeater3](https://cloud.githubusercontent.com/assets/13226461/9293004/8d813368-4420-11e5-87b3-b12d38fb5596.PNG)
But the data saved in database properly. I should just  delete excess subitems manually.  Bug occurs in backend only when I create a new ITEM.
