### PR TITLE
Datepicker: allow specify display format

### DIFF
--- a/modules/backend/formwidgets/DatePicker.php
+++ b/modules/backend/formwidgets/DatePicker.php
@@ -20,6 +20,11 @@ class DatePicker extends FormWidgetBase
     //
 
     /**
+     * @var string Display format.
+     */
+    public $format = 'YYYY-MM-DD';
+
+    /**
      * @var bool Display mode: datetime, date, time.
      */
     public $mode = 'datetime';
@@ -49,6 +54,7 @@ class DatePicker extends FormWidgetBase
     public function init()
     {
         $this->fillFromConfig([
+            'format',
             'mode',
             'minDate',
             'maxDate',
@@ -119,6 +125,7 @@ class DatePicker extends FormWidgetBase
 
         $this->vars['value'] = $value ?: '';
         $this->vars['field'] = $this->formField;
+        $this->vars['format'] = $this->format;
         $this->vars['mode'] = $this->mode;
         $this->vars['minDate'] = $this->minDate;
         $this->vars['maxDate'] = $this->maxDate;

--- a/modules/backend/formwidgets/datepicker/assets/js/datepicker.js
+++ b/modules/backend/formwidgets/datepicker/assets/js/datepicker.js
@@ -1,6 +1,6 @@
 /*
  * DatePicker plugin
- * 
+ *
  * Data attributes:
  * - data-control="datepicker" - enables the plugin on an element
  * - data-min-date="value" - minimum date to allow
@@ -38,6 +38,7 @@
             minDate: new Date(options.minDate),
             maxDate: new Date(options.maxDate),
             yearRange: options.yearRange,
+            format: options.format,
             setDefaultDate: moment(this.$input.val()).toDate(),
             i18n: $.oc.lang.get('datepicker'),
             onOpen: function() {
@@ -57,6 +58,7 @@
     DatePicker.DEFAULTS = {
         minDate: '2000-01-01',
         maxDate: '2020-12-31',
+        format: 'YYYY-MM-DD',
         yearRange: 10
     }
 

--- a/modules/backend/formwidgets/datepicker/assets/js/datepicker.js
+++ b/modules/backend/formwidgets/datepicker/assets/js/datepicker.js
@@ -3,6 +3,7 @@
  *
  * Data attributes:
  * - data-control="datepicker" - enables the plugin on an element
+ * - data-format="value" - display format
  * - data-min-date="value" - minimum date to allow
  * - data-max-date="value" - maximum date to allow
  * - data-year-range="value" - range of years to display

--- a/modules/backend/formwidgets/datepicker/partials/_datepicker.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_datepicker.htm
@@ -8,6 +8,7 @@
             id="<?= $this->getId() ?>"
             class="field-datepicker"
             data-control="datepicker"
+            data-format="<?= $format ?>"
             data-min-date="<?= $minDate ?>"
             data-max-date="<?= $maxDate ?>">
             <div class="input-with-icon right-align">
@@ -32,6 +33,7 @@
                     id="<?= $this->getId() ?>"
                     class="field-datepicker"
                     data-control="datepicker"
+                    data-format="<?= $format ?>"
                     data-min-date="<?= $minDate ?>"
                     data-max-date="<?= $maxDate ?>">
                     <div class="input-with-icon right-align">


### PR DESCRIPTION
Adds the ability to specify a display format to be used with the [datepicker](https://octobercms.com/docs/backend/forms#widget-datepicker).
Reads the `format` property from field settings and apply it to the `datepicker` instance.

Example usage:
```yaml
created_at:
    label: Date
    type: datepicker
    format: DD/MM/YYYY
```
or
```yaml
created_at:
    label: Date
    type: datepicker
    format: L
```

See [Moment.js docs](http://momentjs.com/docs/#/displaying/format/) for a detailed description of supported display formats.