### PR TITLE
Security tweaks

### DIFF
--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -110,6 +110,14 @@ class ServiceProvider extends ModuleServiceProvider
                     'label' => 'system::lang.permissions.manage_other_administrators',
                     'tab'   => 'system::lang.permissions.name'
                 ],
+                'backend.manage_preferences' => [
+                    'label' => 'system::lang.permissions.manage_preferences',
+                    'tab'   => 'system::lang.permissions.name'
+                ],
+                'backend.manage_editor' => [
+                    'label' => 'system::lang.permissions.manage_editor',
+                    'tab'   => 'system::lang.permissions.name'
+                ],
                 'backend.manage_branding' => [
                     'label' => 'system::lang.permissions.manage_branding',
                     'tab'   => 'system::lang.permissions.name'
@@ -207,6 +215,7 @@ class ServiceProvider extends ModuleServiceProvider
                     'category'    => SettingsManager::CATEGORY_MYSETTINGS,
                     'icon'        => 'icon-laptop',
                     'class'       => 'Backend\Models\BackendPreferences',
+                    'permissions' => ['backend.manage_preferences'],
                     'order'       => 510,
                     'context'     => 'mysettings'
                 ],
@@ -216,6 +225,7 @@ class ServiceProvider extends ModuleServiceProvider
                     'category'    => SettingsManager::CATEGORY_MYSETTINGS,
                     'icon'        => 'icon-code',
                     'url'         => Backend::URL('backend/editorpreferences'),
+                    'permissions' => ['backend.manage_editor'],
                     'order'       => 520,
                     'context'     => 'mysettings'
                 ],

--- a/modules/backend/controllers/EditorPreferences.php
+++ b/modules/backend/controllers/EditorPreferences.php
@@ -20,6 +20,8 @@ class EditorPreferences extends Controller
 
     public $formConfig = 'config_form.yaml';
 
+    public $requiredPermissions = ['backend.manage_editor'];
+
     /**
      * Constructor.
      */

--- a/modules/backend/controllers/Users.php
+++ b/modules/backend/controllers/Users.php
@@ -94,6 +94,10 @@ class Users extends Controller
             return;
         }
 
+        if (!$this->user->isSuperUser()) {
+            $form->removeField('permissions[superuser]');
+        }
+
         /*
          * Add permissions tab
          */

--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -30,8 +30,8 @@ class Settings extends Controller
     {
         parent::__construct();
 
-        if ($this->action == 'mysettings') {
-            $this->requiredPermissions = null;
+        if ($this->action == 'backend_preferences') {
+            $this->requiredPermissions = ['backend.manage_preferences'];
         }
 
         $this->addCss('/modules/system/assets/css/settings/settings.css', 'core');

--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -316,6 +316,8 @@ return [
         'manage_mail_templates' => 'Manage mail templates',
         'manage_mail_settings' => 'Manage mail settings',
         'manage_other_administrators' => 'Manage other administrators',
+        'manage_preferences' => 'Manage backend preferences',
+        'manage_editor' => 'Manage code editor preferences',
         'view_the_dashboard' => 'View the dashboard',
         'manage_branding' => 'Customize the back-end'
     ]


### PR DESCRIPTION
Adds 3 new permissions to allow removing the corresponding links from the backend account dropdown. This is particularly useful in demo scenarios where you don't want people to be able to change the backend language or demo password for example.

Also contains a fix that prevents admins from creating their own superuser account or promoting other users.