### PR TITLE
Fixed Validation failing if the file's extension is uppercase

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -457,7 +457,7 @@ class ServiceProvider extends ModuleServiceProvider
          * - extensions: png,jpg,txt
          */
         Validator::extend('extensions', function($attribute, $value, $parameters) {
-            $extension = $value->getClientOriginalExtension();
+            $extension = strtolower($value->getClientOriginalExtension());
             return in_array($extension, $parameters);
         });
 


### PR DESCRIPTION
Fix for validation failing if the user uploads a file with an uppercase file extension