### PR TITLE
Localise last modified date for mediaManager items

### DIFF
--- a/modules/cms/classes/MediaLibraryItem.php
+++ b/modules/cms/classes/MediaLibraryItem.php
@@ -2,6 +2,8 @@
 
 use File;
 use Config;
+use IntlDateFormatter;
+use Backend\Models\UserPreferences;
 
 /**
  * Represents a file or folder in the Media Library.
@@ -48,7 +50,7 @@ class MediaLibraryItem
 
     /**
      * @var array Contains a default list of files and directories to ignore.
-     * The list can be customized with the following configuration options: 
+     * The list can be customized with the following configuration options:
      * - cms.storage.media.image_extensions
      * - cms.storage.media.video_extensions
      * - cms.storage.media.audo_extensions
@@ -129,10 +131,18 @@ class MediaLibraryItem
 
     /**
      * Returns the item last modification date as string.
-     * @return string Returns the item last modification date as string.
+     * @return string Returns the item's last modification date as string.
      */
     public function lastModifiedAsString()
     {
-        return $this->lastModified ? date('M d, Y', $this->lastModified) : null;
+        if (!($date = $this->lastModified)) {
+            return null;
+        }
+
+        return IntlDateFormatter::create(
+            UserPreferences::forUser()->get('backend::backend.preferences')['locale'],
+            IntlDateFormatter::MEDIUM,
+            IntlDateFormatter::NONE
+        )->format($date);
     }
 }


### PR DESCRIPTION
Updates the string version of the date to use PHP's IntlDateFormatter.
That gives us translated dates in the appropriate format, based on the user's locale set in backend preferences.

If ever there's a case where locale wasn't set or didn't match anything, it would default to the system locale.

Note that this PR supercedes #1460.