### PR TITLE
Update RequestLog.php

### DIFF
--- a/modules/system/models/RequestLog.php
+++ b/modules/system/models/RequestLog.php
@@ -36,7 +36,7 @@ class RequestLog extends Model
         if (!DbDongle::hasDatabase()) return;
 
         $record = static::firstOrNew([
-            'url' => Request::fullUrl(),
+            'url' => substr(Request::fullUrl(), 0, 255),
             'status_code' => $statusCode,
         ]);
 


### PR DESCRIPTION
**Change:** Truncate URL which should has lenght max 255 chars.

**Reason:** Today I got this error:

```
Next exception 'Illuminate\Database\QueryException' with message 'SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'url' at row 1 (SQL: insert into `system_request_logs` (`url`, `status_code`, `count`, `updated_at`, `created_at`) values (http://www.mysite.com/docs/%C3%83%C6%92%...<too-many-chars>...%80%9A%C3%82%C2%814.pdf, 404, 1, 2016-01-02 12:16:08, 2016-01-02 12:16:08))
```