### PR TITLE
Fix Repeater formwidget behaivor when using nested repeaters.

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -120,10 +120,19 @@ class Controller extends Extendable
     protected $statusCode = 200;
 
     /**
+     * @var bool Event flag. If Repeater->onAddItem has occurred, it is set to true.
+     */
+    protected $onAddNewRepeater = false;
+
+    /**
      * Constructor.
      */
     public function __construct()
     {
+        /* If Repeater->onAddItem has occurred, onAddNewRepeater flag is set to true */
+        Event::listen('formwidgets.repeater.onadditem', function() {
+            $this->onAddNewRepeater = true;
+        });
         /*
          * Allow early access to route data.
          */

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -53,6 +53,8 @@ class Repeater extends FormWidgetBase
             'sortable',
         ]);
 
+        if ($this->controller->onAddNewRepeater) return;
+
         $this->processExistingItems();
     }
 
@@ -128,6 +130,8 @@ class Repeater extends FormWidgetBase
 
     public function onAddItem()
     {
+        Event::fire('formwidgets.repeater.onadditem');
+
         $this->indexCount++;
 
         $this->prepareVars();


### PR DESCRIPTION
fields.yaml
```yaml
fields:
    testcol:
        type: repeater
        form:
            fields:
                title:
                    label: ITEM
                item:
                    type: repeater
                    prompt: Add new subitem
                    form:
                        fields:
                            subtitle:
                                span: left
                                label: subitem
```
I create item with two subitems:
![repeater1](https://cloud.githubusercontent.com/assets/13226461/9344948/26655b4a-4615-11e5-978d-c120934cae4b.PNG)
When if I add a new item, I get the following picture:
![repeater2](https://cloud.githubusercontent.com/assets/13226461/9344958/3d385638-4615-11e5-96e1-0c05381e0c83.PNG)
But I expected get the following:
![repeater3](https://cloud.githubusercontent.com/assets/13226461/9344967/5030010a-4615-11e5-841a-ac00f7d1ecba.PNG)

This patch solves the problem. I made tests with two  and three nested repeaters and have not found errors.