### PR TITLE
Fixed relation render onclick in list view to obey $model->primaryKey value

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -555,7 +555,8 @@ class RelationController extends ControllerBehavior
             $config->recordUrl = $this->getConfig('view[recordUrl]', null);
 
             $defaultOnClick = sprintf(
-                "$.oc.relationBehavior.clickViewListRecord(':id', '%s', '%s')",
+                "$.oc.relationBehavior.clickViewListRecord(':%s', '%s', '%s')",
+				$this->relationModel->primaryKey,
                 $this->field,
                 $this->relationGetSessionKey()
             );

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -556,7 +556,7 @@ class RelationController extends ControllerBehavior
 
             $defaultOnClick = sprintf(
                 "$.oc.relationBehavior.clickViewListRecord(':%s', '%s', '%s')",
-			    $this->relationModel->primaryKey,
+                $this->relationModel->getKeyName(),
                 $this->field,
                 $this->relationGetSessionKey()
             );

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -556,7 +556,7 @@ class RelationController extends ControllerBehavior
 
             $defaultOnClick = sprintf(
                 "$.oc.relationBehavior.clickViewListRecord(':%s', '%s', '%s')",
-				$this->relationModel->primaryKey,
+			    $this->relationModel->primaryKey,
                 $this->field,
                 $this->relationGetSessionKey()
             );

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -77,8 +77,11 @@ if (window.jQuery === undefined)
                 options.data[inputName] = $el.val()
         }
 
+		/*
+		 *  Removing unneccesary data by en- and decoding it as JSON so functions are removed from objects.
+		 */
         if (options.data !== undefined && !$.isEmptyObject(options.data))
-            data.push($.param(options.data))
+            data.push($.param(JSON.parse(JSON.stringify(options.data))))
 
         var requestOptions = {
             context: context,


### PR DESCRIPTION
When people have a differently named primary key than id the relation render cannot do the popup when clicking on the list view, because it can't find the field id.

This will make sure that it will obey the primaryKey in the model to define which field to open which will resolve such issues.