### PR TITLE
Expanded select-no-search to consider container class. Fixes #1817 

### DIFF
--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -58,7 +58,7 @@
                 }
             })
 
-            if ($element.hasClass('select-no-search')) {
+            if ($element.hasClass('select-no-search') || $element.parent().hasClass('select-no-search')) {
                 extraOptions.minimumResultsForSearch = Infinity
             }
 

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -2196,7 +2196,7 @@ $('select.custom-select').each(function(){var $element=$(this),extraOptions={}
 if($element.data('select2')!=null){return true;}
 $element.attr('data-disposable','data-disposable')
 $element.one('dispose-control',function(){if($element.data('select2')){$element.select2('destroy')}})
-if($element.hasClass('select-no-search')){extraOptions.minimumResultsForSearch=Infinity}
+if($element.hasClass('select-no-search')||$element.parent().hasClass('select-no-search')){extraOptions.minimumResultsForSearch=Infinity}
 $element.select2($.extend({},selectOptions,extraOptions))})})
 $(document).on('disable','select.custom-select',function(event,status){$(this).select2('enable',!status)})
 $(document).on('focus','select.custom-select',function(event){setTimeout($.proxy(function(){$(this).select2('focus')},this),10)})})(jQuery);+function($){"use strict";var LoadIndicator=function(element,options){var $el=this.$el=$(element)


### PR DESCRIPTION
select-no-search may now be used inside yaml form configs like so:
`````````
form:
  fields:
    shirt_size:
      label: Shirt Size
      type: dropdown
      cssClass: select-no-search
      options: ...
```````

This should be a documented option [here](https://octobercms.com/docs/backend/forms#field-dropdown), but I will leave the verbiage to you, @daftspunk 

Cheers