### PR TITLE
Fix var name typo in FilterWidget javascript

### DIFF
--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -406,7 +406,7 @@
             return defaultValue
         }
 
-        return $.oc.lang.get(name, defaultValue)
+        return $.oc.lang.get(key, defaultValue)
     }
 
 


### PR DESCRIPTION
`name` should be `key`