### PR TITLE
Fix for static primary key naming relationcontroller

### DIFF
--- a/bldgpsxb.b3b.txt
+++ b/bldgpsxb.b3b.txt
@@ -1,8 +1,0 @@
-﻿
-# Please enter the commit message for your changes. Lines starting
-# with '#' will be ignored, and an empty message aborts the commit.
-# On branch fixSortableCheckInList
-# Changes to be committed:
-#	modified:   modules/backend/widgets/Lists.php
-#
-

--- a/bldgpsxb.b3b.txt
+++ b/bldgpsxb.b3b.txt
@@ -1,0 +1,8 @@
+﻿
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+# On branch fixSortableCheckInList
+# Changes to be committed:
+#	modified:   modules/backend/widgets/Lists.php
+#
+

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -688,7 +688,8 @@ class RelationController extends ControllerBehavior
             if ($this->viewMode == 'single') {
                 $config->showCheckboxes = false;
                 $config->recordOnClick = sprintf(
-                    "$.oc.relationBehavior.clickManageListRecord(:id, '%s', '%s')",
+                    "$.oc.relationBehavior.clickManageListRecord(:%s, '%s', '%s')",
+					$this->relationModel->getKeyName(),
                     $this->field,
                     $this->relationGetSessionKey()
                 );
@@ -698,7 +699,8 @@ class RelationController extends ControllerBehavior
             }
             elseif ($isPivot) {
                 $config->recordOnClick = sprintf(
-                    "$.oc.relationBehavior.clickManagePivotListRecord(:id, '%s', '%s')",
+                    "$.oc.relationBehavior.clickManagePivotListRecord(:%s, '%s', '%s')",
+					$this->relationModel->getKeyName(),
                     $this->field,
                     $this->relationGetSessionKey()
                 );


### PR DESCRIPTION
RelationController forced belongs to relations to have a primary key named id.
If primary key was named differently it wouldn't register the onclick.
This fixes that by taking the primary key name from the model.