### PR TITLE
Allow RelationController to list attachOne/attachMany relations

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1304,10 +1304,12 @@ class RelationController extends ControllerBehavior
         switch ($this->relationType) {
             case 'hasMany':
             case 'belongsToMany':
+            case 'attachMany':
                 return 'multi';
 
             case 'hasOne':
             case 'belongsTo':
+            case 'attachOne':
                 return 'single';
         }
     }


### PR DESCRIPTION
I have an attachMany field I'm trying to display in RelationController however I currently get the error:

> Undefined variable: widget in /path/to/modules/backend/Behaviors/RelationController.php line 666

This PR fixes the above error and displays my attachMany relation.