### PR TITLE
Hide FormWidget tabs when they contain no fields or only hidden field

### DIFF
--- a/modules/system/assets/ui/docs/input-trigger.md
+++ b/modules/system/assets/ui/docs/input-trigger.md
@@ -65,6 +65,7 @@ Multie value conditions are supported:
 ### Supported events:
 
 - oc.triggerOn.update - triggers the update. Trigger this event on the element the plugin is bound to to force it to check the condition and update itself. This is useful when the page content is updated with AJAX.
+- oc.triggerOn.afterUpdate - triggered after the element is updated
 
 ### JavaScript API:
 

--- a/modules/system/assets/ui/js/input.trigger.js
+++ b/modules/system/assets/ui/js/input.trigger.js
@@ -87,6 +87,8 @@
         })
 
         $(window).trigger('resize')
+
+        this.$el.trigger('oc.triggerOn.afterUpdate', status)
     }
 
     TriggerOn.prototype.updateTargetAction = function(action, status) {


### PR DESCRIPTION
In reference to issue #1390 this patch triggers  `toggleEmptyTabs` on the parent `FormWidget` when a form field with a `toggle` action is updated.

In `input.trigger.js` a new event `oc.triggerOn.afterUpdate` is triggered after an update.

In `october.form.js` the event is catched to trigger the tab refresh. The CSS selector for "hidden tabs" has been updated because the toggle action doesn't remove the form groups but hides them with a `hide` class.