### PR TITLE
Fix Template Caching

### DIFF
--- a/modules/cms/classes/CmsObject.php
+++ b/modules/cms/classes/CmsObject.php
@@ -80,6 +80,13 @@ class CmsObject implements ArrayAccess
      */
     public static function loadCached($theme, $fileName)
     {
+        if(Config::get('app.debug', false)) {
+          /*
+           * Bypass caching if in debug mode
+           */
+          return static::load($theme, $fileName);
+        }
+
         if (!FileHelper::validatePath($fileName, static::getMaxAllowedPathNesting())) {
             throw new ApplicationException(Lang::get('cms::lang.cms_object.invalid_file', ['name'=>$fileName]));
         }
@@ -109,7 +116,7 @@ class CmsObject implements ArrayAccess
 
         if ($cached !== false) {
             /*
-             * The cached item exists and successfully unserialized. 
+             * The cached item exists and successfully unserialized.
              * Initialize the object from the cached data.
              */
             $obj = new static($theme);
@@ -183,7 +190,7 @@ class CmsObject implements ArrayAccess
     }
 
     /**
-     * Returns the maximum allowed path nesting level. 
+     * Returns the maximum allowed path nesting level.
      * The default value is 2, meaning that files
      * can only exist in the root directory, or in a subdirectory.
      * @return mixed Returns the maximum nesting level or null if any level is allowed.
@@ -443,7 +450,7 @@ class CmsObject implements ArrayAccess
 
         return $result;
     }
-    
+
     /**
      * Returns the absolute file path.
      * @param $theme Specifies a theme the file belongs to.


### PR DESCRIPTION
When developing an October site using an external editor, sometimes even October's own editor, the template cache does not always reflect the source files correctly (http://octobercms.com/forum/post/template-asset-caching-during-development). I stumbled across this and dug into October to find this:

(note: Atom decided to remove the excess whitespace, keep it if you like)