### PR TITLE
Fix close button color modal headers and repeaters

### DIFF
--- a/modules/system/assets/ui/less/popup.less
+++ b/modules/system/assets/ui/less/popup.less
@@ -46,13 +46,14 @@
     .border-radius(2px);
     border: none;
     background: @color-popup-content-bg;
-    .close {color: #fff;}
+    .close {color: #000;}
 }
 
 .modal-header {
     background: @color-popup-header-bg;
     color: @color-popup-header-text;
     border: none;
+    .close {color: #000;}
 
     h4 {
         font-weight: 600;


### PR DESCRIPTION
The "close" and "delete" buttons in modal popups and repeaters inside modal popups was nigh invisible on a light background. This fixes #1635.

