### PR TITLE
Deepen nesting limit of CmsObjects up to 4 directories (up from 2)

### DIFF
--- a/modules/cms/classes/CmsObject.php
+++ b/modules/cms/classes/CmsObject.php
@@ -190,7 +190,7 @@ class CmsObject implements ArrayAccess
      */
     protected static function getMaxAllowedPathNesting()
     {
-        return 2;
+        return 4;
     }
 
     /**
@@ -424,14 +424,14 @@ class CmsObject implements ArrayAccess
         }
 
         $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dirPath));
-        $it->setMaxDepth(1); // Support only a single level of subdirectories
+        $it->setMaxDepth(self::getMaxAllowedPathNesting() - 1); // Limit nesting
         $it->rewind();
 
         while ($it->valid()) {
             if ($it->isFile() && in_array($it->getExtension(), static::$allowedExtensions)) {
                 $filePath = $it->getBasename();
                 if ($it->getDepth() > 0) {
-                    $filePath = basename($it->getPath()).'/'.$filePath;
+                    $filePath = $it->getSubPath().'/'.$filePath;
                 }
 
                 $page = $skipCache ? static::load($theme, $filePath) : static::loadCached($theme, $filePath);

--- a/modules/cms/widgets/TemplateList.php
+++ b/modules/cms/widgets/TemplateList.php
@@ -201,7 +201,7 @@ class TemplateList extends WidgetBase
         $result = [];
         $foundGroups = [];
         foreach ($filteredItems as $itemData) {
-            $pos = strpos($itemData->fileName, '/');
+            $pos = strrpos($itemData->fileName, '/');
 
             if ($pos !== false) {
                 $group = substr($itemData->fileName, 0, $pos);
@@ -220,6 +220,8 @@ class TemplateList extends WidgetBase
                 $result[] = $itemData;
             }
         }
+
+        ksort($foundGroups, SORT_STRING);
 
         foreach ($foundGroups as $group) {
             $result[] = $group;

--- a/tests/unit/cms/classes/CmsObjectQueryTest.php
+++ b/tests/unit/cms/classes/CmsObjectQueryTest.php
@@ -45,13 +45,13 @@ class CmsObjectQueryTest extends TestCase
         // Default theme: test
         $pages = Page::lists('baseFileName');
         sort($pages);
-
         $this->assertEquals([
             "404",
             "a/a-page",
             "ajax-test",
             "authors",
             "b/b-page",
+            "b/c/c-page",
             "blog-archive",
             "blog-post",
             "code-namespaces",

--- a/tests/unit/cms/classes/ThemeTest.php
+++ b/tests/unit/cms/classes/ThemeTest.php
@@ -17,7 +17,7 @@ class ThemeTest extends TestCase
     {
         $result = 0;
         $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
-        $it->setMaxDepth(1);
+        $it->setMaxDepth(3);
         $it->rewind();
 
         while ($it->valid()) {


### PR DESCRIPTION
I attempted to make the most minimally invasive change that would fix #1707. The lists in the backend now show groups like: b, b/c.