### PR TITLE
Remove composer.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /bootstrap/compiled.php
 /vendor
-composer.lock
 composer.phar
 .DS_Store
 .idea


### PR DESCRIPTION
This file should be included in the codebase so that all developers get exact copies of libraries and their corresponding versions.

Explained in more detail [here](https://blog.engineyard.com/2014/composer-its-all-about-the-lock-file).