### PR TITLE
Preserve redirect response attributes

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -650,7 +650,20 @@ class Controller
                     $responseContents['X_OCTOBER_REDIRECT'] = $result->getTargetUrl();
                 }
 
-                return Response::make($responseContents, $this->statusCode);
+                if ($result instanceof \Symfony\Component\HttpFoundation\Response) {
+                    $content = json_decode($result->getContent(), true);
+                    if ($content !== null) {
+                        $responseContents = array_merge($responseContents, $content);
+                    }
+
+                    $result->setStatusCode(200);
+                    $result->setContent(json_encode($responseContents));
+                }
+                else {
+                    $result = Response::make($responseContents, $this->statusCode);
+                }
+
+                return $result;
             }
             catch (ValidationException $ex) {
                 /*


### PR DESCRIPTION
This PR is for complex ajax responses.
Sometimes we want to send a custom response to the client, not only the "result" string.

This make possible the following:

1. Add attributes to the response body.
2. Include custom cookies.
3. Include custom headers.

It works for either Response or RedirectResponse