### PR TITLE
Verify file extensions against server-side scripting file upload

### DIFF
--- a/modules/cms/widgets/MediaManager.php
+++ b/modules/cms/widgets/MediaManager.php
@@ -48,6 +48,49 @@ class MediaManager extends WidgetBase
      */
     public $cropAndInsertButton = false;
 
+	/**
+     * @var array A list of default disallowed file types.
+     * This parameter can be overridden with the cms.disAllowedFileTypes configuration option.
+     * https://en.wikipedia.org/wiki/Server-side_scripting
+     */
+    public $disAllowedFileTypes = [
+        'asp',
+		'avfp',
+		'aspx',
+		'cshtml',
+		'cfm',
+		'go',
+		'gsp',
+		'php',
+		'hs',
+		'jsp',
+		'ssjs',
+		'js',
+		'lasso',
+		'lp',
+		'op',
+		'lua',
+		'p',
+		'cgi', 
+		'ipl',
+		'pl',
+		'php',
+		'php3',
+		'php4',
+		'phtml',
+		'py',
+		'rhtml',
+		'rb',
+		'rbw',
+		'smx',
+		'tcl',
+		'dna',
+		'tpl',
+		'r',
+		'w',
+		'wig'
+    ];
+	
     public function __construct($controller, $alias)
     {
         $this->alias = $alias;
@@ -962,11 +1005,22 @@ class MediaManager extends WidgetBase
             $uploadedFile = Input::file('file_data');
 
             $fileName = $uploadedFile->getClientOriginalName();
-
+			
+			// Use the simple extension validation.
+            $disAllowedFileTypes = Config::get('cms.disAllowedFileTypes');
+            if (!$disAllowedFileTypes) {
+                $disAllowedFileTypes = $this->disAllowedFileTypes;
+            }
+			
             /*
              * Convert uppcare case file extensions to lower case
              */
             $extension = strtolower($uploadedFile->getClientOriginalExtension());
+			// Verify file extensions against server-side scripting file upload
+            if (in_array($extension, $disAllowedFileTypes)) {
+				throw new ApplicationException('Error uploading file');
+            }
+			
             $fileName = File::name($fileName).'.'.$extension;
 
             /*


### PR DESCRIPTION
Additional file extension verification against server-side scripting upload.
A list of default disallowed file types is from https://en.wikipedia.org/wiki/Server-side_scripting, Line 51-92.
            Line 1009-1022:
            // Use the simple extension validation.
            $disAllowedFileTypes = Config::get('cms.disAllowedFileTypes');
            if (!$disAllowedFileTypes) {
                $disAllowedFileTypes = $this->disAllowedFileTypes;
            }
            /*
             * Convert uppcare case file extensions to lower case
             */
            $extension = strtolower($uploadedFile->getClientOriginalExtension());
			// Verify file extensions against server-side scripting file upload
            if (in_array($extension, $disAllowedFileTypes)) {
				throw new ApplicationException('Error uploading file');
            }