### PR TITLE
Add ``conditions`` config to RecordFinder

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -234,9 +234,11 @@ class RecordFinder extends FormWidgetBase
         $config->recordOnClick = sprintf("$('#%s').recordFinder('updateRecord', this, ':id')", $this->getId());
         $widget = $this->makeWidget('Backend\Widgets\Lists', $config);
 
-        $widget->addFilter(function ($query) {
-            return $query->whereRaw($this->conditions);
-        });
+        if (!empty($this->conditions)) {
+            $widget->addFilter(function ($query) {
+                return $query->whereRaw($this->conditions);
+            });
+        }
 
         return $widget;
     }

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -15,7 +15,8 @@ use Backend\Classes\FormWidgetBase;
  *        prompt: Click the Find button to find a user
  *        nameFrom: name
  *        descriptionFrom: email
- * 
+ *        conditions: is_active = 1
+ *
  * @package october\backend
  * @author Alexey Bobkov, Samuel Georges
  */
@@ -45,6 +46,11 @@ class RecordFinder extends FormWidgetBase
      */
     public $prompt = 'Click the %s button to find a record';
 
+    /**
+     * @var string Filters the relation using a raw where query statement.
+     */
+    public $conditions;
+
     //
     // Object properties
     //
@@ -60,12 +66,12 @@ class RecordFinder extends FormWidgetBase
     public $relationModel;
 
     /**
-     * @var Backend\Classes\WidgetBase Reference to the widget used for viewing (list or form).
+     * @var \Backend\Classes\WidgetBase Reference to the widget used for viewing (list or form).
      */
     protected $listWidget;
 
     /**
-     * @var Backend\Classes\WidgetBase Reference to the widget used for searching.
+     * @var \Backend\Classes\WidgetBase Reference to the widget used for searching.
      */
     protected $searchWidget;
 
@@ -79,6 +85,7 @@ class RecordFinder extends FormWidgetBase
             'keyFrom',
             'nameFrom',
             'descriptionFrom',
+            'conditions'
         ]);
 
         if (post('recordfinder_flag')) {
@@ -134,7 +141,7 @@ class RecordFinder extends FormWidgetBase
         $model->{$attribute} = post($this->formField->getName());
 
         $this->prepareVars();
-        return ['#'.$this->getId('container') => $this->makePartial('recordfinder')];
+        return ['#' . $this->getId('container') => $this->makePartial('recordfinder')];
     }
 
     /**
@@ -227,17 +234,9 @@ class RecordFinder extends FormWidgetBase
         $config->recordOnClick = sprintf("$('#%s').recordFinder('updateRecord', this, ':id')", $this->getId());
         $widget = $this->makeWidget('Backend\Widgets\Lists', $config);
 
-        // $widget->bindEvent('list.extendQueryBefore', function($query) {
-
-        //     /*
-        //      * Where not in the current list of related records
-        //      */
-        //     $existingIds = $this->findExistingRelationIds();
-        //     if (count($existingIds)) {
-        //         $query->whereNotIn('id', $existingIds);
-        //     }
-
-        // });
+        $widget->addFilter(function ($query) {
+            return $query->whereRaw($this->conditions);
+        });
 
         return $widget;
     }


### PR DESCRIPTION
Allows custom SQL conditions on the record finder. Relations already support this, but the finder doesnt seem to respect the conditions due to some limitations. I think it is a good idea to bring conditions back with this code.