### PR TITLE
Fix permissions required for theme settings

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -224,7 +224,7 @@ class ServiceProvider extends ModuleServiceProvider
                     'category'    => SettingsManager::CATEGORY_CMS,
                     'icon'        => 'icon-picture-o',
                     'url'         => Backend::URL('cms/themes'),
-                    'permissions' => ['system.manage_themes'],
+                    'permissions' => ['cms.manage_themes'],
                     'order'       => 200
                 ],
                 'maintenance_settings' => [
@@ -233,7 +233,7 @@ class ServiceProvider extends ModuleServiceProvider
                     'category'    => SettingsManager::CATEGORY_CMS,
                     'icon'        => 'icon-plug',
                     'class'       => 'Cms\Models\MaintenanceSettings',
-                    'permissions' => ['system.manage_themes'],
+                    'permissions' => ['cms.manage_themes'],
                     'order'       => 300
                 ],
             ]);


### PR DESCRIPTION
If you create a non-superuser group, users of that group won't see the *Front-end theme* or *Mantenance mode* pages under Settings, despite having the *Manage themes* permission.

This fixes the issue by updating the setting definitions to require the correct permission codes, [defined in the service provider](https://github.com/octobercms/october/blob/96959e0683def248806f8b56a1baaea3be01d9a9/modules/cms/ServiceProvider.php#L186-L190) and referenced from the [CMS Themes controller](https://github.com/octobercms/october/blob/51446f6a27b5680ba062c5afba71f95c6fda7c46/modules/cms/controllers/Themes.php#L36).