### PR TITLE
Fixed form field parsing to accept no config

### DIFF
--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -254,6 +254,10 @@ class FormField
      */
     protected function evalConfig($config)
     {
+        if(is_null($config)) {
+            $config = [];
+        }
+
         /*
          * Standard config:property values
          */


### PR DESCRIPTION
If a programmer would define a yaml like

    fields:

        shortcut:

        country:

It would fail with message

    "array_key_exists() expects parameter 2 to be array, null given" on line 275 of ..\modules\backend\classes\FormField.php

The yaml parsing returns a null. This check intercepts that null value being passed to the function and turns it into a proper array.