### PR TITLE
Allow RelationController to list morphOne/morphMany relations

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1303,10 +1303,12 @@ class RelationController extends ControllerBehavior
 
         switch ($this->relationType) {
             case 'hasMany':
+            case 'morphMany':
             case 'belongsToMany':
                 return 'multi';
 
             case 'hasOne':
+            case 'morphOne':
             case 'belongsTo':
                 return 'single';
         }


### PR DESCRIPTION
I have an morphMany field I'm trying to display in RelationController however I currently get the error:

> Undefined variable: widget in /path/to/modules/backend/Behaviors/RelationController.php line 666

This PR fixes the above error and displays my morphMany relation.