### PR TITLE
Add localization for the backend list Switch widget

### DIFF
--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -138,7 +138,9 @@ return [
         'delete_selected' => 'Delete selected',
         'delete_selected_empty' => 'There are no selected records to delete.',
         'delete_selected_confirm' => 'Delete the selected records?',
-        'delete_selected_success' => 'Successfully deleted the selected records.'
+        'delete_selected_success' => 'Successfully deleted the selected records.',
+        'widget_switch_true' => 'Yes',
+        'widget_switch_false' => 'No'
     ],
     'fileupload' => [
         'attachment' => 'Attachment',

--- a/modules/backend/lang/fr/lang.php
+++ b/modules/backend/lang/fr/lang.php
@@ -139,6 +139,8 @@ return [
         'delete_selected_empty' => 'Il n’y a aucun enregistrement à supprimer',
         'delete_selected_confirm' => 'Confirmer la suppression des enregistrements sélectionnés ?',
         'delete_selected_success' => 'Les enregistrements ont bien été supprimés.',
+        'widget_switch_true' => 'Oui',
+        'widget_switch_false' => 'Non'
     ],
     'fileupload' => [
         'attachment' => 'Pièce jointe',

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -878,8 +878,16 @@ class Lists extends WidgetBase
      */
     protected function evalSwitchTypeValue($record, $column, $value)
     {
-        // return ($value) ? '<i class="icon-check"></i>' : '<i class="icon-times"></i>';
-        return ($value) ? 'Yes' : 'No';
+        $contents = '';
+
+        if($value) {
+            $contents = trans('backend::lang.list.widget_switch_true');
+        }
+        else {
+            $contents = trans('backend::lang.list.widget_switch_false');
+        }
+
+        return $contents;
     }
 
     /**


### PR DESCRIPTION
This is my first time making a pull request on a public repo so please bear with me. I'm loving what I've seen of October so far! This is a very small issue.

Currently, the "Switch" column type in the backend List, [as described in the docs](https://octobercms.com/docs/backend/lists#column-switch), allows you to render a boolean model field.

Unfortunately, in the current implementation, its value is hardcoded to english "Yes" and "No", and there was a commented version using an icon instead. This means as an October user, I'd have to customize directly in a core file or do some other bizarre tweak in order to translate or change it to my likings, and it would break when the site is updated. It should be a fairly simple thing to change.

I propose using localization instead so that it can be easily overridden by sites (which also allows icons if that is what the site's developer desire, without bloating the API) and at least display in the right language by default.

I didn't see anything about localization in the contribution guidelines. Since I speak french I provided the translations in french, but those are pretty simple and common words so I wouldn't mind fetching the values for all languages and adding them to the language files if that's preferable over partial translation.

I don't think unit tests are applicable for this change either, but do tell me if I'm wrong!

As for code style, I removed the ternary for readability because I was adding long translation strings.

Thank you!