### PR TITLE
UI fix for multiple dropdowns inside the same context

### DIFF
--- a/modules/system/assets/ui/js/dropdown.js
+++ b/modules/system/assets/ui/js/dropdown.js
@@ -8,11 +8,15 @@
  */
 +function ($) { "use strict";
 
-    $(document).on('shown.bs.dropdown', '.dropdown', function() {
+    $(document).on('shown.bs.dropdown', '.dropdown', function(event, relatedTarget) {
         $(document.body).addClass('dropdown-open')
 
-        var dropdown = $('.dropdown-menu', this),
+        var dropdown = $(relatedTarget.relatedTarget).siblings('.dropdown-menu'),
             dropdownContainer = $(this).data('dropdown-container')
+
+        if (dropdown.length === 0){
+            dropdown = $('.dropdown-menu', this)
+        }
 
         if ($('.dropdown-container', dropdown).length == 0) {
 

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -1943,8 +1943,9 @@ if(!data)$this.data('oc.balloon-selector',(data=new BalloonSelector(this,options
 $.fn.balloonSelector.Constructor=BalloonSelector
 $.fn.balloonSelector.noConflict=function(){$.fn.balloonSelector=old
 return this}
-$(document).on('render',function(){$('div[data-control=balloon-selector]').balloonSelector()})}(window.jQuery);+function($){"use strict";$(document).on('shown.bs.dropdown','.dropdown',function(){$(document.body).addClass('dropdown-open')
-var dropdown=$('.dropdown-menu',this),dropdownContainer=$(this).data('dropdown-container')
+$(document).on('render',function(){$('div[data-control=balloon-selector]').balloonSelector()})}(window.jQuery);+function($){"use strict";$(document).on('shown.bs.dropdown','.dropdown',function(event,relatedTarget){$(document.body).addClass('dropdown-open')
+var dropdown=$(relatedTarget.relatedTarget).siblings('.dropdown-menu'),dropdownContainer=$(this).data('dropdown-container')
+if(dropdown.length===0){dropdown=$('.dropdown-menu',this)}
 if($('.dropdown-container',dropdown).length==0){var title=$('[data-toggle=dropdown]',this).text(),titleAttr=dropdown.data('dropdown-title'),timer=null
 if(titleAttr!==undefined)
 title=titleAttr


### PR DESCRIPTION
I was working on translatable markdown editors (pull request here https://github.com/rainlab/translate-plugin/pull/122) and there is some minor issue when multiple dropdowns exist in the same context 
`var dropdown = $('.dropdown-menu', this)` was selecting each dropdown in the context resulting in `.dropdown-container` being created from all available dropdown options.

I added `relatedTarget` object which is supposed to be a sibling to the `.dropdown-menu`. Only options from the sibling will be displayed in the modal