### PR TITLE
Added support for arrays in the dropdown form option when Many To Many Relations are used

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -18,7 +18,7 @@
                 if (!is_array($option)) $option = [$option];
             ?>
             <option
-                <?= $value == $field->value ? 'selected="selected"' : '' ?>
+                <?= ($value == $field->value || (is_array($field->value) && in_array($value,$field->value))) ? 'selected="selected"' : '' ?>
                 <?php if (isset($option[1])): ?>data-<?=strpos($option[1],'.')?'image':'icon'?>="<?= $option[1] ?>"<?php endif ?>
                 value="<?= $value ?>">
                     <?= e(trans($option[0])) ?>


### PR DESCRIPTION
This way if someone specifies a belongsToMany or other many to many relation field types it can still select the correct one to show as selected.
This is solely for the niche cases where this is used, But it's useful to be able to use the dropdown when needed for relationship displaying.