### PR TITLE
Fix placeholder color on fancy layout backend form

### DIFF
--- a/modules/backend/models/brandsettings/custom.less
+++ b/modules/backend/models/brandsettings/custom.less
@@ -113,6 +113,7 @@ table.table.data {
 @color-fancy-form-tabless-fields-bg: @primary-color-light;
 @color-fancy-master-tabs-bg: @primary-color-dark;
 @color-fancy-form-inactive-tab: mix(black, desaturate(@primary-color-dark, 14.5%), 5%);
+@color-fancy-form-placeholder: lighten(@primary-color-light, 30%);
 
 .fancy-layout {
     .control-tabs, &.control-tabs {
@@ -162,9 +163,14 @@ table.table.data {
         }
     }
 
-    .form-tabless-fields,
-    .form-tabless-fields .loading-indicator-container .loading-indicator {
-        background: @color-fancy-form-tabless-fields-bg;
+    .form-tabless-fields {
+        &,
+        .loading-indicator-container .loading-indicator {
+            background: @color-fancy-form-tabless-fields-bg;
+        }
+        input[type=text]::-webkit-input-placeholder {
+            color: @color-fancy-form-placeholder;
+        }
     }
 }
 


### PR DESCRIPTION
After change the backend brand colors, there are bugs on fancy layout form placeholder.

BEFORE:
![screen shot 2015-10-25 at 12 02 23 am](https://cloud.githubusercontent.com/assets/7110859/10711630/c98348bc-7aab-11e5-9199-8109557f87eb.png)

AFTER:
![screen shot 2015-10-24 at 11 55 42 pm](https://cloud.githubusercontent.com/assets/7110859/10711629/c5fa42cc-7aab-11e5-84be-b556f10a6b01.png)

