### PR TITLE
Fixing path to the compiled class map - fixes #1608

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -47,7 +47,7 @@ require __DIR__.'/../vendor/autoload.php';
 |
 */
 
-$compiledPath = __DIR__.'/../vendor/compiled.php';
+$compiledPath = __DIR__.'/../storage/framework/compiled.php';
 
 if (file_exists($compiledPath)) {
     require $compiledPath;


### PR DESCRIPTION
This PR fixes the issue of autoload.php not loading the compiled class map generated from ```php artisan optimize```