### PR TITLE
Add newline conversion to code data section too

### DIFF
--- a/modules/cms/controllers/Index.php
+++ b/modules/cms/controllers/Index.php
@@ -158,6 +158,10 @@ class Index extends Controller
             $templateData['markup'] = $this->convertLineEndings($templateData['markup']);
         }
 
+        if (!empty($templateData['code']) && Config::get('cms.convertLineEndings', false) === true) {
+            $templateData['code'] = $this->convertLineEndings($templateData['code']);
+        }
+
         if (!Request::input('templateForceSave') && $template->mtime) {
             if (Request::input('templateMtime') != $template->mtime) {
                 throw new ApplicationException('mtime-mismatch');


### PR DESCRIPTION
When saving through Editor, OctoberCMS only convert newline of markup section once config 'cms.convertLineEndings' enabled.
In the code too, I've only seen [the conversion](https://github.com/octobercms/october/blob/master/modules/cms/controllers/Index.php#L158) of newline for markup.
Then, I propose the conversion of code section data too.