### PR TITLE
Date fixes

### DIFF
--- a/modules/backend/database/migrations/2013_10_01_000001_Db_Backend_Users.php
+++ b/modules/backend/database/migrations/2013_10_01_000001_Db_Backend_Users.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbBackendUsers extends Migration
 {
     public function up()
     {
-        Schema::create('backend_users', function ($table) {
+        Schema::create('backend_users', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('first_name')->nullable();

--- a/modules/backend/database/migrations/2013_10_01_000002_Db_Backend_User_Groups.php
+++ b/modules/backend/database/migrations/2013_10_01_000002_Db_Backend_User_Groups.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbBackendUserGroups extends Migration
 {
     public function up()
     {
-        Schema::create('backend_user_groups', function ($table) {
+        Schema::create('backend_user_groups', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('name')->unique('name_unique');

--- a/modules/backend/database/migrations/2013_10_01_000003_Db_Backend_Users_Groups.php
+++ b/modules/backend/database/migrations/2013_10_01_000003_Db_Backend_Users_Groups.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbBackendUsersGroups extends Migration
 {
     public function up()
     {
-        Schema::create('backend_users_groups', function ($table) {
+        Schema::create('backend_users_groups', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->integer('user_id')->unsigned();
             $table->integer('user_group_id')->unsigned();

--- a/modules/backend/database/migrations/2013_10_01_000004_Db_Backend_User_Throttle.php
+++ b/modules/backend/database/migrations/2013_10_01_000004_Db_Backend_User_Throttle.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbBackendUserThrottle extends Migration
 {
     public function up()
     {
-        Schema::create('backend_user_throttle', function ($table) {
+        Schema::create('backend_user_throttle', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('user_id')->unsigned()->nullable()->index();

--- a/modules/backend/database/migrations/2014_01_04_000005_Db_Backend_User_Preferences.php
+++ b/modules/backend/database/migrations/2014_01_04_000005_Db_Backend_User_Preferences.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbBackendUserPreferences extends Migration
 {
     public function up()
     {
-        Schema::create('backend_user_preferences', function ($table) {
+        Schema::create('backend_user_preferences', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('user_id')->unsigned();

--- a/modules/backend/database/migrations/2014_10_01_000006_Db_Backend_Access_Log.php
+++ b/modules/backend/database/migrations/2014_10_01_000006_Db_Backend_Access_Log.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbBackendAccessLog extends Migration
 {
     public function up()
     {
-        Schema::create('backend_access_log', function ($table) {
+        Schema::create('backend_access_log', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('user_id')->unsigned();

--- a/modules/backend/database/migrations/2014_10_01_000007_Db_Backend_Add_Description_Field.php
+++ b/modules/backend/database/migrations/2014_10_01_000007_Db_Backend_Add_Description_Field.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbBackendAddDescriptionField extends Migration
 {
     public function up()
     {
-        Schema::table('backend_user_groups', function ($table) {
+        Schema::table('backend_user_groups', function (Blueprint $table) {
             $table->string('code')->nullable()->index('code_index');
             $table->text('description')->nullable();
             $table->boolean('is_new_user_default')->default(false);
@@ -15,7 +16,7 @@ class DbBackendAddDescriptionField extends Migration
 
     public function down()
     {
-        // Schema::table('backend_user_groups', function ($table) {
+        // Schema::table('backend_user_groups', function (Blueprint $table) {
         //     $table->dropColumn('code');
         //     $table->dropColumn('description');
         //     $table->dropColumn('is_new_user_default');

--- a/modules/backend/database/migrations/2015_10_01_000008_Db_Backend_Add_Superuser_Flag.php
+++ b/modules/backend/database/migrations/2015_10_01_000008_Db_Backend_Add_Superuser_Flag.php
@@ -1,5 +1,6 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 use Backend\Models\User as AdminModel;
 
@@ -7,7 +8,7 @@ class DbBackendAddSuperuserFlag extends Migration
 {
     public function up()
     {
-        Schema::table('backend_users', function ($table) {
+        Schema::table('backend_users', function (Blueprint $table) {
             $table->boolean('is_superuser')->default(false);
         });
 
@@ -21,7 +22,7 @@ class DbBackendAddSuperuserFlag extends Migration
 
     public function down()
     {
-        // Schema::table('backend_users', function ($table) {
+        // Schema::table('backend_users', function (Blueprint $table) {
         //     $table->dropColumn('is_superuser');
         // });
     }

--- a/modules/backend/database/migrations/2016_10_01_000009_Db_Backend_Timestamp_Fix.php
+++ b/modules/backend/database/migrations/2016_10_01_000009_Db_Backend_Timestamp_Fix.php
@@ -1,0 +1,28 @@
+<?php
+
+use October\Rain\Database\Updates\Migration;
+
+class DbBackendTimestampFix extends Migration
+{
+    protected $backendTables = [
+        'users',
+        'user_groups',
+        'access_log',
+    ];
+
+    public function up()
+    {
+        // Disable all special modes such as NO_ZERO_DATE to prevent any
+        // errors from MySQL before we can update the timestamp columns.
+        Db::statement("SET @@SQL_MODE=''");
+
+        foreach ($this->backendTables as $table) {
+            DbDongle::convertTimestamps($table);
+        }
+    }
+
+    public function down()
+    {
+        // ...
+    }
+}

--- a/modules/cms/database/migrations/2014_10_01_000001_Db_Cms_Theme_Data.php
+++ b/modules/cms/database/migrations/2014_10_01_000001_Db_Cms_Theme_Data.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbCmsThemeData extends Migration
 {
     public function up()
     {
-        Schema::create('cms_theme_data', function ($table) {
+        Schema::create('cms_theme_data', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('theme')->nullable()->index();

--- a/modules/cms/database/migrations/2016_10_01_000002_Db_Cms_Timestamp_Fix.php
+++ b/modules/cms/database/migrations/2016_10_01_000002_Db_Cms_Timestamp_Fix.php
@@ -1,0 +1,19 @@
+<?php
+
+use October\Rain\Database\Updates\Migration;
+
+class DbCmsTimestampFix extends Migration
+{
+    public function up()
+    {
+        // Disable all special modes such as NO_ZERO_DATE to prevent any
+        // errors from MySQL before we can update the timestamp columns.
+        Db::statement("SET @@SQL_MODE=''");
+        DbDongle::convertTimestamps('cms_theme_data');
+    }
+
+    public function down()
+    {
+        // ...
+    }
+}

--- a/modules/system/aliases.php
+++ b/modules/system/aliases.php
@@ -26,7 +26,6 @@ return [
     'Request'   => Illuminate\Support\Facades\Request::class,
     'Response'  => Illuminate\Support\Facades\Response::class,
     'Route'     => Illuminate\Support\Facades\Route::class,
-    'Schema'    => Illuminate\Support\Facades\Schema::class,
     'Session'   => Illuminate\Support\Facades\Session::class,
     'Storage'   => Illuminate\Support\Facades\Storage::class,
     'Url'       => Illuminate\Support\Facades\URL::class, // Preferred
@@ -52,6 +51,7 @@ return [
     'Ini'             => October\Rain\Support\Facades\Ini::class,
     'Twig'            => October\Rain\Support\Facades\Twig::class,
     'DbDongle'        => October\Rain\Support\Facades\DbDongle::class,
+    'Schema'          => October\Rain\Support\Facades\Schema::class,
     'Backend'         => Backend\Facades\Backend::class,
     'BackendMenu'     => Backend\Facades\BackendMenu::class,
     'BackendAuth'     => Backend\Facades\BackendAuth::class,

--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -366,6 +366,8 @@ class UpdateManager
      */
     public function migrateModule($module)
     {
+        DbDongle::disableStrictMode();
+
         $this->migrator->run(base_path() . '/modules/'.strtolower($module).'/database/migrations');
 
         $this->note($module);

--- a/modules/system/classes/VersionManager.php
+++ b/modules/system/classes/VersionManager.php
@@ -385,6 +385,8 @@ class VersionManager
      */
     protected function applyDatabaseScript($code, $version, $script)
     {
+        DbDongle::disableStrictMode();
+
         /*
          * Execute the database PHP script
          */
@@ -405,6 +407,8 @@ class VersionManager
      */
     protected function removeDatabaseScript($code, $version, $script)
     {
+        DbDongle::disableStrictMode();
+
         /*
          * Execute the database PHP script
          */

--- a/modules/system/database/migrations/2013_10_01_000001_Db_Deferred_Bindings.php
+++ b/modules/system/database/migrations/2013_10_01_000001_Db_Deferred_Bindings.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbDeferredBindings extends Migration
 {
-
     public function up()
     {
-        Schema::create('deferred_bindings', function ($table) {
+        Schema::create('deferred_bindings', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('master_type')->index();

--- a/modules/system/database/migrations/2013_10_01_000002_Db_System_Files.php
+++ b/modules/system/database/migrations/2013_10_01_000002_Db_System_Files.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemFiles extends Migration
 {
-
     public function up()
     {
-        Schema::create('system_files', function ($table) {
+        Schema::create('system_files', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('disk_name');

--- a/modules/system/database/migrations/2013_10_01_000003_Db_System_Plugin_Versions.php
+++ b/modules/system/database/migrations/2013_10_01_000003_Db_System_Plugin_Versions.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemPluginVersions extends Migration
 {
-
     public function up()
     {
-        Schema::create('system_plugin_versions', function ($table) {
+        Schema::create('system_plugin_versions', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('code')->index();

--- a/modules/system/database/migrations/2013_10_01_000003_Db_System_Plugin_Versions.php
+++ b/modules/system/database/migrations/2013_10_01_000003_Db_System_Plugin_Versions.php
@@ -12,7 +12,7 @@ class DbSystemPluginVersions extends Migration
             $table->increments('id');
             $table->string('code')->index();
             $table->string('version', 50);
-            $table->timestamp('created_at');
+            $table->timestamp('created_at')->nullable();
         });
     }
 

--- a/modules/system/database/migrations/2013_10_01_000004_Db_System_Plugin_History.php
+++ b/modules/system/database/migrations/2013_10_01_000004_Db_System_Plugin_History.php
@@ -14,7 +14,7 @@ class DbSystemPluginHistory extends Migration
             $table->string('type', 20)->index();
             $table->string('version', 50);
             $table->string('detail')->nullable();
-            $table->timestamp('created_at');
+            $table->timestamp('created_at')->nullable();
         });
     }
 

--- a/modules/system/database/migrations/2013_10_01_000004_Db_System_Plugin_History.php
+++ b/modules/system/database/migrations/2013_10_01_000004_Db_System_Plugin_History.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemPluginHistory extends Migration
 {
     public function up()
     {
-        Schema::create('system_plugin_history', function ($table) {
+        Schema::create('system_plugin_history', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('code')->index();

--- a/modules/system/database/migrations/2013_10_01_000005_Db_System_Settings.php
+++ b/modules/system/database/migrations/2013_10_01_000005_Db_System_Settings.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemSettings extends Migration
 {
     public function up()
     {
-        Schema::create('system_settings', function ($table) {
+        Schema::create('system_settings', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('item')->nullable()->index();

--- a/modules/system/database/migrations/2013_10_01_000006_Db_System_Parameters.php
+++ b/modules/system/database/migrations/2013_10_01_000006_Db_System_Parameters.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemParameters extends Migration
 {
     public function up()
     {
-        Schema::create('system_parameters', function ($table) {
+        Schema::create('system_parameters', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('namespace', 100);

--- a/modules/system/database/migrations/2013_10_01_000007_Db_System_Add_Disabled_Flag.php
+++ b/modules/system/database/migrations/2013_10_01_000007_Db_System_Add_Disabled_Flag.php
@@ -1,19 +1,20 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemAddDisabledFlag extends Migration
 {
     public function up()
     {
-        Schema::table('system_plugin_versions', function ($table) {
+        Schema::table('system_plugin_versions', function (Blueprint $table) {
             $table->boolean('is_disabled')->default(0);
         });
     }
 
     public function down()
     {
-        Schema::table('system_plugin_versions', function ($table) {
+        Schema::table('system_plugin_versions', function (Blueprint $table) {
             $table->dropColumn('is_disabled');
         });
     }

--- a/modules/system/database/migrations/2013_10_01_000008_Db_System_Mail_Templates.php
+++ b/modules/system/database/migrations/2013_10_01_000008_Db_System_Mail_Templates.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemMailTemplates extends Migration
 {
-
     public function up()
     {
-        Schema::create('system_mail_templates', function ($table) {
+        Schema::create('system_mail_templates', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('code')->nullable();

--- a/modules/system/database/migrations/2013_10_01_000009_Db_System_Mail_Layouts.php
+++ b/modules/system/database/migrations/2013_10_01_000009_Db_System_Mail_Layouts.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemMailLayouts extends Migration
 {
-
     public function up()
     {
-        Schema::create('system_mail_layouts', function ($table) {
+        Schema::create('system_mail_layouts', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('name')->nullable();

--- a/modules/system/database/migrations/2014_10_01_000010_Db_Jobs.php
+++ b/modules/system/database/migrations/2014_10_01_000010_Db_Jobs.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbJobs extends Migration
 {
     public function up()
     {
-        Schema::create('jobs', function ($table) {
+        Schema::create('jobs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->bigIncrements('id');
             $table->string('queue');

--- a/modules/system/database/migrations/2014_10_01_000011_Db_System_Event_Logs.php
+++ b/modules/system/database/migrations/2014_10_01_000011_Db_System_Event_Logs.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemEventLogs extends Migration
 {
-
     public function up()
     {
-        Schema::create('system_event_logs', function ($table) {
+        Schema::create('system_event_logs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('level')->nullable()->index();

--- a/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
+++ b/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemRequestLogs extends Migration
 {
-
     public function up()
     {
-        Schema::create('system_request_logs', function ($table) {
+        Schema::create('system_request_logs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('status_code')->nullable();

--- a/modules/system/database/migrations/2014_10_01_000013_Db_System_Sessions.php
+++ b/modules/system/database/migrations/2014_10_01_000013_Db_System_Sessions.php
@@ -1,10 +1,10 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemSessions extends Migration
 {
-
     /**
      * Run the migrations.
      *
@@ -12,7 +12,7 @@ class DbSystemSessions extends Migration
      */
     public function up()
     {
-        Schema::create('sessions', function ($table) {
+        Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->unique();
             $table->text('payload')->nullable();
             $table->integer('last_activity')->nullable();

--- a/modules/system/database/migrations/2015_10_01_000014_Db_System_Mail_Layout_Rename.php
+++ b/modules/system/database/migrations/2015_10_01_000014_Db_System_Mail_Layout_Rename.php
@@ -1,6 +1,7 @@
 <?php
 
 use System\Models\MailLayout;
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemMailLayoutRename extends Migration

--- a/modules/system/database/migrations/2015_10_01_000015_Db_System_Add_Frozen_Flag.php
+++ b/modules/system/database/migrations/2015_10_01_000015_Db_System_Add_Frozen_Flag.php
@@ -1,19 +1,20 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemAddFrozenFlag extends Migration
 {
     public function up()
     {
-        Schema::table('system_plugin_versions', function ($table) {
+        Schema::table('system_plugin_versions', function (Blueprint $table) {
             $table->boolean('is_frozen')->default(0);
         });
     }
 
     public function down()
     {
-        Schema::table('system_plugin_versions', function ($table) {
+        Schema::table('system_plugin_versions', function (Blueprint $table) {
             $table->dropColumn('is_frozen');
         });
     }

--- a/modules/system/database/migrations/2015_10_01_000016_Db_Cache.php
+++ b/modules/system/database/migrations/2015_10_01_000016_Db_Cache.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbCache extends Migration
 {
     public function up()
     {
-        Schema::create('cache', function ($table) {
+        Schema::create('cache', function (Blueprint $table) {
             $table->string('key')->unique();
             $table->text('value');
             $table->integer('expiration');

--- a/modules/system/database/migrations/2015_10_01_000017_Db_System_Revisions.php
+++ b/modules/system/database/migrations/2015_10_01_000017_Db_System_Revisions.php
@@ -1,13 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemRevisions extends Migration
 {
-
     public function up()
     {
-        Schema::create('system_revisions', function ($table) {
+        Schema::create('system_revisions', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('user_id')->unsigned()->nullable()->index();

--- a/modules/system/database/migrations/2015_10_01_000018_Db_FailedJobs.php
+++ b/modules/system/database/migrations/2015_10_01_000018_Db_FailedJobs.php
@@ -13,7 +13,7 @@ class DbFailedJobs extends Migration
             $table->text('connection');
             $table->text('queue');
             $table->text('payload');
-            $table->timestamp('failed_at');
+            $table->timestamp('failed_at')->nullable();
         });
     }
 

--- a/modules/system/database/migrations/2015_10_01_000018_Db_FailedJobs.php
+++ b/modules/system/database/migrations/2015_10_01_000018_Db_FailedJobs.php
@@ -1,12 +1,13 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbFailedJobs extends Migration
 {
     public function up()
     {
-        Schema::create('failed_jobs', function ($table) {
+        Schema::create('failed_jobs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->text('connection');

--- a/modules/system/database/migrations/2016_10_01_000019_Db_System_Plugin_History_Detail_Text.php
+++ b/modules/system/database/migrations/2016_10_01_000019_Db_System_Plugin_History_Detail_Text.php
@@ -1,19 +1,20 @@
 <?php
 
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class DbSystemPluginHistoryDetailText extends Migration
 {
     public function up()
     {
-        Schema::table('system_plugin_history', function ($table) {
+        Schema::table('system_plugin_history', function (Blueprint $table) {
             $table->text('detail')->nullable()->change();
         });
     }
 
     public function down()
     {
-        Schema::table('system_plugin_history', function ($table) {
+        Schema::table('system_plugin_history', function (Blueprint $table) {
             $table->string('detail')->nullable()->change();
         });
     }

--- a/modules/system/database/migrations/2016_10_01_000020_Db_System_Timestamp_Fix.php
+++ b/modules/system/database/migrations/2016_10_01_000020_Db_System_Timestamp_Fix.php
@@ -1,0 +1,40 @@
+<?php
+
+use October\Rain\Database\Updates\Migration;
+
+class DbSystemTimestampFix extends Migration
+{
+    protected $coreTables = [
+        'deferred_bindings',
+        'failed_jobs' => 'failed_at',
+        'system_files',
+        'system_event_logs',
+        'system_mail_layouts',
+        'system_mail_templates',
+        'system_plugin_history' => 'created_at',
+        'system_plugin_versions' => 'created_at',
+        'system_request_logs',
+        'system_revisions',
+    ];
+
+    public function up()
+    {
+        // Disable all special modes such as NO_ZERO_DATE to prevent any
+        // errors from MySQL before we can update the timestamp columns.
+        Db::statement("SET @@SQL_MODE=''");
+
+        foreach ($this->coreTables as $table => $columns) {
+            if (is_int($table)) {
+                $table = $columns;
+                $columns = ['created_at', 'updated_at'];
+            }
+
+            DbDongle::convertTimestamps($table, $columns);
+        }
+    }
+
+    public function down()
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
Updates Schema alias to use our own facade and fixes existing migrations to specify our own Blueprint and specify `nullable()` where applicable. Finally adds new migrations to convert all the existing tables' `timestamp` fields to `NULL DEFAULT NULL`.

Requires octobercms/library#212 (travis won't pass unless it's merged first)

Fixes #1667 and #1619