### PR TITLE
Added the ability to inject dependencies into components

### DIFF
--- a/modules/cms/classes/ComponentManager.php
+++ b/modules/cms/classes/ComponentManager.php
@@ -4,6 +4,7 @@ use Str;
 use Illuminate\Container\Container;
 use System\Classes\PluginManager;
 use SystemException;
+use Illuminate\Support\Facades\App;
 
 /**
  * Component manager
@@ -132,7 +133,7 @@ class ComponentManager
         return $this->codeMap;
     }
 
-    /** 
+    /**
      * Returns an array of all component detail definitions.
      * @return array Array keys are component codes, values are the details defined in the component.
      */
@@ -210,7 +211,7 @@ class ComponentManager
             ));
         }
 
-        $component = new $className($cmsObject, $properties);
+        $component = App::make($className, [$cmsObject, $properties]);
         $component->name = $name;
 
         return $component;

--- a/tests/fixtures/plugins/october/tester/Plugin.php
+++ b/tests/fixtures/plugins/october/tester/Plugin.php
@@ -20,7 +20,8 @@ class Plugin extends PluginBase
             'October\Tester\Components\Archive' => 'testArchive',
             'October\Tester\Components\Post' => 'testPost',
             'October\Tester\Components\MainMenu' => 'testMainMenu',
-            'October\Tester\Components\ContentBlock' => 'testContentBlock'
+            'October\Tester\Components\ContentBlock' => 'testContentBlock',
+            'October\Tester\Components\Comments' => 'testComments',
         ];
     }
 

--- a/tests/fixtures/plugins/october/tester/classes/Users.php
+++ b/tests/fixtures/plugins/october/tester/classes/Users.php
@@ -1,0 +1,12 @@
+<?php namespace October\Tester\Classes;
+
+class Users
+{
+    public function getUsers()
+    {
+        return [
+            'Art Vandelay' => 'Arquitecht and Importer/Exporter',
+            'Carl' => 'where is he?',
+        ];
+    }
+}

--- a/tests/fixtures/plugins/october/tester/components/Categories.php
+++ b/tests/fixtures/plugins/october/tester/components/Categories.php
@@ -1,0 +1,34 @@
+<?php namespace October\Tester\Components;
+
+use Cms\Classes\ComponentBase;
+use Cms\Classes\CodeBase;
+
+class Categories extends ComponentBase
+{
+    public function __construct(CodeBase $cmsObject = null, $properties = [])
+    {
+        parent::__construct($cmsObject, $properties);
+    }
+
+    public function componentDetails()
+    {
+        return [
+            'name' => 'Blog Categories Dummy Component',
+            'description' => 'Displays the list of categories in the blog.'
+        ];
+    }
+
+    public function posts()
+    {
+        return [
+            ['title' => 'Lorum ipsum', 'content' => 'Post Content #1'],
+            ['title' => 'La Playa Nudista', 'content' => 'Second Post Content']
+        ];
+    }
+
+    public function onTestAjax()
+    {
+        $this->page['var'] = 'page';
+    }
+
+}

--- a/tests/fixtures/plugins/october/tester/components/Comments.php
+++ b/tests/fixtures/plugins/october/tester/components/Comments.php
@@ -1,0 +1,43 @@
+<?php namespace October\Tester\Components;
+
+use Cms\Classes\ComponentBase;
+use Cms\Classes\CodeBase;
+use October\Tester\Classes\Users;
+
+class Comments extends ComponentBase
+{
+    private $users;
+
+    public function __construct(CodeBase $cmsObject = null, $properties = [], Users $users)
+    {
+        parent::__construct($cmsObject, $properties);
+        $this->users = $users;
+    }
+
+    public function componentDetails()
+    {
+        return [
+            'name' => 'Blog Comments Dummy Component',
+            'description' => 'Displays the list of comments on a post.'
+        ];
+    }
+
+    public function posts()
+    {
+        return [
+            ['title' => 'Lorum ipsum', 'content' => 'Post Content #1'],
+            ['title' => 'La Playa Nudista', 'content' => 'Second Post Content']
+        ];
+    }
+
+    public function onTestAjax()
+    {
+        $this->page['var'] = 'page';
+    }
+
+    public function getUsers()
+    {
+        return $this->users;
+    }
+
+}

--- a/tests/unit/cms/classes/ComponentManagerTest.php
+++ b/tests/unit/cms/classes/ComponentManagerTest.php
@@ -9,6 +9,19 @@ use Cms\Classes\ComponentManager;
 
 class ComponentManagerTest extends TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Archive.php';
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Post.php';
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/MainMenu.php';
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/ContentBlock.php';
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Comments.php';
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/classes/Users.php';
+    }
+
+
     public function testListComponents()
     {
         $manager = ComponentManager::instance();
@@ -20,14 +33,9 @@ class ComponentManagerTest extends TestCase
 
     public function testListComponentDetails()
     {
-        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Archive.php';
-        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Post.php';
-        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/MainMenu.php';
-        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/ContentBlock.php';
-
         $manager = ComponentManager::instance();
         $components = $manager->listComponentDetails();
-        
+
         $this->assertArrayHasKey('testArchive', $components);
         $this->assertArrayHasKey('name', $components['testArchive']);
         $this->assertArrayHasKey('description', $components['testArchive']);
@@ -41,6 +49,26 @@ class ComponentManagerTest extends TestCase
         $this->assertEquals('Displays a blog post.', $components['testPost']['description']);
     }
 
+    public function testGetComponentWithFactoryUsingAutomaticResolution()
+    {
+        $manager = ComponentManager::instance();
+        $components = $manager->listComponentDetails();
+
+        $this->assertArrayHasKey('testComments', $components);
+        $this->assertArrayHasKey('name', $components['testComments']);
+        $this->assertArrayHasKey('description', $components['testComments']);
+        $this->assertEquals('Blog Comments Dummy Component', $components['testComments']['name']);
+        $this->assertEquals('Displays the list of comments on a post.', $components['testComments']['description']);
+
+        $comments = $manager->makeComponent('testComments', $this->spoofPageCode(), []);
+        $users = $comments->getUsers()->getUsers();
+
+        $this->assertArrayHasKey('Art Vandelay', $users);
+        $this->assertArrayHasKey('Carl', $users);
+        $this->assertEquals('Arquitecht and Importer/Exporter', $users['Art Vandelay']);
+        $this->assertEquals('where is he?', $users['Carl']);
+    }
+
     public function testFindByAlias()
     {
         $manager = ComponentManager::instance();
@@ -50,7 +78,6 @@ class ComponentManagerTest extends TestCase
 
         $component = $manager->resolve('testPost');
         $this->assertEquals('\October\Tester\Components\Post', $component);
-
     }
 
     public function testHasComponent()


### PR DESCRIPTION
Hi.
I would like to have the ability to inject dependencies in my component classes. I noticed that they are registered in a way that it is not allowed because they need some specific parameters on the constructor method.
I added the option to register components factories in the registerComponents method of the plugin registration class, so this factory can create the component adding it's required arguments and all other dependencies required by it.

Would be nice to have this also in rainlab.pages plugin for snippets registration from components.