### PR TITLE
Fix plugin management page - Ref #907

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -166,12 +166,24 @@ class PluginManager
             $pluginId = $this->getIdentifier($plugin);
         }
 
-        if (!$plugin || $plugin->disabled) {
+        if (!$plugin) {
             return;
         }
 
         $pluginPath = $this->getPluginPath($plugin);
         $pluginNamespace = strtolower($pluginId);
+
+        /*
+         * Register language namespaces
+         */
+        $langPath = $pluginPath . '/lang';
+        if (File::isDirectory($langPath)) {
+            Lang::addNamespace($pluginNamespace, $langPath);
+        }
+
+        if ($plugin->disabled) {
+            return;
+        }
 
         /*
          * Register plugin class autoloaders
@@ -183,14 +195,6 @@ class PluginManager
 
         if (!self::$noInit || $plugin->elevated) {
             $plugin->register();
-        }
-
-        /*
-         * Register language namespaces
-         */
-        $langPath = $pluginPath . '/lang';
-        if (File::isDirectory($langPath)) {
-            Lang::addNamespace($pluginNamespace, $langPath);
         }
 
         /*

--- a/modules/system/controllers/updates/_list_manage_toolbar.htm
+++ b/modules/system/controllers/updates/_list_manage_toolbar.htm
@@ -44,6 +44,7 @@
             data-trigger-action="enable"
             data-trigger=".control-list input[type=checkbox]"
             data-trigger-condition="checked"
+            data-request-success="$(this).closest('.btn-group').find('button').prop('disabled', true)"
             data-stripe-load-indicator>
             <?= e(trans('system::lang.plugins.remove')) ?>
         </button>


### PR DESCRIPTION
#### 1 - When a user deletes a plugin the button should be disabled on success

Use the `data-request-success` handler to set the disabled state on the buttons.

#### 2 - When a plugin is disabled the translated names should be presented instead of the raw translation key

Change the plugin manager to load only the languages files of a plugin if it is disabled.

Fixes #907 