### PR TITLE
Allow plugins to be symlinks

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -360,7 +360,9 @@ class PluginManager
             return $plugins;
         }
 
-        $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dirPath));
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dirPath, RecursiveDirectoryIterator::FOLLOW_SYMLINKS)
+        );
         $it->setMaxDepth(2);
         $it->rewind();
 


### PR DESCRIPTION
This change makes sure that plugins can be loaded even though they are symlinks. The change makes it easier to have custom schemes to handle version control with zero-downtime deployment.