### PR TITLE
Fix small bug with ".noclick" column in ListController

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -544,7 +544,7 @@ class Lists extends WidgetBase
 
         $columns = array_keys($record->getAttributes());
         $recordOnClick = RouterHelper::parseValues($record, $columns, $this->recordOnClick);
-        return Html::attributes(['onclick' => $recordOnClick]);
+        return $recordOnClick;
     }
 
     /**

--- a/modules/backend/widgets/lists/partials/_list_body_row.htm
+++ b/modules/backend/widgets/lists/partials/_list_body_row.htm
@@ -3,8 +3,12 @@
         $expanded = $this->isTreeNodeExpanded($record);
         $childRecords = $record->getChildren();
     }
+    $url = $this->getRecordUrl($record);
+    $onclick = $this->getRecordOnClick($record);
 ?>
-<tr class="list-tree-level-<?= $treeLevel ?> <?= $this->getRowClass($record) ?>">
+<tr class="list-tree-level-<?= $treeLevel ?> <?= $this->getRowClass($record) ?>"
+    <?= $url ? 'data-link="' . $url . '"' : '' ?>
+    <?= $onclick ? 'data-onclick="' . $onclick . '"' : '' ?>>
     <?php if ($showCheckboxes): ?>
         <?= $this->makePartial('list_body_checkbox', ['record' => $record]) ?>
     <?php endif ?>
@@ -20,13 +24,7 @@
     <?php $index = 0; foreach ($columns as $key => $column): ?>
         <?php $index++; ?>
         <td data-title="<?= e(trans($column->label)) ?>" class="list-cell-index-<?= $index ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->cssClass ?>">
-            <?php if ($index == 1 && ($url = $this->getRecordUrl($record))): ?>
-                <a <?= $this->getRecordOnClick($record) ?> href="<?= $url ?>">
-                    <?= $this->getColumnValue($record, $column) ?>
-                </a>
-            <?php else: ?>
-                <?= $this->getColumnValue($record, $column) ?>
-            <?php endif ?>
+            <?= $this->getColumnValue($record, $column) ?>
         </td>
     <?php endforeach ?>
 

--- a/modules/system/assets/ui/js/list.rowlink.js
+++ b/modules/system/assets/ui/js/list.rowlink.js
@@ -27,24 +27,17 @@
 
         tr.each(function(){
 
-            var link = $(this).find(options.target).filter(function(){
-                return !$(this).closest('td').hasClass(options.excludeClass) && !$(this).hasClass(options.excludeClass)
-            }).first()
-
-            if (!link.length) return
-
-            var href = link.attr('href'),
-                onclick = (typeof link.get(0).onclick == "function") ? link.get(0).onclick : null
+            var href = $(this).data('link'),
+                onclick = $(this).data('onclick') ? new Function('object', $(this).data('onclick')) : null
 
             $(this).find('td').not('.' + options.excludeClass).click(function() {
                 if (onclick)
-                    onclick.apply(link.get(0))
+                    onclick.apply(this)
                 else
                     window.location = href;
             })
 
             $(this).addClass(options.linkedClass)
-            link.hide().after(link.html())
         })
 
     }


### PR DESCRIPTION
**Bug:**
On the page with a list of items (ListController) add a column and assign property cssClass in config_list.yaml value "nolink", to click on the column is not processed. (Example: Column button switch element visibility).
If this is the first column, then click stops processing on all columns line, ie you can not go to the editing of the element.
If this is not the first column, the error does not occur.
**Reason:**
Handler click on the column takes the value of href attribute from the first found in the string if this reference, as well as the parent <td> no class "nolink". The template "list_body_row" such a link is automatically inserted in the first column. Since in our example, the column has the class "nolink", the handler does not find a single link, and ignoring clicks on the line.
**Decision:**
Change the click handler so that he took the reference value of the data-attribute row (tr). Accordingly, the change template "list_body_row".