### PR TITLE
Improves plugin:refresh error handling

### DIFF
--- a/modules/system/console/PluginRefresh.php
+++ b/modules/system/console/PluginRefresh.php
@@ -38,6 +38,9 @@ class PluginRefresh extends Command
     {
         $pluginName = $this->argument('name');
         $pluginName = PluginManager::instance()->normalizeIdentifier($pluginName);
+        if (!PluginManager::instance()->exists($pluginName)) {
+            throw new \InvalidArgumentException(sprintf('Plugin "%s" not found.', $pluginName));
+        }
 
         $manager = UpdateManager::instance()->resetNotes();
 


### PR DESCRIPTION
This halts execution of plugin:refresh and throws an invalid argument exception if the argument passed (plugin name) doesn't exist. I came across this when calling plugin:refresh from another console command using call() and realized I was unable to verify if it completed successfully or failed. Additionally, it felt a bit strange that the output I was getting acknowledged the plugin couldn't be found but execution continued.

Current output from plugin:refresh when passing a plugin that doesn't exist:
```
art plugin:refresh somePlugin
Unable to find: somePlugin
Reinstalling plugin...
Unable to find: somePlugin
```


Output from plugin:refresh using implemented solution when passing a plugin that doesn't exist: 
```
php artisan plugin:refresh somePlugin
                                  
  [InvalidArgumentException]      
  Plugin "somePlugin" not found.  
```                              

Hopefully this would be useful to someone else as well. Thanks!