### PR TITLE
Allow minDate/maxDate to be entered in date format for DatePicker. Fixes #909.

### DIFF
--- a/modules/backend/formwidgets/DatePicker.php
+++ b/modules/backend/formwidgets/DatePicker.php
@@ -46,13 +46,33 @@ class DatePicker extends FormWidgetBase
      */
     public function init()
     {
-        $this->fillFromConfig([
-            'mode',
-            'minDate',
-            'maxDate',
-        ]);
-
+        $this->fillDatesFromConfig();
+        $this->fillFromConfig(['mode']);
         $this->mode = strtolower($this->mode);
+    }
+
+    /**
+     * Transfers minDate and maxDate config values stored inside the
+     * $config property directly on to the root object properties.
+     *
+     * This method checks for Yaml parsed dates that have been converted
+     * into integer timestamps via the Symfony Yaml parser and converts them
+     * back into strings for use with the datepicker.
+     *
+     * @param array $properties
+     * @return void
+     */
+    protected function fillDatesFromConfig()
+    {
+        foreach(['minDate', 'maxDate'] as $property) {
+
+            $this->{$property} = $this->getConfig($property, $this->{$property});
+
+            if (is_integer($this->{$property})) {
+                $this->{$property} = date('Y-m-d', $this->{$property});
+            }
+
+        }
     }
 
     /**


### PR DESCRIPTION
The Symfony Yaml parser converts dates into timestamps via `strtotime` whenever a value matches a regex pattern that looks like a date. So, when adding a date for the `minDate` and `maxDate` options without quoting them as strings, the Yaml parser converts them into an integer timestamp. This fix looks for minDate and maxDate properties that are integers and turns them back into a date string with the form `Y-m-d`. 

Tested with multiple date formats. For example: 

* 2015-01-01 
* 01/01/2015 
* January 1, 2015 
* 2015 01 01 
* 2015-01-01 11:11:11
* 2015 January 01 11:11:11
* January 01 2015 11:11

Should work with any valid PHP date format.
 