### PR TITLE
Fix List Date Filter error thrown when `$date` is not set

### DIFF
--- a/modules/backend/widgets/filter/partials/_scope_date.htm
+++ b/modules/backend/widgets/filter/partials/_scope_date.htm
@@ -4,7 +4,7 @@
     href="javascript:;"
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
-        'date' => $date,
+        'date' => isset($date) ? $date : null,
         'minDate' => $scope->minDate ? $scope->minDate : '2000-01-01' ,
         'maxDate' => $scope->maxDate ? $scope->maxDate : '2099-12-31',
     ]))


### PR DESCRIPTION
Sorry, a test was missing in the PR branch #2008 to prevent an error when no date was sent in the partial parameters.