### PR TITLE
Fix 2006 - Allow usage of namespace alias in the code section a a CMS page

### DIFF
--- a/modules/cms/classes/CodeParser.php
+++ b/modules/cms/classes/CodeParser.php
@@ -91,7 +91,7 @@ class CodeParser
         $body = preg_replace('/^\s*function/m', 'public function', $body);
 
         $codeNamespaces = [];
-        $pattern = '/(use\s+[a-z0-9_\\\\]+;\n?)/mi';
+        $pattern = '/(use\s+[a-z0-9_\\\\]+(\s+as\s+[a-z0-9_]+)?;\n?)/mi';
         preg_match_all($pattern, $body, $namespaces);
         $body = preg_replace($pattern, '', $body);
 

--- a/tests/fixtures/cms/reference/namespaces-aliases.php.stub
+++ b/tests/fixtures/cms/reference/namespaces-aliases.php.stub
@@ -1,0 +1,9 @@
+<?php 
+use Cms\Classes\Theme as MyTheme;
+use Cms\Classes\Router as MyRouter;
+class {className} extends \Cms\Classes\PageCode
+{
+public function onStart() {
+    $this['pageStartVar'] = 3;
+}
+}

--- a/tests/fixtures/themes/test/pages/code-namespaces-aliases.htm
+++ b/tests/fixtures/themes/test/pages/code-namespaces-aliases.htm
@@ -1,0 +1,13 @@
+url = "/code-namespaces"
+==
+<?php
+
+use Cms\Classes\Theme as MyTheme;
+use Cms\Classes\Router as MyRouter;
+
+function onStart() {
+    $this['pageStartVar'] = 3;
+}
+?>
+==
+<p>Page</p>

--- a/tests/unit/cms/classes/CmsObjectQueryTest.php
+++ b/tests/unit/cms/classes/CmsObjectQueryTest.php
@@ -65,6 +65,7 @@ class CmsObjectQueryTest extends TestCase
             "blog-archive",
             "blog-post",
             "code-namespaces",
+            "code-namespaces-aliases",
             "component-custom-render",
             "component-partial",
             "component-partial-nesting",

--- a/tests/unit/cms/classes/CodeParserTest.php
+++ b/tests/unit/cms/classes/CodeParserTest.php
@@ -260,6 +260,35 @@ class CodeParserTest extends TestCase
         $this->assertEquals($referenceContents, $this->getContents($info['filePath']));
     }
 
+    public function testNamespacesAliases()
+    {
+        $theme = Theme::load('test');
+
+        $page = Page::load($theme, 'code-namespaces-aliases.htm');
+        $this->assertNotEmpty($page);
+
+        $parser = new CodeParser($page);
+        $info = $parser->parse();
+
+        $this->assertInternalType('array', $info);
+        $this->assertArrayHasKey('filePath', $info);
+        $this->assertArrayHasKey('className', $info);
+        $this->assertArrayHasKey('source', $info);
+
+        $this->assertFileExists($info['filePath']);
+        $controller = new Controller($theme);
+        $obj = $parser->source($page, null, $controller);
+        $this->assertInstanceOf('\Cms\Classes\PageCode', $obj);
+
+        $referenceFilePath = base_path().'/tests/fixtures/cms/reference/namespaces-aliases.php.stub';
+        $this->assertFileExists($referenceFilePath);
+        $referenceContents = $this->getContents($referenceFilePath);
+
+        $referenceContents = str_replace('{className}', $info['className'], $referenceContents);
+
+        $this->assertEquals($referenceContents, $this->getContents($info['filePath']));
+    }
+
    //
    // Helpers
    //


### PR DESCRIPTION
Added the sub-pattern `(\s+as\s+[a-z0-9_]+)?` to match `as MyAliasName`. Bundled with a unit test.