### PR TITLE
Allow Pikaday translation for backend datepickers

### DIFF
--- a/modules/backend/formwidgets/datepicker/assets/js/datepicker.js
+++ b/modules/backend/formwidgets/datepicker/assets/js/datepicker.js
@@ -39,6 +39,7 @@
             maxDate: new Date(options.maxDate),
             yearRange: options.yearRange,
             setDefaultDate: moment(this.$input.val()).toDate(),
+            i18n: $.oc.lang.get('pikaday'),
             onOpen: function() {
                 var $field = $(this._o.trigger)
 

--- a/modules/system/lang/en/client.php
+++ b/modules/system/lang/en/client.php
@@ -51,6 +51,14 @@ return [
         'cancel_button_text' => 'Cancel',
     ],
 
+    'pikaday' => [
+        'previousMonth' => 'Previous Month',
+        'nextMonth' => 'Next Month',
+        'months' => ['January','February','March','April','May','June','July','August','September','October','November','December'],
+        'weekdays' => ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'],
+        'weekdaysShort' => ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
+    ],
+
 ];
 
 

--- a/modules/system/lang/fr/client.php
+++ b/modules/system/lang/fr/client.php
@@ -53,6 +53,14 @@ return [
         'confirm_button_text' => 'OK',
         'cancel_button_text' => 'Annuler',
     ],
+
+    'pikaday' => [
+        'previousMonth' => 'Mois précédent',
+        'nextMonth'     => 'Mois suivant',
+        'months'        => ['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'],
+        'weekdays'      => ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
+        'weekdaysShort' => ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']
+    ],
 ];
 
 


### PR DESCRIPTION
Extracted from PR #1651 

Using the built-in $.oc.lang module, the patch injects the i18n object into the datepicker init call.

Assets needs to be recompiled `php artisan october:util compile assets`