### PR TITLE
Add YAML-specific settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.yaml]
+indent_size = 2
+trim_trailing_whitespace = false


### PR DESCRIPTION
Force text editor to indent using 2 spaces on `editorconfig` enabled text editor.