### PR TITLE
Allow extend query on reorder controller, on 'simple' sortMode

### DIFF
--- a/modules/backend/behaviors/ReorderController.php
+++ b/modules/backend/behaviors/ReorderController.php
@@ -215,16 +215,25 @@ class ReorderController extends ControllerBehavior
         $records = null;
 
         if ($this->sortMode == 'simple') {
-            $records = $model
-                ->orderBy($model->getSortOrderColumn())
-                ->get()
-            ;
+            $records = $model->orderBy($model->getSortOrderColumn());
+            $this->controller->reorderExtendQuery($records);
+            $records = $records->get();
         }
         elseif ($this->sortMode == 'nested') {
             $records = $model->getEagerRoot();
         }
 
         return $records;
+    }
+
+    /**
+     * Extend the query used for finding reorder records. Extra conditions
+     * can be applied to the query, for example, $query->withTrashed();
+     * @param October\Rain\Database\Builder $query
+     * @return void
+     */
+    public function reorderExtendQuery($query)
+    {
     }
 
     //


### PR DESCRIPTION
Only tested on 'simple' sortMode, hence placed within `$this->sortMode == 'simple'` condition.