### PR TITLE
Unbinding javascript event handlers from html elements

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -199,7 +199,7 @@ if (window.jQuery === undefined)
                             $(selector.substring(1)).prepend(data[partial]).trigger('ajaxUpdate', [context, data, textStatus, jqXHR])
                         } else {
                             $(selector).trigger('ajaxBeforeReplace')
-                            $(selector).html(data[partial]).trigger('ajaxUpdate', [context, data, textStatus, jqXHR])
+                            $(selector).empty().html(data[partial]).trigger('ajaxUpdate', [context, data, textStatus, jqXHR])
                         }
                     }
 


### PR DESCRIPTION
When event handlers are bound to elements within the refreshed partial object they don't
get unbound when the element is refreshed and the elements are not valid anymore.
However, new event handlers will be bound to the new elements  by coders.
Both eventhandlers will usually fire, remain scoped, etc.. and get triggered.
By calling empty first on the selected target, which is safe to do because all contents
are overwritten anyways, we make jQuery "clean up" all lingering event handlers.