### PR TITLE
Add new option to the rich text editor form widget

### DIFF
--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -32,6 +32,12 @@ class RichEditor extends FormWidgetBase
     protected $defaultAlias = 'richeditor';
 
     /**
+     * Redactor default plugins options
+     * @var array
+     */
+    protected $defaultPlugins = ['fullscreen','figure','table','pagelinks','mediamanager'];
+
+    /**
      * {@inheritDoc}
      */
     public function init()
@@ -56,6 +62,9 @@ class RichEditor extends FormWidgetBase
     public function prepareVars()
     {
         $this->vars['fullPage'] = $this->fullPage;
+        // Enabled Redactor's plugins
+        $this->vars['plugins'] = $this->formField->options ?
+            $this->formField->options : $this->defaultPlugins;
         $this->vars['stretch'] = $this->formField->stretch;
         $this->vars['size'] = $this->formField->size;
         $this->vars['name'] = $this->formField->getName();

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -87,7 +87,7 @@
             redactorOptions.fullpage = true
         }
 
-        redactorOptions.plugins = ['fullscreen', 'figure', 'table', 'pagelinks', 'mediamanager']
+        redactorOptions.plugins = this.options.plugins
         redactorOptions.buttons = ['html', 'formatting', 'bold', 'italic', 'alignment', 'unorderedlist', 'orderedlist', 'link', 'horizontalrule'],
 
         this.$textarea.redactor(redactorOptions)

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -6,6 +6,7 @@
         id="<?= $this->getId() ?>"
         class="field-richeditor size-<?= $size ?> <?= $stretch?'layout-relative stretch':'' ?>"
         <?php if ($fullPage): ?>data-fullpage="true"<?php endif ?>
+        data-plugins='<?= json_encode($plugins) ?>'
         data-data-locker="#<?= $this->getId('dataLocker') ?>"
         data-links-handler="<?= $this->getEventHandler('onGetPageLinks') ?>"
         data-control="richeditor">


### PR DESCRIPTION
This will fix issue #1743.

I had a new option to the rich text editor form widget to choose which plugin is enabled in Redactor.js. I have needed this feature one a couple of projects now and have either had to do work arounds or edit the core files. It's a tiny modification, but it's very helpful for some projects!

### Rich editor / WYSIWYG
Richeditor - renders a visual editor for rich formatted text, also known as a WYSIWYG editor.

````
html_content:
    type: richeditor
    size: huge
    options: [fullscreen, figure, table, pagelinks, mediamanager]
````

The **options** field must be an array which contains the plugin's names to activate in the rich text editor toolbar. If this option is empty, the rich text editor will have all plugins activated by default.

### Example

You want a rich text editor field with no media manager :
`````
my_field:
    label: my field
    type: richeditor
    size: huge
    options: [fullscreen, figure, table, pagelinks]
````

The result toolbar will be :
![image](https://cloud.githubusercontent.com/assets/7080301/12715695/ff16fd10-c8db-11e5-97e3-29e13081205c.png)

Instead of :
![image](https://cloud.githubusercontent.com/assets/7080301/12715726/2bb18df4-c8dc-11e5-9d5f-8f1971fc7a76.png)