### PR TITLE
Workaround for Microsoft SYLK bug

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -566,9 +566,11 @@ class ImportExportController extends ControllerBehavior
          * Add headers
          */
         $headers = [];
+        $index = 0;
         $columns = $widget->getVisibleColumns();
         foreach ($columns as $column) {
-            $headers[] = Lang::get($column->label);
+            $label = Lang::get($column->label);
+            $headers[] = ($index++ == 0) ? ucfirst(mb_strtolower($label)) : $label;
         }
         $csv->insertOne($headers);
 


### PR DESCRIPTION
There is some wierd Microsoft SYLK bug which appears when you have first two characters of CSV uppercased (for example "ID", which is a very common situation in OctoberCMS).

It is reported for:
- Windows - https://support.microsoft.com/en-us/kb/323626
- Mac - https://support.microsoft.com/en-us/kb/215591

**Solutions** are at least two:
a) Insert apostrophe as first character, which works only when inserting apostrophe directly in Excel, not while exporting.
b) Make this two first characters not uppercased (I made it in this PR). It means convert "ID" to "Id" what is still well readable.

**Screenshots** from Win and Mac:

![snimek obrazovky 2016-02-11 v 15 11 45](https://cloud.githubusercontent.com/assets/374917/12978648/87389408-d0d2-11e5-8eb7-87873314de57.png)

![excel-sylk-error](https://cloud.githubusercontent.com/assets/374917/12978650/8c3aecf8-d0d2-11e5-88a7-e10b0f488b25.png)

Tested with latest build 317, unit tests passed.