### PR TITLE
Allow ajax framework to handle File download response 

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -24,6 +24,7 @@ use October\Rain\Exception\ApplicationException;
 use October\Rain\Extension\Extendable;
 use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 /**
  * The Backend base controller class, used by Backend controllers.
@@ -442,6 +443,13 @@ class Controller extends Extendable
                  */
                 if ($result instanceof RedirectResponse) {
                     $responseContents['X_OCTOBER_REDIRECT'] = $result->getTargetUrl();
+                }
+                /**
+                 * If the handler returned File response,
+                 * return as it is.
+                 */
+                elseif ($result instanceof BinaryFileResponse) {
+                    return $result;
                 }
                 /*
                  * No redirect is used, look for any flash messages

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -29,6 +29,7 @@ use October\Rain\Exception\ValidationException;
 use October\Rain\Exception\ApplicationException;
 use October\Rain\Parse\Bracket as TextParser;
 use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 /**
  * The CMS controller class.
@@ -654,6 +655,13 @@ class Controller
                 if ($result instanceof RedirectResponse) {
                     $responseContents['X_OCTOBER_REDIRECT'] = $result->getTargetUrl();
                 }
+                /**
+                 * If the handler returned File response,
+                 * return as it is.
+                 */
+                elseif ($result instanceof BinaryFileResponse) {
+                    return $result;
+                }
 
                 return Response::make($responseContents, $this->statusCode);
             }
@@ -862,7 +870,7 @@ class Controller
             foreach ($partial->settings['components'] as $component => $properties) {
                 // Do not inject the viewBag component to the environment.
                 // Not sure if they're needed there by the requirements,
-                // but there were problems with array-typed properties used by Static Pages 
+                // but there were problems with array-typed properties used by Static Pages
                 // snippets and setComponentPropertiesFromParams(). --ab
                 if ($component == 'viewBag')
                     continue;

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -214,6 +214,47 @@ if (window.jQuery === undefined)
                     }, 0)
                 })
 
+                /**
+                 * Handle download
+                 */
+                var disposition = jqXHR.getResponseHeader('Content-Disposition');
+                if (disposition && disposition.indexOf('attachment') !== -1) {
+                    var filename = "download";
+                    var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+                    var matches = filenameRegex.exec(disposition);
+                    if (matches != null && matches[1])
+                        filename = matches[1].replace(/['"]/g, '');
+
+                    var type = jqXHR.getResponseHeader('Content-Type');
+
+                    var blob = new Blob([data], { type: type });
+                    if (typeof window.navigator.msSaveBlob !== 'undefined') {
+                        // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
+                        window.navigator.msSaveBlob(blob, filename);
+                    } else {
+                        var URL = window.URL || window.webkitURL;
+                        var downloadUrl = URL.createObjectURL(blob);
+
+                        if (filename) {
+                            // use HTML5 a[download] attribute to specify filename
+                            var a = document.createElement("a");
+                            // safari doesn't support this yet
+                            if (typeof a.download === 'undefined') {
+                                window.location = downloadUrl;
+                            } else {
+                                a.href = downloadUrl;
+                                a.download = filename;
+                                document.body.appendChild(a);
+                                a.click();
+                            }
+                        } else {
+                            window.location = downloadUrl;
+                        }
+
+                        setTimeout(function () { URL.revokeObjectURL(downloadUrl); }, 100); // cleanup
+                    }
+                }
+
                 /*
                  * Handle redirect
                  */


### PR DESCRIPTION
This allow the convenience of returning `response()->download('file.txt')` in Backend controller and Component during AJAX request, and have the client initiates file download.

Credit to this thread on Javascript part: http://stackoverflow.com/questions/16086162/handle-file-download-from-ajax-post

The checking can be pulled up a bit higher in the `execAjaxHandlers` since no partials will be pushed back to client as part of response.

Usage example:

```
// CMS page
<button type="button"
    class="btn btn-primary"
    data-request="demoTodo::onExportList">
    Export Todo List
</button>

// Todo Component
public function onExportList()
{
    return response()->download('path_to_todo_file.csv');
}
```
