### PR TITLE
Allow nested form field widgets to send AJAX requests

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -401,7 +401,7 @@ class Controller extends Extendable
                 /*
                  * Validate the handler name
                  */
-                if (!preg_match('/^(?:\w+\:{2})?on[A-Z]{1}[\w+]*$/', $handler)) {
+                if (!preg_match('/^(?:\w+(?:\[\w+\])*\:{2})?on[A-Z]{1}[\w+]*$/', $handler)) {
                     throw new SystemException(Lang::get('cms::lang.ajax_handler.invalid_name', ['name'=>$handler]));
                 }
 

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -21,7 +21,7 @@ if (window.jQuery === undefined)
         if (handler == undefined)
             throw new Error('The request handler name is not specified.')
 
-        if (!handler.match(/^(?:\w+\:{2})?on*/))
+        if (!handler.match(/^(?:\w+(?:\[\w+\])*\:{2})?on*/))
             throw new Error('Invalid handler name. The correct handler name format is: "onEvent".')
 
         /*


### PR DESCRIPTION
This PR allows nested widgets to send AJAX requests.

Usually you can only have an ajax handler like `config::onGetAutocompleteOptions` however nested form fields will send `config[rates]::onGetAutocompleteOptions` which isn't allowed currently.

### Example
Say I have a DataTable widget of name `config[rates]`. If I click a field in the table it tries to send an AJAX request with its handler name `config[rates]::onGetAutocompleteOptions` resulting in a JS error
> Invalid handler name. The correct handler name format is: "onEvent".