### PR TITLE
Use Grammar from Query in Widget List

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -410,7 +410,7 @@ class Lists extends WidgetBase
                 continue;
             }
 
-            $alias = Db::getQueryGrammar()->wrap($column->columnName);
+            $alias = $query->getQuery()->getGrammar()->wrap($column->columnName);
 
             /*
              * Relation column


### PR DESCRIPTION
When using models with a different database software than the default, the old code produced a syntax error. 
Using the Grammar from the query ensures that the alias is always wrapped correctly. 

Suggestion: The code should be scanned for similar errors, produced by using DB Facade.