### PR TITLE
Added permission for /backend/system/settings

### DIFF
--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -113,6 +113,10 @@ class ServiceProvider extends ModuleServiceProvider
                 'backend.manage_branding' => [
                     'label' => 'system::lang.permissions.manage_branding',
                     'tab'   => 'system::lang.permissions.name'
+                ],
+                'backend.preferences' => [
+                    'label' => 'system::lang.permissions.manage_backend_preferences',
+                    'tab'   => 'system::lang.permissions.name'
                 ]
             ]);
         });
@@ -208,7 +212,8 @@ class ServiceProvider extends ModuleServiceProvider
                     'icon'        => 'icon-laptop',
                     'class'       => 'Backend\Models\BackendPreferences',
                     'order'       => 510,
-                    'context'     => 'mysettings'
+                    'context'     => 'mysettings',
+                    'permissions' => ['backend.preferences']
                 ],
                 'editor' => [
                     'label'       => 'backend::lang.editor.menu_label',

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -315,7 +315,7 @@ class ServiceProvider extends ModuleServiceProvider
                     'label'       => 'system::lang.settings.menu_label',
                     'icon'        => 'icon-cog',
                     'url'         => Backend::url('system/settings'),
-                    'permissions' => [],
+                    'permissions' => ['system.general'],
                     'order'       => 1000
                 ]
             ]);
@@ -367,7 +367,11 @@ class ServiceProvider extends ModuleServiceProvider
                 'system.manage_mail_templates' => [
                     'label' => 'system::lang.permissions.manage_mail_templates',
                     'tab' => 'system::lang.permissions.name'
-                ]
+                ],
+                'system.general' => [
+                    'label' => 'system::lang.permissions.manage_general_settings',
+                    'tab' => 'system::lang.permissions.name'
+                ],
             ]);
         });
     }

--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -24,7 +24,7 @@ class Settings extends Controller
      */
     protected $formWidget;
 
-    public $requiredPermissions = [];
+    public $requiredPermissions = ['system.general','backend.preferences'];
 
     public function __construct()
     {

--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -313,6 +313,8 @@ return [
         'manage_mail_settings' => 'Manage mail settings',
         'manage_other_administrators' => 'Manage other administrators',
         'view_the_dashboard' => 'View the dashboard',
-        'manage_branding' => 'Customize the back-end'
+        'manage_branding' => 'Customize the back-end',
+        'manage_general_settings' => 'Manage general settings',
+        'manage_backend_preferences' => 'Backend preferences'
     ]
 ];

--- a/modules/system/partials/_system_sidebar.htm
+++ b/modules/system/partials/_system_sidebar.htm
@@ -1,6 +1,8 @@
 <div class="layout-cell sidenav-tree" data-control="sidenav-tree" data-search-input="#settings-search-input">
     <a class="back-link" href="<?= Backend::url('system/settings') ?>"><i class="icon-angle-left"></i><?= e(trans('system::lang.settings.menu_label')) ?></a>
 
+    <?php if ($this->user->hasAccess('system.general')): ?>
+
     <div class="layout">
         <div class="layout-row min-size">
             <?= $this->makePartial('~/modules/system/partials/_settings_menu_toolbar.htm') ?>
@@ -20,4 +22,7 @@
             </div>
         </div>
     </div>
+
+    <?php endif ?>
+
 </div>


### PR DESCRIPTION
## Permission for Settings menu

I have added permission for /backend/system/settings overal page and backend preferences setting page.

With this option you can exclude the backend user(s) for the settings part in the backend. Useful for user that only are allowed to manage content for example.

If you are developing a plugin thats has to be accessed thru backend/settings controller you should add this __'permissions' => ['system.general']__ to you __registerSettings__ in your plugin in order to be in sync with the permissions.

In the permissions page for groups or users i have added 2 extra options, __Backend preferences__ and __Manage general settings__ .

## Why??
We needed this for a client project, we dont want the customer to have access to settings part of the backend, and dont want to explain why the settings menu item is there and why he may not use it! :)