### PR TITLE
Made it so relation render update on click also supports differently …

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -555,7 +555,8 @@ class RelationController extends ControllerBehavior
             $config->recordUrl = $this->getConfig('view[recordUrl]', null);
 
             $defaultOnClick = sprintf(
-                "$.oc.relationBehavior.clickViewListRecord(':id', '%s', '%s')",
+                "$.oc.relationBehavior.clickViewListRecord(':%s', '%s', '%s')",
+				$this->relationModel->primaryKey,
                 $this->field,
                 $this->relationGetSessionKey()
             );


### PR DESCRIPTION
When people have a differently named primary key than id the relation render cannot do the popup when clicking on the list view.
This will make sure that it will obey the primaryKey in the model to define which field to open.