### PR TITLE
Make default 404 page use 404 status code

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -190,7 +190,7 @@ class Controller
         /*
          * If the page was not found, render the 404 page - either provided by the theme or the built-in one.
          */
-        if (!$page) {
+        if (!$page || $url === '404') {
             $this->setStatusCode(404);
 
             // Log the 404 request


### PR DESCRIPTION
On a fresh installation, when the default 404 page is visited at domain.com/404, the HTTP status code is 200. That would make search engines able to index the 404 page. IMO the url should act as if the 404 page itself did not exist.