### PR TITLE
Add event to extend relation form widget query

### DIFF
--- a/modules/backend/formwidgets/Relation.php
+++ b/modules/backend/formwidgets/Relation.php
@@ -129,7 +129,7 @@ class Relation extends FormWidgetBase
             /**
              * Extensibility
              */
-            Event::fire('backend.relation.extendQuery', [$this, $query]);
+            Event::fire('backend.relation.extendQuery', [$this, $attribute, $query]);
 
             // The "sqlSelect" config takes precedence over "nameFrom".
             // A virtual column called "selection" will contain the result.

--- a/modules/backend/formwidgets/Relation.php
+++ b/modules/backend/formwidgets/Relation.php
@@ -2,6 +2,7 @@
 
 use Db;
 use Lang;
+use Event;
 use Backend\Classes\FormWidgetBase;
 use ApplicationException;
 use SystemException;
@@ -124,6 +125,11 @@ class Relation extends FormWidgetBase
             // Determine if the model uses a tree trait
             $treeTraits = ['October\Rain\Database\Traits\NestedTree', 'October\Rain\Database\Traits\SimpleTree'];
             $usesTree = count(array_intersect($treeTraits, class_uses($relationModel))) > 0;
+
+            /**
+             * Extensibility
+             */
+            Event::fire('backend.relation.extendQuery', [$this, $query]);
 
             // The "sqlSelect" config takes precedence over "nameFrom".
             // A virtual column called "selection" will contain the result.


### PR DESCRIPTION
### Description
ListController and FormController have both some extend events which are useful to filter elements.
This pull request allow you to extend the query used by the Relation widget form to populate dropdown or checkbox list.

### Example
You have a model with a belongsToMany relation, and you want his form controller to display it thanks to a field of type 'relation'. If you want to restrict results of the checkbox list generated by your relation field, you can write something like that :
````
// Extend Rainlab User controller form
        Event::listen('backend.relation.extendQuery', function ($widget, $query) {
            if (!$widget->getController() instanceof \RainLab\User\Controllers\Users) return;
            if (!$widget->model instanceof \RainLab\User\Models\User) return;
            
            // No restriction for super users
            if (BackendAuth::getUser()->isSuperUser()) return;
            
            // Filter available groups using backend user permissions
            $query->whereIn('id', BackendAuth::getUser()->frontend_groups);
        });
````
In this code, I extended Backend User model with a JSON attribute which contains allowed frontend groups.

*Sorry for duplicated pull request in the master branch...*