### PR TITLE
Hotfix for mysql 5.7

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -62,6 +62,7 @@ return [
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix'    => '',
+            'strict'    => true
         ],
 
         'pgsql' => [


### PR DESCRIPTION
MySQL 5.7 defaults to NO_ZERO_DATE which makes Laravel's Schemabuilder timestamps() throw this error when running migrations: `Syntax error or access violation: 1067 Invalid default value for 'created_at'`
According to [laravel/framework issue #3602](https://github.com/laravel/framework/issues/3602) our options are to make timestamps nullable by default, default to something valid (like the current time), or to turn offthe NO_ZERO_DATE flag in mysql config. In the short term, setting strict=true allows October to be used with MySQL 5.7. However, this is a blanket fix and should be reviewed as the Laravel community addresses/solves this issue.

fixes #1667 
fixes #1619