### PR TITLE
Use correct folder permissions in ThemeImport/Export

### DIFF
--- a/modules/cms/models/ThemeExport.php
+++ b/modules/cms/models/ThemeExport.php
@@ -86,10 +86,10 @@ class ThemeExport extends Model
             $zipName = uniqid('oc');
             $zipPath = temp_path().'/'.$zipName;
 
-            if (!@mkdir($tempPath))
+            if (!File::makeDirectory($tempPath))
                 throw new ApplicationException('Unable to create directory '.$tempPath);
 
-            if (!@mkdir($metaPath = $tempPath . '/meta'))
+            if (!File::makeDirectory($metaPath = $tempPath . '/meta'))
                 throw new ApplicationException('Unable to create directory '.$metaPath);
 
             File::copy($themePath.'/theme.yaml', $tempPath.'/theme.yaml');
@@ -133,7 +133,7 @@ class ThemeExport extends Model
         $headers = Response::download($zipPath, $outputName)->headers->all();
         $result = Response::make(File::get($zipPath), 200, $headers);
 
-        @unlink($zipPath);
+        @File::delete($zipPath);
 
         return $result;
     }

--- a/modules/cms/models/ThemeImport.php
+++ b/modules/cms/models/ThemeImport.php
@@ -101,7 +101,7 @@ class ThemeImport extends Model
 
             File::put($zipPath, $file->getContents());
 
-            if (!@mkdir($tempPath))
+            if (!File::makeDirectory($tempPath))
                 throw new ApplicationException('Unable to create directory '.$tempPath);
 
             Zip::extract($zipPath, $tempPath);


### PR DESCRIPTION
Similar to #1442 we should be using the `File` facade rather than `mkdir` and `unlink` so we don't ignore umask config.