### PR TITLE
Make sure Project ID is always included in POST

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -220,10 +220,6 @@ class UpdateManager
             'force' => $force
         ];
 
-        if ($projectId = Parameters::get('system::project.id')) {
-            $params['project'] = $projectId;
-        }
-
         $result = $this->requestServerData('core/update', $params);
         $updateCount = (int) array_get($result, 'update', 0);
 

--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -772,10 +772,6 @@ class UpdateManager
     {
         $filePath = $this->getFilePath($fileCode);
 
-        if ($projectId = Parameters::get('system::project.id')) {
-            $postData['project'] = $projectId;
-        }
-
         $result = Http::post($this->createServerUrl($uri), function ($http) use ($postData, $filePath) {
             $this->applyHttpAttributes($http, $postData);
             $http->toFile($filePath);
@@ -837,6 +833,11 @@ class UpdateManager
     protected function applyHttpAttributes($http, $postData)
     {
         $postData['server'] = base64_encode(serialize(['php' => PHP_VERSION, 'url' => URL::to('/')]));
+
+        if ($projectId = Parameters::get('system::project.id')) {
+            $postData['project'] = $projectId;
+        }
+
         if (Config::get('cms.edgeUpdates', false)) {
             $postData['edge'] = 1;
         }


### PR DESCRIPTION
Attempting to install a paid plugin through Artisan would return an 'authority not found' error, when the same would work fine when clicking "Update" in the backend.

This moves the code that adds the project ID into the applyHttpAttributes method to ensure it gets added for all post requests, and not just those that are actually requesting a file.