### PR TITLE
Quoted strings are more polite

### DIFF
--- a/themes/demo/theme.yaml
+++ b/themes/demo/theme.yaml
@@ -1,4 +1,4 @@
-name: Demo
-description: Demo OctoberCMS theme. Demonstrates the basic concepts of the front-end theming: layouts, pages, partials, components, content blocks, AJAX framework.
-author: OctoberCMS
+name: 'Demo'
+description: 'Demo OctoberCMS theme. Demonstrates the basic concepts of the front-end theming: layouts, pages, partials, components, content blocks, AJAX framework.'
+author: 'OctoberCMS'
 homepage: 'http://octobercms.com'


### PR DESCRIPTION
Some environments have a problem with unquoted strings and this can clobber the `/backend/cms/themes` route.

![unquoted_string](https://cloud.githubusercontent.com/assets/7980426/14305560/69955498-fb72-11e5-9078-be9c6cda5200.png)