### PR TITLE
allow using get attribute mutators as nameFrom

### DIFF
--- a/modules/backend/formwidgets/Relation.php
+++ b/modules/backend/formwidgets/Relation.php
@@ -116,7 +116,14 @@ class Relation extends FormWidgetBase
                 $field->options = $query->listsNested($this->nameFrom, $relationModel->getKeyName());
             }
             else {
-                $field->options = $query->lists($this->nameFrom, $relationModel->getKeyName());
+                if ($query->getModel()->hasGetMutator($this->nameFrom)) {
+                    $results = $query->get();
+                    foreach($results as $model) {
+                        $field->options[$model->id] = $model->{$this->nameFrom};
+                    }
+                } else {
+                    $field->options = $query->lists($this->nameFrom, $relationModel->getKeyName());   
+                }
             }
 
             return $field;


### PR DESCRIPTION
Adding those few lines enable using getAttribute mutators as nameFrom property on the RelationWidget.

Example:

*fields.yaml*
```
...
author:              
  type: relation     
  nameFrom: full_name
...
```

*Model.php*
```
...
public $belongsTo = [
    "author" => 'Backend\Models\User'
];
...
```
*Result*
```
print_r($fields->$options)

array(
    [0] => "first_name last_name"
)
```


