### PR TITLE
Add SES configuration for mailer

### DIFF
--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -162,6 +162,13 @@ return [
         'mandrill' => 'Mandrill',
         'mandrill_secret' => 'Mandrill secret',
         'mandrill_secret_comment' => 'Enter your Mandrill API key.',
+        'ses' => 'SES',
+        'ses_key' => 'SES key',
+        'ses_key_comment' => 'Enter your SES API key',
+        'ses_secret' => 'SES secret',
+        'ses_secret_comment' => 'Enter your SES API secret key',
+        'ses_region' => 'SES region',
+        'ses_region_comment' => 'Enter your SES region (e.g. us-east-1)',
         'drivers_hint_header' => 'Drivers not installed',
         'drivers_hint_content' => 'This mail method requires the plugin ":plugin" be installed before you can send mail.'
     ],

--- a/modules/system/lang/es/lang.php
+++ b/modules/system/lang/es/lang.php
@@ -164,6 +164,13 @@ return [
         'mandrill' => 'Mandrill',
         'mandrill_secret' => 'Mandrill secret',
         'mandrill_secret_comment' => 'Introduzca su key de Mandrill API.',
+        'ses' => 'SES',
+        'ses_key' => 'SES key',
+        'ses_key_comment' => 'Introduzca su key de SES API',
+        'ses_secret' => 'SES secret',
+        'ses_secret_comment' => 'Introduzca su key de SES API',
+        'ses_region' => 'Región SES',
+        'ses_region_comment' => 'Introduzca su región SES (e.g. us-east-1)',
         'drivers_hint_header' => 'Drivers no instalados',
         'drivers_hint_content' => 'Este método de correo electrónico requiere que el plugin ":plugin" este instalado antes de poder enviar correo.'
     ],

--- a/modules/system/lang/fr/lang.php
+++ b/modules/system/lang/fr/lang.php
@@ -160,6 +160,13 @@ return [
         'mandrill' => 'Mandrill',
         'mandrill_secret' => 'Clé secrète Mandrill',
         'mandrill_secret_comment' => 'Saisir la clé de l’API Mandrill.',
+        'ses' => 'SES',
+        'ses_key' => 'Clé SES',
+        'ses_key_comment' => 'Saisir la clé de l’API SES',
+        'ses_secret' => 'Clé secrète SES',
+        'ses_secret_comment' => 'Saisir la clé secrète de l’API SES',
+        'ses_region' => 'Région SES',
+        'ses_region_comment' => 'Saisir la région SES (e.g. us-east-1)',
         'drivers_hint_header' => 'Les drivers ne sont pas installés',
         'drivers_hint_content' => 'Cette méthode d’envoi d’e-mails nécessite que le plugin ":plugin" soit installé avant de pouvoir envoyer des e-mails.'
     ],

--- a/modules/system/models/MailSettings.php
+++ b/modules/system/models/MailSettings.php
@@ -24,10 +24,11 @@ class MailSettings extends Model
     const MODE_SMTP     = 'smtp';
     const MODE_MAILGUN  = 'mailgun';
     const MODE_MANDRILL = 'mandrill';
+    const MODE_SES      = 'ses';
 
     /*
      * Validation rules
-     */ 
+     */
     public $rules = [
         'sender_name'  => 'required',
         'sender_email' => 'required|email'
@@ -57,6 +58,7 @@ class MailSettings extends Model
             static::MODE_SMTP     => 'system::lang.mail.smtp',
             static::MODE_MAILGUN  => 'system::lang.mail.mailgun',
             static::MODE_MANDRILL => 'system::lang.mail.mandrill',
+            static::MODE_SES      => 'system::lang.mail.ses',
         ];
     }
 
@@ -100,6 +102,12 @@ class MailSettings extends Model
 
             case self::MODE_MANDRILL:
                 $config->set('services.mandrill.secret', $settings->mandrill_secret);
+                break;
+
+            case self::MODE_SES:
+                $config->set('services.ses.key', $settings->ses_key);
+                $config->set('services.ses.secret', $settings->ses_secret);
+                $config->set('services.ses.region', $settings->ses_region);
                 break;
         }
 

--- a/modules/system/models/mailsettings/fields.yaml
+++ b/modules/system/models/mailsettings/fields.yaml
@@ -27,7 +27,7 @@ tabs:
             trigger:
                 action: show
                 field: send_mode
-                condition: value[mandrill][mailgun]
+                condition: value[mandrill][mailgun][ses]
 
         smtp_address:
             label: system::lang.mail.smtp_address
@@ -119,3 +119,33 @@ tabs:
                 action: show
                 field: send_mode
                 condition: value[mandrill]
+
+        ses_key:
+          label: system::lang.mail.ses_key
+          commentAbove: system::lang.mail.ses_key
+          tab: system::lang.mail.general
+          span: left
+          trigger:
+            action: show
+            field: send_mode
+            condition: value[ses]
+
+        ses_secret:
+          label: system::lang.mail.ses_secret
+          commentAbove: system::lang.mail.ses_secret_comment
+          tab: system::lang.mail.general
+          span: right
+          trigger:
+            action: show
+            field: send_mode
+            condition: value[ses]
+
+        ses_region:
+          label: system::lang.mail.ses_region
+          commentAbove: system::lang.mail.ses_region_comment
+          tab: system::lang.mail.general
+          span: left
+          trigger:
+            action: show
+            field: send_mode
+            condition: value[ses]


### PR DESCRIPTION
Laravel ships with a SES transport class, even on the 5.0 branch that's currently used by October, but currently there's no option for it when configuring the mail settings via the backend.
