### PR TITLE
Add getPublicActions controller method

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -554,6 +554,14 @@ class Controller extends Extendable
     }
 
     /**
+     * Returns the controllers public actions.
+     */
+    public function getPublicActions()
+    {
+        return $this->publicActions;
+    }
+
+    /**
      * Returns a unique ID for the controller and route. Useful in creating HTML markup.
      */
     public function getId($suffix = null)


### PR DESCRIPTION
The latest update which stopped accessing of protected attributes broke the ability to grab the current controller's public actions with an event - something used in my MFA plugin. This PR adds a getter for the $publicActions attribute.