### PR TITLE
Remember previous page in list view

### DIFF
--- a/modules/backend/widgets/lists/assets/js/october.list.js
+++ b/modules/backend/widgets/lists/assets/js/october.list.js
@@ -131,4 +131,17 @@
         $('[data-control="listwidget"]').listWidget();
     })
 
+    // Remember the previous page if the user clicks "back" from
+    // within a list items page.
+    $(window).on('ajaxUpdate', function(event, data, response, status) {
+        if (data.handler !== 'list::onPaginate' || status !== 'success') {
+            return
+        }
+
+        var params = jQuery.param(data.options.data)
+        var url = window.location.href.split('?')[0] + '?' + params
+
+        history.pushState(data.options.data, 'history', url)
+    })
+
 }(window.jQuery);


### PR DESCRIPTION
Steps to reproduce this bug:

1. Open up a list;
2. Go to page 20;
3. Open any record;
4. Go "back";
5. You get thrown back to the first page.

This commit fixes that issue.
