### PR TITLE
Fix evaluate zero value as null

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -804,7 +804,7 @@ class Lists extends WidgetBase
         /*
          * Apply default value.
          */
-        if (empty($value)) {
+        if (is_null($value)) {
             $value = $column->defaults;
         }
 


### PR DESCRIPTION
**Bug summary:** Zero value in backend list is represented as null value. But zero is normal value as any other.

**Expected result:** Zero is printed as "0", not as "".

**Use case:** When I have product in eshop a want to save stock level. _Zero_ represents empty stock (all items sold) and _null_ represents stock waiting for fill its value.

**Solution:** Fix condition.

**Screenshot** before/after with testing dump() which show real value in database:

![null](https://cloud.githubusercontent.com/assets/374917/9636749/6c5c5d40-519d-11e5-8baf-89da4e6af016.png)