### PR TITLE
Bug: Fix for components that support autowiring

### DIFF
--- a/modules/cms/widgets/ComponentList.php
+++ b/modules/cms/widgets/ComponentList.php
@@ -1,5 +1,6 @@
 <?php namespace Cms\Widgets;
 
+use App;
 use Str;
 use Lang;
 use Input;
@@ -110,7 +111,7 @@ class ComponentList extends WidgetBase
             foreach ($components as $componentInfo) {
                 $className = $componentInfo->className;
                 $alias = $componentInfo->alias;
-                $component = new $className();
+                $component = App::make($className);
 
                 if ($component->isHidden) {
                     continue;


### PR DESCRIPTION
Hi. 
Some weeks ago I created a pull request with changes to support autowiring in components: https://github.com/octobercms/october/pull/1799
It was merged to master recently, but still does not work because there is another place where components are being created: Cms\Widgets\ComponentsList
I created a fix for this, so the autowiring works for the components also in /backend/cms section.