### PR TITLE
Phpdoc cleanup

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -39,7 +39,12 @@ class FormController extends ControllerBehavior
     const CONTEXT_PREVIEW = 'preview';
 
     /**
-     * @var Backend\Classes\WidgetBase Reference to the widget object.
+     * @var \Backend\Classes\Controller|FormController Reference to the back end controller.
+     */
+    protected $controller;
+
+    /**
+     * @var \Backend\Widgets\Form Reference to the widget object.
      */
     protected $formWidget;
 

--- a/modules/backend/classes/ControllerBehavior.php
+++ b/modules/backend/classes/ControllerBehavior.php
@@ -27,7 +27,7 @@ class ControllerBehavior extends ExtensionBase
     protected $config;
 
     /**
-     * @var Backend\Classes\Controller Reference to the back end controller.
+     * @var \Backend\Classes\Controller Reference to the back end controller.
      */
     protected $controller;
 
@@ -71,8 +71,8 @@ class ControllerBehavior extends ExtensionBase
 
     /**
      * Safe accessor for configuration values.
-     * @param $name Config name, supports array names like "field[key]"
-     * @param $default Default value if nothing is found
+     * @param string $name Config name, supports array names like "field[key]"
+     * @param mixed $default Default value if nothing is found
      * @return string
      */
     public function getConfig($name = null, $default = null)

--- a/modules/backend/classes/FormWidgetBase.php
+++ b/modules/backend/classes/FormWidgetBase.php
@@ -99,7 +99,7 @@ abstract class FormWidgetBase extends WidgetBase
     /**
      * Process the postback value for this widget. If the value is omitted from
      * postback data, it will be NULL, otherwise it will be an empty string.
-     * @param $value The existing value for this widget.
+     * @param mixed $value The existing value for this widget.
      * @return string The new value for this widget.
      */
     public function getSaveValue($value)

--- a/modules/backend/classes/WidgetBase.php
+++ b/modules/backend/classes/WidgetBase.php
@@ -26,7 +26,7 @@ abstract class WidgetBase
     public $config;
 
     /**
-     * @var Backend\Classes\Controller Backend controller object.
+     * @var \Backend\Classes\Controller Backend controller object.
      */
     protected $controller;
 
@@ -42,9 +42,8 @@ abstract class WidgetBase
 
     /**
      * Constructor
-     * @param Backend\Classes\Controller $controller
+     * @param \Backend\Classes\Controller $controller
      * @param array $configuration Proactive configuration definition.
-     * @return void
      */
     public function __construct($controller, $configuration = [])
     {

--- a/modules/backend/traits/FormModelSaver.php
+++ b/modules/backend/traits/FormModelSaver.php
@@ -39,7 +39,7 @@ trait FormModelSaver
     /**
      * Sets a data collection to a model attributes, relations will also be set.
      * @param array $saveData Data to save.
-     * @param Model $model Model to save to
+     * @param \October\Rain\Database\Model $model Model to save to
      * @return array The collection of models to save.
      */
     protected function setModelAttributes($model, $saveData)

--- a/modules/backend/traits/WidgetMaker.php
+++ b/modules/backend/traits/WidgetMaker.php
@@ -16,8 +16,6 @@ use SystemException;
  */
 trait WidgetMaker
 {
-    /**@var \Backend\Classes\Controller $controller */
-    protected $controller;
 
     /**
      * Makes a widget object with the supplied configuration file.

--- a/modules/backend/traits/WidgetMaker.php
+++ b/modules/backend/traits/WidgetMaker.php
@@ -14,14 +14,17 @@ use SystemException;
  * @package october\backend
  * @author Alexey Bobkov, Samuel Georges
  */
-
 trait WidgetMaker
 {
+    /**@var \Backend\Classes\Controller $controller */
+    protected $controller;
+
     /**
      * Makes a widget object with the supplied configuration file.
      * @param string $class Widget class name
      * @param array $widgetConfig An array of config.
-     * @return WidgetBase The widget object
+     * @return \Backend\Classes\WidgetBase The widget object
+     * @throws SystemException
      */
     public function makeWidget($class, $widgetConfig = [])
     {
@@ -43,7 +46,8 @@ trait WidgetMaker
      * @param string $class Widget class name
      * @param mixed $fieldConfig A field name, an array of config or a FormField object.
      * @param array $widgetConfig An array of config.
-     * @return FormWidgetBase The widget object
+     * @return \Backend\Classes\FormWidgetBase The widget object
+     * @throws SystemException
      */
     public function makeFormWidget($class, $fieldConfig = [], $widgetConfig = [])
     {

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1,8 +1,6 @@
 <?php namespace Backend\Widgets;
 
-use App;
 use Lang;
-use Input;
 use Event;
 use Form as FormHelper;
 use Backend\Classes\FormTabs;
@@ -95,7 +93,7 @@ class Form extends WidgetBase
     ];
 
     /**
-     * @var array Collection of all form widgets used in this form.
+     * @var FormWidgetBase[] Collection of all form widgets used in this form.
      */
     protected $formWidgets = [];
 
@@ -110,7 +108,7 @@ class Form extends WidgetBase
     public $previewMode = false;
 
     /**
-     * @var Backend\Classes\WidgetManager
+     * @var \Backend\Classes\WidgetManager
      */
     protected $widgetManager;
 
@@ -165,6 +163,10 @@ class Form extends WidgetBase
      *     - primary: Renders the Primary Tabs section.
      *     - secondary: Renders the Secondary Tabs section.
      *     - null: Renders all sections
+     *
+     * @param array $options
+     * @return string|bool The rendered partial contents, or false if suppressing an exception
+     * @throws \SystemException
      */
     public function render($options = [])
     {
@@ -216,6 +218,15 @@ class Form extends WidgetBase
 
     /**
      * Renders a single form field
+     *
+     * Options:
+     *  - useContainer: Wrap the result in a container, used by AJAX. Default: true
+     *
+     * @param string|array $field The field name or definition
+     * @param array $options
+     * @return string|bool The rendered partial contents, or false if suppressing an exception
+     * @throws ApplicationException
+     * @throws \SystemException
      */
     public function renderField($field, $options = [])
     {
@@ -241,6 +252,9 @@ class Form extends WidgetBase
 
     /**
      * Renders the HTML element for a field
+     * @param FormWidgetBase $field
+     * @return string|bool The rendered partial contents, or false if suppressing an exception
+     * @throws \SystemException
      */
     public function renderFieldElement($field)
     {
@@ -249,7 +263,8 @@ class Form extends WidgetBase
 
     /**
      * Validate the supplied form model.
-     * @return void
+     * @throws ApplicationException
+     * @return Model
      */
     protected function validateModel()
     {
@@ -338,7 +353,7 @@ class Form extends WidgetBase
                 if (!isset($this->allFields[$field])) {
                     continue;
                 }
-
+                /** @var FormWidgetBase $fieldObject */
                 $fieldObject = $this->allFields[$field];
                 $result['#' . $fieldObject->getId('group')] = $this->makePartial('field', ['field' => $fieldObject]);
             }
@@ -470,6 +485,7 @@ class Form extends WidgetBase
     /**
      * Converts fields with a span set to 'auto' as either
      * 'left' or 'right' depending on the previous field.
+     * @param array $fields
      */
     protected function processAutoSpan($fields)
     {
@@ -490,6 +506,9 @@ class Form extends WidgetBase
 
     /**
      * Programatically add fields, used internally and for extensibility.
+     * @param array $fields
+     * @param string $addToArea
+     * @throws ApplicationException
      */
     public function addFields(array $fields, $addToArea = null)
     {
@@ -536,7 +555,8 @@ class Form extends WidgetBase
 
     /**
      * Programatically remove a field.
-     * @return boolean
+     * @param string $name
+     * @return bool
      */
     public function removeField($name)
     {
@@ -561,6 +581,10 @@ class Form extends WidgetBase
 
     /**
      * Creates a form field object from name and configuration.
+     * @param string $name
+     * @param array $config
+     * @return FormField
+     * @throws ApplicationException
      */
     protected function makeFormField($name, $config)
     {
@@ -673,6 +697,10 @@ class Form extends WidgetBase
 
     /**
      * Makes a widget object from a form field object.
+     * @param FormField $field
+     * @return FormWidgetBase
+     * @throws ApplicationException
+     * @throws \SystemException
      */
     protected function makeFormFieldWidget($field)
     {
@@ -716,7 +744,7 @@ class Form extends WidgetBase
 
     /**
      * Get a specified form widget
-     * @param  string $fieldName
+     * @param FormWidgetBase $field
      * @return mixed
      */
     public function getFormWidget($field)
@@ -735,7 +763,7 @@ class Form extends WidgetBase
 
     /**
      * Get a specified field object
-     * @param  string $fieldName
+     * @param string $field
      * @return mixed
      */
     public function getField($field)
@@ -759,8 +787,9 @@ class Form extends WidgetBase
 
     /**
      * Looks up the field value.
-     * @param  use Backend\Classes\FormField $field
+     * @param  \Backend\Classes\FormField $field
      * @return string
+     * @throws ApplicationException
      */
     protected function getFieldValue($field)
     {
@@ -785,13 +814,13 @@ class Form extends WidgetBase
     /**
      * Returns a HTML encoded value containing the other fields this
      * field depends on
-     * @param  use Backend\Classes\FormField $field
+     * @param \Backend\Classes\FormField $field
      * @return string
      */
     protected function getFieldDepends($field)
     {
         if (!$field->dependsOn) {
-            return;
+            return '';
         }
 
         $dependsOn = is_array($field->dependsOn) ? $field->dependsOn : [$field->dependsOn];
@@ -802,7 +831,7 @@ class Form extends WidgetBase
     /**
      * Helper method to determine if field should be rendered
      * with label and comments.
-     * @param  use Backend\Classes\FormField $field
+     * @param \Backend\Classes\FormField $field
      * @return boolean
      */
     protected function showFieldLabels($field)
@@ -820,7 +849,7 @@ class Form extends WidgetBase
     }
 
     /**
-     * Returns postback data from a submitted form.
+     * Returns post data from a submitted form.
      */
     public function getSaveData()
     {
@@ -882,6 +911,10 @@ class Form extends WidgetBase
 
     /**
      * Looks at the model for defined options.
+     * @param FormField $field
+     * @param array|callable|string $fieldOptions
+     * @return mixed
+     * @throws ApplicationException
      */
     protected function getOptionsFromModel($field, $fieldOptions)
     {
@@ -974,6 +1007,10 @@ class Form extends WidgetBase
 
     /**
      * Variant to array_get() but preserves dots in key names.
+     * @param array $array
+     * @param array $parts
+     * @param array $default
+     * @return array|null
      */
     protected function dataArrayGet(array $array, array $parts, $default = null)
     {
@@ -1004,6 +1041,10 @@ class Form extends WidgetBase
 
     /**
      * Variant to array_set() but preserves dots in key names.
+     * @param array $array
+     * @param array $parts
+     * @param mixed $value
+     * @return array
      */
     protected function dataArraySet(array &$array, array $parts, $value)
     {

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -545,12 +545,12 @@ class Form extends WidgetBase
 
     public function addTabFields(array $fields)
     {
-        return $this->addFields($fields, 'primary');
+        $this->addFields($fields, 'primary');
     }
 
     public function addSecondaryTabFields(array $fields)
     {
-        return $this->addFields($fields, 'secondary');
+        $this->addFields($fields, 'secondary');
     }
 
     /**

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -2,10 +2,8 @@
 
 use Url;
 use Html;
-use File;
 use System\Models\Parameters;
 use System\Models\PluginVersion;
-use SystemException;
 
 /**
  * Asset Maker Trait
@@ -14,7 +12,6 @@ use SystemException;
  * @package october\system
  * @author Alexey Bobkov, Samuel Georges
  */
-
 trait AssetMaker
 {
 

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -25,6 +25,10 @@ trait ConfigMaker
 
     /**
      * Reads the contents of the supplied file and applies it to this object.
+     * @param array $configFile
+     * @param array $requiredConfig
+     * @return array|stdClass
+     * @throws SystemException
      */
     public function makeConfig($configFile = [], $requiredConfig = [])
     {
@@ -100,7 +104,7 @@ trait ConfigMaker
      * Makes a config object from an array, making the first level keys properties a new object. 
      * Property values are converted to camelCase and are not set if one already exists.
      * @param array $configArray Config array.
-     * @return stdObject The config object
+     * @return stdClass The config object
      */
     public function makeConfigFromArray($configArray = [])
     {

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -153,11 +153,11 @@ trait ConfigMaker
         foreach ($configPath as $path) {
             $_fileName = $path . '/' . $fileName;
             if (File::isFile($_fileName)) {
-                break;
+                return $_fileName;
             }
         }
 
-        return $_fileName;
+        return '';
     }
 
     /**

--- a/modules/system/traits/PropertyContainer.php
+++ b/modules/system/traits/PropertyContainer.php
@@ -52,6 +52,8 @@ trait PropertyContainer
 
     /**
      * Sets multiple properties.
+     * @param array $properties
+     * @return array
      */
     public function setProperties($properties)
     {
@@ -60,14 +62,18 @@ trait PropertyContainer
 
     /**
      * Sets a property value
+     * @param string $name
+     * @param mixed $value
+     * @return void
      */
     public function setProperty($name, $value)
     {
-        return $this->properties[$name] = $value;
+        $this->properties[$name] = $value;
     }
 
     /**
      * Returns all properties.
+     * @return array
      */
     public function getProperties()
     {

--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -47,6 +47,7 @@ trait ViewMaker
      * @param array $params Parameter variables to pass to the view.
      * @param bool $throwException Throw an exception if the partial is not found.
      * @return mixed Partial contents or false if not throwing an exception.
+     * @throws SystemException
      */
     public function makePartial($partial, $params = [], $throwException = true)
     {
@@ -85,9 +86,8 @@ trait ViewMaker
     /**
      * Renders supplied contents inside a layout.
      * @param string $contents The inner contents as a string.
-     * @param string $name Specifies the layout name.
-     * If this parameter is omitted, the $layout property will be used.
-     * @return string The layout contents
+     * @param string $layout Specifies the layout name.
+     * @throws SystemException
      */
     public function makeViewContent($contents, $layout = null)
     {
@@ -98,7 +98,7 @@ trait ViewMaker
         // Append any undefined block content to the body block
         Block::set('undefinedBlock', $contents);
         Block::append('body', Block::get('undefinedBlock'));
-        return $this->makeLayout();
+        return $this->makeLayout($layout);
     }
 
     /**
@@ -108,12 +108,13 @@ trait ViewMaker
      * @param array $params Parameter variables to pass to the view.
      * @param bool $throwException Throw an exception if the layout is not found
      * @return string The layout contents
+     * @throws SystemException
      */
     public function makeLayout($name = null, $params = [], $throwException = true)
     {
         $layout = ($name === null) ? $this->layout : $name;
         if ($layout == '') {
-            return;
+            return '';
         }
 
         $layoutPath = $this->getViewPath($layout . '.htm', $this->layoutPath);
@@ -194,7 +195,7 @@ trait ViewMaker
     public function makeFileContents($filePath, $extraParams = [])
     {
         if (!strlen($filePath) || !File::isFile($filePath)) {
-            return;
+            return '';
         }
 
         if (!is_array($extraParams)) {
@@ -250,5 +251,6 @@ trait ViewMaker
         if ($result = Event::fire($event, $params)) {
             return implode(PHP_EOL.PHP_EOL, (array) $result);
         }
+        return '';
     }
 }

--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -178,11 +178,11 @@ trait ViewMaker
         foreach ($viewPath as $path) {
             $_fileName = File::symbolizePath($path) . '/' . $fileName;
             if (File::isFile($_fileName)) {
-                break;
+                return $_fileName;
             }
         }
 
-        return $_fileName;
+        return '';
     }
 
     /**


### PR DESCRIPTION
Most of the changes here represent phpdoc-only changes. However, there are few places where return types did not match what was in the phpdoc or seemed to be expected by the usages of the relevant method. I have done my best to ensure that all return types in the files I touched are now consistent with the way the return values are used.

Phpstorm was used to validate phpdoc blocks. 

At your request I can also clean up other files as part of this pr. I only cleaned the files immediately associated with a form issue I was troubleshooting today.