### PR TITLE
Add filetypes of FileUpload formwidgets in uppercase too

### DIFF
--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -255,7 +255,9 @@ class FileUpload extends FormWidgetBase
             return $value;
         }, $types);
 
-        return implode(',', $types);
+        $types = implode(',', $types);
+
+        return $types . ',' . strtoupper($types);
     }
 
     /**


### PR DESCRIPTION
I was not able to make upload of images with uppercase extensions like ``.JPG `` so this is how i solve the problem. 

Maybe this is not the best way of doing this! I think this is a simple but important thing so if you like the idea but not the code, i can learn and do better :smiley:.