### PR TITLE
Add morphic relations to backend

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1102,7 +1102,7 @@ class RelationController extends ControllerBehavior
                 if ($this->relationType == 'belongsToMany') {
                     $this->relationObject->detach($checkedIds);
                 }
-                elseif ($this->relationType == 'hasMany') {
+                elseif ($this->relationType == 'hasMany' || $this->relationType == 'morphMany') {
                     $relatedModel = $this->relationObject->getRelated();
                     foreach ($checkedIds as $relationId) {
                         if ($obj = $relatedModel->find($relationId)) {
@@ -1121,7 +1121,7 @@ class RelationController extends ControllerBehavior
                 $this->relationObject->dissociate();
                 $this->relationObject->getParent()->save();
             }
-            elseif ($this->relationType == 'hasOne') {
+            elseif ($this->relationType == 'hasOne' || $this->relationType == 'morphOne') {
                 if ($obj = $this->relationModel->find($recordId)) {
                     $this->relationObject->remove($obj);
                 }
@@ -1295,10 +1295,12 @@ class RelationController extends ControllerBehavior
 
         switch ($this->relationType) {
             case 'hasMany':
+            case 'morphMany':
             case 'belongsToMany':
                 return ['create', 'add', 'delete', 'remove'];
 
             case 'hasOne':
+            case 'morphOne':
             case 'belongsTo':
                 return ['create', 'update', 'link', 'delete', 'unlink'];
         }
@@ -1316,10 +1318,12 @@ class RelationController extends ControllerBehavior
 
         switch ($this->relationType) {
             case 'hasMany':
+            case 'morphMany':
             case 'belongsToMany':
                 return 'multi';
 
             case 'hasOne':
+            case 'morphOne':
             case 'belongsTo':
                 return 'single';
         }
@@ -1358,7 +1362,9 @@ class RelationController extends ControllerBehavior
                 else return 'list';
 
             case 'hasOne':
+            case 'morphOne':
             case 'hasMany':
+            case 'morphMany':
                 if ($this->eventTarget == 'button-add') return 'list';
                 else return 'form';
         }


### PR DESCRIPTION
This will fix issue #1359 

I have needed this feature one a couple of projects now and have either had to do work arounds or edit the core files.

This Pull Request contains a modified RelationController.php
The changes are adding 'morphOne' and 'morphMany' into the controller to permit polymorphic relations to display and be edited in the backend.
Attempting to do this previously would result in error of:
'Undefined variable: widget' 