### PR TITLE
Full path for assets

### DIFF
--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -212,7 +212,7 @@ trait AssetMaker
             return $fileName;
         }
 
-        return $assetPath . '/' . $fileName;
+        return URL::to($assetPath . '/' . $fileName);
     }
 
     /**


### PR DESCRIPTION
In my website, backend assets (all JS and CSS added with addCss, addJs) doesn't work. This small change fixes this.