### PR TITLE
Fix for PluginTestCase not loading dependencies.

### DIFF
--- a/tests/PluginTestCase.php
+++ b/tests/PluginTestCase.php
@@ -144,7 +144,7 @@ abstract class PluginTestCase extends Illuminate\Foundation\Testing\TestCase
         if (!empty($plugin->require)) {
             foreach ((array) $plugin->require as $dependency) {
 
-                if (isset($this->pluginTestCaseLoadedPlugins[$code])) continue;
+                if (isset($this->pluginTestCaseLoadedPlugins[$dependency])) continue;
 
                 $this->runPluginRefreshCommand($dependency);
             }


### PR DESCRIPTION
At the moment the class will just skip all dependencies because of the incorrect variable.

Worth rethinking how we are calling `plugin:refresh` on tested plugin *before* other `$required` plugins? Shouldn't we load plugins dependencies before loading tested plugin?

```
/*
 * Execute the command
 * ---- Move this line after the $require loop?
 */
Artisan::call('plugin:refresh', ['name' => $code]);

/*
 * Spin over dependencies and refresh them too
 */
$this->pluginTestCaseLoadedPlugins[$code] = $plugin;

if (!empty($plugin->require)) {
    foreach ((array) $plugin->require as $dependency) {

        if (isset($this->pluginTestCaseLoadedPlugins[$dependency])) continue;

        $this->runPluginRefreshCommand($dependency);
    }
}
```