### PR TITLE
Check if email subject set in closure

### DIFF
--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -133,7 +133,9 @@ class MailTemplate extends Model
         /*
          * Subject
          */
-        $message->subject(Twig::parse($template->subject, $data));
+        if (empty($message->getSwiftMessage()->getSubject())) {
+            $message->subject(Twig::parse($template->subject, $data));
+        }
 
         /*
          * HTML contents

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -133,7 +133,9 @@ class MailTemplate extends Model
         /*
          * Subject
          */
-        if (empty($message->getSwiftMessage()->getSubject())) {
+        $swiftMessageSubject = $message->getSwiftMessage()->getSubject();
+
+        if (empty($swiftMessageSubject)) {
             $message->subject(Twig::parse($template->subject, $data));
         }
 


### PR DESCRIPTION
If subject setted in template, changing in closure like:

Mail::queue("template", [], function ($message) use ($subject, $email) {
	$message->subject($subject)->to($email);
});

has no effect.