### PR TITLE
Improved list date / daterange filter implementation

### DIFF
--- a/modules/backend/widgets/filter/partials/_scope_date.htm
+++ b/modules/backend/widgets/filter/partials/_scope_date.htm
@@ -1,14 +1,14 @@
 <!-- Date scope -->
 <a
-    class="filter-scope-date <?= $scope->value ? 'active' : '' ?>"
+    class="filter-scope-date <?= isset($date) ? 'active' : '' ?>"
     href="javascript:;"
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
-        'date' => $scope->value && $scope->value instanceof \Carbon\Carbon ? $scope->value->format('Y-m-d') : null,
+        'date' => $date,
         'minDate' => $scope->minDate ? $scope->minDate : '2000-01-01' ,
         'maxDate' => $scope->maxDate ? $scope->maxDate : '2099-12-31',
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
-    <span class="filter-setting"><?= $scope->value && $scope->value instanceof \Carbon\Carbon ? $scope->value->format('Y-m-d') : e(trans('backend::lang.filter.date_all')) ?></span>
+    <span class="filter-setting"><?= isset($dateStr) ? $dateStr : e(trans('backend::lang.filter.date_all')) ?></span>
 </a>

--- a/modules/backend/widgets/filter/partials/_scope_daterange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_daterange.htm
@@ -1,14 +1,14 @@
 <!-- Date Range scope -->
 <a
-    class="filter-scope-date range <?= $scope->value ? 'active' : '' ?>"
+    class="filter-scope-date range <?= isset($after) && isset($before) ? 'active' : '' ?>"
     href="javascript:;"
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
-        'dates' => $scope->value && is_array($scope->value) ? array_map(function($value) { return $value && $value instanceof \Carbon\Carbon ? $value->format('Y-m-d') : null; }, $scope->value) : null,
+        'dates' => isset($after) && isset($before) ? [$after, $before] : null,
         'minDate' => $scope->minDate ? $scope->minDate : '2000-01-01',
         'maxDate' => $scope->maxDate ? $scope->maxDate : '2099-12-31',
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
-    <span class="filter-setting"><?= $scope->value && is_array($scope->value) ? join(' → ', array_map(function($value) { return $value && $value instanceof \Carbon\Carbon ? $value->format('Y-m-d') : null; }, $scope->value)) : e(trans('backend::lang.filter.date_all')) ?></span>
+    <span class="filter-setting"><?= isset($afterStr) && isset($beforeStr) ? ($afterStr . ' → ' . $beforeStr) : e(trans('backend::lang.filter.date_all')) ?></span>
 </a>

--- a/modules/backend/widgets/filter/partials/_scope_daterange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_daterange.htm
@@ -4,11 +4,11 @@
     href="javascript:;"
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
-        'dates' => $scope->value && is_array($scope->value) ? array_map(function($value) { return $value instanceof \Carbon\Carbon ? $value->format('Y-m-d') : null; }, $scope->value) : null,
+        'dates' => $scope->value && is_array($scope->value) ? array_map(function($value) { return $value && $value instanceof \Carbon\Carbon ? $value->format('Y-m-d') : null; }, $scope->value) : null,
         'minDate' => $scope->minDate ? $scope->minDate : '2000-01-01',
         'maxDate' => $scope->maxDate ? $scope->maxDate : '2099-12-31',
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
-    <span class="filter-setting"><?= $scope->value && is_array($scope->value) ? join(' → ', array_map(function($value) { return $value instanceof \Carbon\Carbon ? $value->format('Y-m-d') : null; }, $scope->value)) : e(trans('backend::lang.filter.date_all')) ?></span>
+    <span class="filter-setting"><?= $scope->value && is_array($scope->value) ? join(' → ', array_map(function($value) { return $value && $value instanceof \Carbon\Carbon ? $value->format('Y-m-d') : null; }, $scope->value)) : e(trans('backend::lang.filter.date_all')) ?></span>
 </a>

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -121,7 +121,7 @@
                                 </div>                                                                                  \
                             </div>                                                                                      \
                             <div class="filter-buttons">                                                                \
-                                <button class="btn btn-block btn-secondary" data-trigger="clear">                         \
+                                <button class="btn btn-block btn-secondary" data-trigger="clear">                       \
                                     {{ reset_button_text }}                                                             \
                                 </button>                                                                               \
                             </div>                                                                                      \
@@ -138,7 +138,7 @@
         return '                                                                                                        \
                 <form>                                                                                                  \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
-                    <div id="controlFilterPopover" class="control-filter-popover control-filter-date-popover">          \
+                    <div id="controlFilterPopover" class="control-filter-popover control-filter-date-popover --range">  \
                         <div class="filter-search loading-indicator-container size-input-text">                         \
                             <div class="field-datepicker">                                                              \
                                 <div class="input-with-icon right-align">                                               \
@@ -168,7 +168,7 @@
                                 <button class="btn btn-block btn-primary oc-icon-search" data-trigger="filter">         \
                                     {{ filter_button_text }}                                                            \
                                 </button>                                                                               \
-                                <button class="btn btn-block btn-secondary" data-trigger="clear">                         \
+                                <button class="btn btn-block btn-secondary" data-trigger="clear">                       \
                                     {{ reset_button_text }}                                                             \
                                 </button>                                                                               \
                             </div>                                                                                      \

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -288,14 +288,20 @@
     FilterWidget.prototype.updateScopeDateSetting = function ($scope, dates) {
         var self = this,
             $setting = $scope.find('.filter-setting'),
-            dateFormat = self.getDateFormat()
+            dateFormat = self.getDateFormat(),
+            dateRegex =/\d{4}-\d{2}-\d{2}/,
+            reset = false
 
-        if (dates && dates.length) {
+        if (dates && dates.length && dates[0].match(dateRegex)) {
             if (dates.length > 1) {
-                var after = moment(dates[0], 'YYYY-MM-DD').format(dateFormat),
-                    before = moment(dates[1], 'YYYY-MM-DD').format(dateFormat);
+                if(dates[1].match(dateRegex)) {
+                    var after = moment(dates[0], 'YYYY-MM-DD').format(dateFormat),
+                        before = moment(dates[1], 'YYYY-MM-DD').format(dateFormat);
 
-                $setting.text(after + ' → ' + before)
+                    $setting.text(after + ' → ' + before)
+                } else {
+                    reset = true
+                }
             }
             else {
                 $setting.text(moment(dates[0], 'YYYY-MM-DD').format(dateFormat))
@@ -304,6 +310,10 @@
             $scope.addClass('active')
         }
         else {
+            reset = true
+        }
+
+        if(reset) {
             $setting.text(this.getLang('filter.dates.all', 'all'));
             $scope.removeClass('active')
         }

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -165,7 +165,7 @@
                                 </div>                                                                                  \
                             </div>                                                                                      \
                             <div class="filter-buttons">                                                                \
-                                <button class="btn btn-block btn-primary oc-icon-search" data-trigger="filter">         \
+                                <button class="btn btn-block btn-primary" data-trigger="filter">                        \
                                     {{ filter_button_text }}                                                            \
                                 </button>                                                                               \
                                 <button class="btn btn-block btn-secondary" data-trigger="clear">                       \
@@ -184,8 +184,8 @@
             data = this.scopeValues[scopeName]
 
         data = $.extend({}, data, {
-            filter_button_text: $.oc.lang.get('filter.dates.filter_button_text'),
-            reset_button_text: $.oc.lang.get('filter.dates.reset_button_text'),
+            filter_button_text: this.getLang('filter.dates.filter_button_text'),
+            reset_button_text: this.getLang('filter.dates.reset_button_text'),
             date_placeholder: this.getLang('filter.dates.date_placeholder', 'Date')
         })
 
@@ -195,7 +195,7 @@
         $scope.data('oc.popover', null)
 
         $scope.ocPopover({
-            content: Mustache.render(self.getPopoverDateTemplate(), data),
+            content: Mustache.render(this.getPopoverDateTemplate(), data),
             modal: false,
             highlightModalTarget: true,
             closeOnPageClick: true,
@@ -212,8 +212,8 @@
             data = this.scopeValues[scopeName]
 
         data = $.extend({}, data, {
-            filter_button_text: $.oc.lang.get('filter.dates.filter_button_text'),
-            reset_button_text: $.oc.lang.get('filter.dates.reset_button_text'),
+            filter_button_text: this.getLang('filter.dates.filter_button_text'),
+            reset_button_text: this.getLang('filter.dates.reset_button_text'),
             after_placeholder: this.getLang('filter.dates.after_placeholder', 'After'),
             before_placeholder: this.getLang('filter.dates.before_placeholder', 'Before')
         })
@@ -224,7 +224,7 @@
         $scope.data('oc.popover', null)
 
         $scope.ocPopover({
-            content: Mustache.render(self.getPopoverRangeTemplate(), data),
+            content: Mustache.render(this.getPopoverRangeTemplate(), data),
             modal: false,
             highlightModalTarget: true,
             closeOnPageClick: true,
@@ -237,9 +237,9 @@
 
     FilterWidget.prototype.initDatePickers = function (isRange) {
         var self = this,
-            scopeData = self.$activeScope.data('scope-data'),
+            scopeData = this.$activeScope.data('scope-data'),
             $inputs = $('.field-datepicker input', '#controlFilterPopover'),
-            data = self.scopeValues[self.activeScopeName]
+            data = this.scopeValues[this.activeScopeName]
 
         if (!data) {
             data = {
@@ -256,11 +256,11 @@
                     yearRange: 10,
                     setDefaultDate: '' !== defaultValue ? defaultValue.toDate() : '',
                     format: self.getDateFormat(),
-                    i18n: $.oc.lang.get('datepicker')
+                    i18n: self.getLang('datepicker')
                 }
 
             if (0 <= index && index < data.dates.length) {
-                defaultValue = moment(data.dates[index], 'YYYY-MM-DD')
+                defaultValue = moment.tz(data.dates[index], self.appTimezone).tz(self.timezone)
             }
 
             if (!isRange) {
@@ -286,17 +286,16 @@
     }
 
     FilterWidget.prototype.updateScopeDateSetting = function ($scope, dates) {
-        var self = this,
-            $setting = $scope.find('.filter-setting'),
-            dateFormat = self.getDateFormat(),
-            dateRegex =/\d{4}-\d{2}-\d{2}/,
+        var $setting = $scope.find('.filter-setting'),
+            dateFormat = this.getDateFormat(),
+            dateRegex =/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/,
             reset = false
 
         if (dates && dates.length && dates[0].match(dateRegex)) {
             if (dates.length > 1) {
                 if(dates[1].match(dateRegex)) {
-                    var after = moment(dates[0], 'YYYY-MM-DD').format(dateFormat),
-                        before = moment(dates[1], 'YYYY-MM-DD').format(dateFormat);
+                    var after = moment.tz(dates[0], this.appTimezone).tz(this.timezone).format(dateFormat),
+                        before = moment.tz(dates[1], this.appTimezone).tz(this.timezone).format(dateFormat);
 
                     $setting.text(after + ' → ' + before)
                 } else {
@@ -304,7 +303,7 @@
                 }
             }
             else {
-                $setting.text(moment(dates[0], 'YYYY-MM-DD').format(dateFormat))
+                $setting.text(moment.tz(dates[0], this.appTimezone).tz(this.timezone).format(dateFormat))
             }
 
             $scope.addClass('active')
@@ -325,16 +324,26 @@
 
         if (!isReset) {
             $('.field-datepicker input', '#controlFilterPopover').each(function (index, datepicker) {
-                dates.push($(datepicker).data('pikaday').toString('YYYY-MM-DD'))
+                var date = $(datepicker).data('pikaday').toString('YYYY-MM-DD');
+
+                if (index === 0) {
+                    date += '00:00:00'
+                } else if (index === 1) {
+                    date += '23:59:59'
+                }
+
+                dates.push(moment.tz(date, self.timezone)
+                    .tz(self.appTimezone)
+                    .format('YYYY-MM-DD HH:mm:ss'))
             })
         }
 
-        self.updateScopeDateSetting(self.$activeScope, dates);
-        self.scopeValues[self.activeScopeName] = {
+        this.updateScopeDateSetting(this.$activeScope, dates);
+        this.scopeValues[this.activeScopeName] = {
             dates: dates
         }
-        self.isActiveScopeDirty = true;
-        self.$activeScope.data('oc.popover').hide()
+        this.isActiveScopeDirty = true;
+        this.$activeScope.data('oc.popover').hide()
     }
 
     FilterWidget.prototype.getDateFormat = function () {

--- a/modules/system/assets/ui/less/filter.less
+++ b/modules/system/assets/ui/less/filter.less
@@ -219,10 +219,29 @@
     &.control-filter-date-popover {
         min-width: 190px;
 
-        .filter-buttons .btn {
-            border-radius: 0;
-            text-align: center;
+        .filter-buttons {
             margin: 0;
+            padding: 0;
+
+            &:after {
+                content: "";
+                display: block;
+                clear: both;
+            }
+
+            .btn {
+                float: left;
+                width: 100%;
+                margin: 0;
+                border-radius: 0;
+                text-align: center;
+            }
+        }
+
+        &.--range {
+            .filter-buttons .btn {
+                width: 50%;
+            }
         }
     }
 }


### PR DESCRIPTION
Follow up of #1651 

Let me know if it needs more improvements.

#### Continuity requirement

Popup buttons are streamlined : 
![image](https://cloud.githubusercontent.com/assets/1851314/15265673/5e638c0c-198b-11e6-9ecc-7c0239710e75.png)

#### Timezone conversion

The displayed date on the PHP side are now displayed with Backend::dateTime format alias dateMin
The client side code converts the datepickers value to app timezone before submitting.

User selection is converted from 00:00:00 / 23:59:59 in the backend timezone (user timezone) to the application timezone (database timezone).

For example, if the app timezone is UTC and the backend timezone UTC+4 then selecting _after_ date `2016-05-16` will send to the server `2016-05-15 20:00:00` and _before_ date `2016-05-16` will send to the server `2016-05-16 19:59:59`.

#### Nicer syntax

New placeholders are populated in order to allow simpler conditions writing : 
- for _date_ and _daterange_ types : 
  * `after` holds the full datetime _Y-m-d HH:mm:ss_  (00:00:00 in the backend timezone converted to app timezone)
  * `before` holds the full datetime _Y-m-d HH:mm:ss_  (23:59:59 in the backend timezone converted to app timezone)
- for _date_ type only : 
  * `filtered` holds the short date _Y-m-d_  (keeping the same name as other filter widgets)
- for _daterange_ type only : 
  * `afterDate` holds the short date _Y-m-d_
  * `beforeDate` holds the short date _Y-m-d_

Conditions for timestamp type columns can be written like this : 

```
    # Filter type
    type: date

    # Scope Conditions (match against a timestamp column)
    conditions: created_at >= ':after' AND created_at <= ':before'
```


```
    # Filter type
    type: date

    # Scope Conditions (match against a timestamp column)
    conditions: created_at >= ':after' AND created_at <= ':before'
```

Conditions for date type columns can be written like this : 


```
    # Filter type
    type: date

    # Scope Conditions (match against a date column)
    conditions: birthday = ':filtered'
```


```
    # Filter type
    type: daterange

    # Scope Conditions (match against a date column)
    conditions: birthday >= ':afterDate' AND birthday <= ':beforeDate'
```

#### Scope queries

Date type scoped query is passed a `Carbon` instance that correspond to _Y-m-d 00:00:00_ in the backend timezone but converted to the app timezone. See above in the timezone conversion.

        scope: FilterDate

```

    public function scopeFilterDate($query, $date)
    {
        return $query
            ->where('published_at', '>=', $date)
            ->where('published_at', '<=', $date->copy()->addDay()->addMinutes(-1));
    }

```

Daterange type scoped query is passed two `Carbon` instances that correspond to _Y-m-d 00:00:00_ and _Y-m-d 23:59:59_ in the backend timezone but converted to the app timezone. See above in the timezone conversion.

    scope: FilterDateRange

```

    public function scopeFilterDateRange($query, $after, $before)
    {
        return $query
            ->where('published_at', '>=', $after)
            ->where('published_at', '<=', $before);
    }

```

#### Bugfixes

- Submitting null dates is now working (two name refactoring were missing from date(range)picker to date(range))