### PR TITLE
Made $viewPath public

### DIFF
--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -23,7 +23,7 @@ trait ViewMaker
     /**
      * @var string Specifies a path to the views directory.
      */
-    protected $viewPath;
+    public $viewPath;
 
     /**
      * @var string Specifies a path to the layout directory.


### PR DESCRIPTION
You may be asking: **why?**

Because if `$viewPath` is a public variable, we can simply extend the backend forms with custom view files. For example, I don't like the markup of tabs. With this change in place I can simply change this markup in a new file.

```php
<?php
Event::listen('backend.form.extendFields', function($widget) {
    $widget->viewPath = [getcwd() . '/themes/acme/widgets', $widget->viewPath];
});
```

Now I can create a new file `_form_tabs.htm` in the `themes/acme/widgets/` folder and I don't need to worry about the OctoberCMS system changing.