### PR TITLE
Add support for default values in form widgets

### DIFF
--- a/modules/backend/classes/FormWidgetBase.php
+++ b/modules/backend/classes/FormWidgetBase.php
@@ -113,7 +113,19 @@ abstract class FormWidgetBase extends WidgetBase
      */
     public function getLoadValue()
     {
-        return $this->formField->getValueFromData($this->data ?: $this->model);
+        $defaultValue = null;
+
+        if (!$this->model->exists) {
+            if ($this->formField->defaultFrom) {
+                list($model, $attribute) = $this->formField->resolveModelAttribute($this->model, $this->formField->defaultFrom);
+                $defaultValue = $model->{$attribute};
+            }
+            elseif ($this->formField->defaults !== '') {
+                $defaultValue = $this->formField->defaults;
+            }
+        }
+
+        return $this->formField->getValueFromData($this->data ?: $this->model, $defaultValue);
     }
 
     /**


### PR DESCRIPTION
Form Widgets like colorpicker ignore the default value you specify in your YAML. This PR makes them work.

Example YAML:
```yaml
my_colorpicker:
    label: My Colorpicker
    type: colorpicker
    default: #27ae60
```

My PR is just a modified version of what you already have for standard form fields:
https://github.com/octobercms/october/blob/master/modules/backend/widgets/Form.php#L778-L788