### PR TITLE
Fix hardcoded column name `id` on recordfinder form widget

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -16,7 +16,7 @@ use Backend\Classes\FormWidgetBase;
  *        prompt: Click the Find button to find a user
  *        nameFrom: name
  *        descriptionFrom: email
- * 
+ *
  * @package october\backend
  * @author Alexey Bobkov, Samuel Georges
  */
@@ -232,7 +232,7 @@ class RecordFinder extends FormWidgetBase
         $config->showSetup = false;
         $config->showCheckboxes = false;
         $config->recordsPerPage = 20;
-        $config->recordOnClick = sprintf("$('#%s').recordFinder('updateRecord', this, ':id')", $this->getId());
+        $config->recordOnClick = sprintf("$('#%s').recordFinder('updateRecord', this, ':" . $this->keyFrom . "')", $this->getId());
         $widget = $this->makeWidget('Backend\Widgets\Lists', $config);
 
         // $widget->bindEvent('list.extendQueryBefore', function($query) {


### PR DESCRIPTION
See: #1761
Thanks @tschallacka!

It is currently not possible to use the `recordfinder` field type if a database table does not contain an `id` column. This is due to the fact this `id` name was hardcoded on the plugin code.

This PR assumes the `keyFrom` property will be defined in the field options:
```yaml
category:
    label: Category
    type: relation
    nameFrom: Description
    keyFrom: Category      # <------- Important if your table doesn't have an id field
    emptyOption: Select a category
```

It would be great if this could be merged as it is a show stopper if one cannot change the database table to include an `id` column.