### PR TITLE
Fix in PluginTestBase

### DIFF
--- a/tests/PluginTestCase.php
+++ b/tests/PluginTestCase.php
@@ -101,7 +101,7 @@ abstract class PluginTestCase extends Illuminate\Foundation\Testing\TestCase
     }
 
     /**
-     * Since the test environment has loaded all the test plugins 
+     * Since the test environment has loaded all the test plugins
      * natively, this method will ensure the desired plugin is
      * loaded in the system before proceeding to migrate it.
      * @return void
@@ -132,23 +132,20 @@ abstract class PluginTestCase extends Illuminate\Foundation\Testing\TestCase
         }
 
         /*
-         * Execute the command
-         */
-        Artisan::call('plugin:refresh', ['name' => $code]);
-
-        /*
          * Spin over dependencies and refresh them too
          */
         $this->pluginTestCaseLoadedPlugins[$code] = $plugin;
 
         if (!empty($plugin->require)) {
             foreach ((array) $plugin->require as $dependency) {
-
-                if (isset($this->pluginTestCaseLoadedPlugins[$code])) continue;
-
                 $this->runPluginRefreshCommand($dependency);
             }
         }
+
+        /*
+         * Execute the command
+         */
+        Artisan::call('plugin:refresh', ['name' => $code]);
     }
 
     /**

--- a/tests/PluginTestCase.php
+++ b/tests/PluginTestCase.php
@@ -138,6 +138,9 @@ abstract class PluginTestCase extends Illuminate\Foundation\Testing\TestCase
 
         if (!empty($plugin->require)) {
             foreach ((array) $plugin->require as $dependency) {
+
+                if (isset($this->pluginTestCaseLoadedPlugins[$code])) continue;
+
                 $this->runPluginRefreshCommand($dependency);
             }
         }

--- a/tests/PluginTestCase.php
+++ b/tests/PluginTestCase.php
@@ -139,7 +139,7 @@ abstract class PluginTestCase extends Illuminate\Foundation\Testing\TestCase
         if (!empty($plugin->require)) {
             foreach ((array) $plugin->require as $dependency) {
 
-                if (isset($this->pluginTestCaseLoadedPlugins[$code])) continue;
+                if (isset($this->pluginTestCaseLoadedPlugins[$dependency])) continue;
 
                 $this->runPluginRefreshCommand($dependency);
             }


### PR DESCRIPTION
I had a problem with dependencies refresh in PluginTestCase.
I have a plugin that extends RainLab.Translate and seeds translate's tables with some translatable content I get from an API.
When I tried to run the tests, october threw an exception because my plugin versioning (with the seeding of other plugin's tables) was running before its dependencies, so the seeding could not find the locales and messages tables from translate plugin in the database. I moved the dependencies refresh up, so they run before the plugin being refreshed.

---

Also, I noticed this portion of code:
```
$this->pluginTestCaseLoadedPlugins[$code] = $plugin;

if (!empty($plugin->require)) {
    foreach ((array) $plugin->require as $dependency) {

        if (isset($this->pluginTestCaseLoadedPlugins[$code])) continue;

        $this->runPluginRefreshCommand($dependency);
    }
}
```
The value of `$this->pluginTestCaseLoadedPlugins[$code]` is being set before the loop, so the check inside the foreach will make it continue always. 
I think the proper check should be this one:
`if (isset($this->pluginTestCaseLoadedPlugins[$dependency])) continue;`
So if the plugin was already refreshed in some point of the recursion, it will be skipped.
