### PR TITLE
Fix advanced import error  Class StreamFilterTranscode not found 

### DIFF
--- a/modules/backend/behaviors/importexportcontroller/TranscodeFilter.php
+++ b/modules/backend/behaviors/importexportcontroller/TranscodeFilter.php
@@ -2,7 +2,7 @@
 
 use php_user_filter;
 
-stream_filter_register(StreamFilterTranscode::FILTER_NAME . "*", StreamFilterTranscode::class);
+stream_filter_register(TranscodeFilter::FILTER_NAME . "*", TranscodeFilter::class);
 
 /**
  * Transcode stream filter.


### PR DESCRIPTION
Updated the global stream registration to match the new name (changed from `StreamFilterTranscode ` to `TranscodeFilter ` when merging the PR) and fix the error when using the advanced import mode.