### PR TITLE
Show matching folders when filtering CMS objects. Ref #1466

### DIFF
--- a/modules/cms/widgets/TemplateList.php
+++ b/modules/cms/widgets/TemplateList.php
@@ -304,7 +304,8 @@ class TemplateList extends WidgetBase
                 return true;
             }
         }
-        elseif (Str::$operator(Str::lower($item->fileName), $word)) {
+
+        if (Str::$operator(Str::lower($item->fileName), $word)) {
             return true;
         }
 


### PR DESCRIPTION
If I search using the filter field in CMS pages/partials/layouts sidebar, it currently includes anything with a matching filename or description. I would also like matching folder names included in this list.

## Use case
If I have for example all my blog related partials inside a *blog* subfolder, that folder is the most relevant search result I could possibly have when searching for *blog*.

Fixes #1466 