### PR TITLE
Added a new plugin:update command

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -219,6 +219,7 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerConsoleCommand('plugin.install', 'System\Console\PluginInstall');
         $this->registerConsoleCommand('plugin.remove', 'System\Console\PluginRemove');
         $this->registerConsoleCommand('plugin.refresh', 'System\Console\PluginRefresh');
+        $this->registerConsoleCommand('plugin.update', 'System\Console\PluginUpdate');
 
         $this->registerConsoleCommand('theme.install', 'System\Console\ThemeInstall');
         $this->registerConsoleCommand('theme.remove', 'System\Console\ThemeRemove');

--- a/modules/system/console/PluginUpdate.php
+++ b/modules/system/console/PluginUpdate.php
@@ -1,0 +1,71 @@
+<?php namespace System\Console;
+
+use Illuminate\Console\Command;
+use System\Classes\UpdateManager;
+use System\Classes\PluginManager;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class PluginUpdate extends Command
+{
+
+    /**
+     * The console command name.
+     * @var string
+     */
+    protected $name = 'plugin:update';
+
+    /**
+     * The console command description.
+     * @var string
+     */
+    protected $description = 'Update an existing plugin.';
+
+    /**
+     * Create a new command instance.
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     * @return void
+     */
+    public function fire()
+    {
+        $pluginName = $this->argument('name');
+        $pluginName = PluginManager::instance()->normalizeIdentifier($pluginName);
+
+        $manager = UpdateManager::instance()->resetNotes();
+
+        $this->output->writeln('<info>Updating plugin...</info>');
+        $manager->updatePlugin($pluginName);
+
+        foreach ($manager->getNotes() as $note) {
+            $this->output->writeln($note);
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the plugin. Eg: AuthorName.PluginName'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
As reference to #1402, if one wants to update __a single plugin__ and considering that `plugin:refresh` does a tearDown / up and removes database table, to avoid disconnecting / reconnecting from the back-end interface, running `php artisan plugin:update Acme.Plugin` might be useful.

Another solution is to add an option switch to the `update:refresh` command to bypass the `rollbackPlugin` call.