### PR TITLE
Remove brackets from DataTable's table widget

### DIFF
--- a/modules/backend/formwidgets/DataTable.php
+++ b/modules/backend/formwidgets/DataTable.php
@@ -3,6 +3,7 @@
 use Lang;
 use Backend\Widgets\Table;
 use Backend\Classes\FormWidgetBase;
+use October\Rain\Html\Helper as HtmlHelper;
 use ApplicationException;
 
 /**
@@ -106,8 +107,8 @@ class DataTable extends FormWidgetBase
      */
     public function getSaveValue($value)
     {
-        // TODO: provide a streaming implementation of saving 
-        // data to the model. The current implementation returns 
+        // TODO: provide a streaming implementation of saving
+        // data to the model. The current implementation returns
         // all records at once. -ab
 
         $dataSource = $this->table->getDataSource();
@@ -133,7 +134,7 @@ class DataTable extends FormWidgetBase
     {
         $dataSource = $this->table->getDataSource();
 
-        // TODO: provide a streaming implementation of loading 
+        // TODO: provide a streaming implementation of loading
         // data from the model. The current implementation loads
         // all records at once. -ab
 
@@ -150,10 +151,10 @@ class DataTable extends FormWidgetBase
 
         // It's safe to use the field name as an alias
         // as field names do not repeat in forms. This
-        // approach lets to access the table data by the 
+        // approach lets to access the table data by the
         // field name in POST requests directly (required
         // in some edge cases).
-        $config->alias = $this->fieldName;
+        $config->alias = studly_case(HtmlHelper::nameToId($this->fieldName)) . 'datatable';
 
         $table = new Table($this->controller, $config);
 


### PR DESCRIPTION
See #1748 for full discussion.

Say I have a DataTable widget of name config[rates]. If I click a field in the table it tries to send an AJAX request with its handler name config[rates]::onGetAutocompleteOptions resulting in a JS error
> Invalid handler name. The correct handler name format is: "onEvent".

This PR removes the brackets from `config[rates]` fixing the validation errors and letting the form submit correctly.