### PR TITLE
Fix "Unsupported operand types"

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -360,7 +360,9 @@ class Form extends WidgetBase
         );
 
         foreach ($eventResults as $eventResult) {
-            $result = $eventResult + $result;
+            if (is_array($eventResult)) {
+                $result = $eventResult + $result;
+            }
         }
 
         return $result;


### PR DESCRIPTION
On a fresh installation of October with PHP 5.6.13 when AJAX calls a `dependsOn` AJAX handler, the following error is being thrown:

    "Unsupported operand types" on line 363 of /path/to/modules/backend/widgets/Form.php

Checking if `$eventResult` is array fixed this problem and everything was functioning as expected.