### PR TITLE
Make recordfinder's popup list title configurable

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -12,6 +12,7 @@ use Backend\Classes\FormWidgetBase;
  *        label: User
  *        type: recordfinder
  *        list: ~/plugins/rainlab/user/models/user/columns.yaml
+ *        title: Find Record
  *        prompt: Click the Find button to find a user
  *        nameFrom: name
  *        descriptionFrom: email
@@ -39,6 +40,11 @@ class RecordFinder extends FormWidgetBase
      * @var string Relation column to display for the description
      */
     public $descriptionFrom;
+
+    /**
+     * @var string Text to display for the title of the popup list form
+     */
+    public $title = 'backend::lang.recordfinder.find_record';
 
     /**
      * @var string Prompt to display if no record is selected.
@@ -75,6 +81,7 @@ class RecordFinder extends FormWidgetBase
     public function init()
     {
         $this->fillFromConfig([
+            'title',
             'prompt',
             'keyFrom',
             'nameFrom',
@@ -150,6 +157,7 @@ class RecordFinder extends FormWidgetBase
         $this->vars['descriptionValue'] = $this->getDescriptionValue();
         $this->vars['listWidget'] = $this->listWidget;
         $this->vars['searchWidget'] = $this->searchWidget;
+        $this->vars['title'] = $this->getTitle();
         $this->vars['prompt'] = str_replace('%s', '<i class="icon-th-list"></i>', e(trans($this->prompt)));
     }
 
@@ -192,6 +200,15 @@ class RecordFinder extends FormWidgetBase
         return $this->relationModel->{$this->keyFrom};
     }
 
+    public function getTitle()
+    {
+        if (!$this->relationModel || !$this->title) {
+            return null;
+        }
+
+        return $this->relationModel->{$this->title};
+    }
+
     public function getNameValue()
     {
         if (!$this->relationModel || !$this->nameFrom) {
@@ -213,7 +230,7 @@ class RecordFinder extends FormWidgetBase
     public function onFindRecord()
     {
         $this->prepareVars();
-        return $this->makePartial('recordfinder_form');
+        return $this->makePartial('recordfinder_form', ['title' => $this->title]);
     }
 
     protected function makeListWidget()

--- a/modules/backend/formwidgets/recordfinder/partials/_recordfinder_form.htm
+++ b/modules/backend/formwidgets/recordfinder/partials/_recordfinder_form.htm
@@ -2,7 +2,7 @@
     <?= Form::open() ?>
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
-            <h4 class="modal-title">Find Record</h4>
+            <h4 class="modal-title"><?= e(trans($title)) ?></h4>
         </div>
 
         <div class="list-flush" data-request-data="recordfinder_flag: 1">

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -206,6 +206,9 @@ return [
         'concurrency_file_changed_title' => 'File was changed',
         'concurrency_file_changed_description' => "The file you're editing has been changed on disk by another user. You can either reload the file and lose your changes or override the file on the disk."
     ],
+    'recordfinder' => [
+        'find_record' => 'Find Record'
+    ],
     'relation' => [
         'missing_config' => "Relation behavior does not have any configuration for ':config'.",
         'missing_definition' => "Relation behavior does not contain a definition for ':field'.",


### PR DESCRIPTION
When selecting record using the recordfinder, by default the popup list
shows **Find Record** as the title. Made this field a user configurable
field, and kept **Find Record** as default if not specified. Also,
added this default string to the lang file.