### PR TITLE
Improved exception beautifier plugin

### DIFF
--- a/modules/system/assets/css/eventlogs/exception-beautifier.css
+++ b/modules/system/assets/css/eventlogs/exception-beautifier.css
@@ -2,28 +2,38 @@
     width: auto !important;
 }
 
-.plugin-exception-beautifier .beautifier-name {
-    display: block;
-    font-weight: bold;
-    font-size: 1.2em;
-}
-
 .plugin-exception-beautifier .beautifier-message {
     display: block;
     padding: 15px 0;
     font-size: 1.1em;
 }
 
-.plugin-exception-beautifier .beautifier-stacktrace-title {
+.plugin-exception-beautifier .beautifier-toggle-stacktrace {
+    background: #D0D9DD;
+    color: #2b3e50;
+    text-decoration: none;
     display: block;
-    margin-top: 15px;
-    font-weight: bold;
+    padding: 20px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+}
+
+.plugin-exception-beautifier .beautifier-toggle-stacktrace.--hidden {
+    background: #ecf0f1;
+    color: #2b3e50;
+}
+
+.plugin-exception-beautifier .beautifier-toggle-stacktrace:hover,
+.plugin-exception-beautifier .beautifier-toggle-stacktrace.--hidden:hover {
+    background: #0181b9;
+    color: white;
 }
 
 .plugin-exception-beautifier .beautifier-stacktrace-line {
     display: block;
-    white-space: nowrap;
     padding: 10px 0;
+    white-space: nowrap;
 }
 
 .plugin-exception-beautifier .beautifier-stacktrace-line:nth-child(even) {
@@ -53,6 +63,7 @@
 
 .plugin-exception-beautifier .beautifier-file {
     color: #204bff;
+    white-space: nowrap;
 }
 
 .plugin-exception-beautifier .beautifier-line-number {

--- a/modules/system/assets/js/eventlogs/exception-beautifier.links.js
+++ b/modules/system/assets/js/eventlogs/exception-beautifier.links.js
@@ -22,7 +22,7 @@
             exceptionBeautfier.initEditorPopup()
         },
         onParse: function (exceptionBeautfier) {
-            exceptionBeautfier.$el.on('click', 'a', function () {
+            exceptionBeautfier.$el.on('click', 'a[data-href]', function () {
                 exceptionBeautfier.openWithEditor($(this).data('href'))
             })
         }
@@ -33,7 +33,7 @@
             var title = $.oc.lang.get('eventlog.editor.title'),
                 description = $.oc.lang.get('eventlog.editor.description'),
                 openWith = $.oc.lang.get('eventlog.editor.openWith'),
-                rememberChoice = $.oc.lang.get('eventlog.editor.rememberChoice'),
+                rememberChoice = $.oc.lang.get('eventlog.editor.remember_choice'),
                 open = $.oc.lang.get('eventlog.editor.open'),
                 cancel = $.oc.lang.get('eventlog.editor.cancel'),
                 popup = $('                                                                                            \
@@ -120,7 +120,7 @@
     }
 
     ExceptionBeautifier.prototype.rewritePath = function (path) {
-        return path
+        return path.replace(/\\/g, '/')
     }
 
     ExceptionBeautifier.prototype.initCustomSelect = function (select) {

--- a/modules/system/controllers/eventlogs/config_form.yaml
+++ b/modules/system/controllers/eventlogs/config_form.yaml
@@ -16,4 +16,4 @@ defaultRedirect: system/eventlogs
 
 # Preview page
 preview:
-    title: Event
+    title: system::lang.event_log.preview_title

--- a/modules/system/lang/en/client.php
+++ b/modules/system/lang/en/client.php
@@ -74,6 +74,12 @@ return [
     ],
 
     'eventlog' => [
+        'show_stacktrace' => 'Show the stacktrace',
+        'hide_stacktrace' => 'Hide the stacktrace',
+        'tabs' => [
+            'formatted' => 'Formatted',
+            'raw' => 'Raw',
+        ],
         'editor' => [
             'title' => 'Select the source code editor to use',
             'description' => 'Your OS environnement must be configured to listen to one of these URL schemes.',

--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -310,7 +310,8 @@ return [
         'id_label' => 'Event ID',
         'created_at' => 'Date & Time',
         'message' => 'Message',
-        'level' => 'Level'
+        'level' => 'Level',
+        'preview_title' => 'Event'
     ],
     'request_log' => [
         'hint' => 'This log displays a list of browser requests that may require attention. For example, if a visitor opens a CMS page that cannot be found, a record is created with the status code 404.',

--- a/modules/system/lang/fr/client.php
+++ b/modules/system/lang/fr/client.php
@@ -77,13 +77,19 @@ return [
     ],
 
     'eventlog' => [
+        'show_stacktrace' => 'Afficher la pile d’exécution',
+        'hide_stacktrace' => 'Masquer la pile d’exécution',
+        'tabs' => [
+            'formatted' => 'Formaté',
+            'raw' => 'Message brut',
+        ],
         'editor' => [
             'title' => 'Sélectionnez l’éditeur de code source à utiliser',
             'description' => 'L’environnement de votre système d’exploitation doit être configuré pour ouvrir l’un des schémas d’URL ci-dessous.',
             'openWith' => 'Ouvrir avec',
-            'rememberChoice' => 'Se souvenir de la sélection pour la durée de la session dans ce navigateur',
+            'remember_choice' => 'Se souvenir de la sélection pour la durée de la session dans ce navigateur',
             'open' => 'Ouvrir',
-            'cancel' => 'Annuler',
+            'cancel' => 'Annuler'
         ],
     ]
 ];

--- a/modules/system/lang/fr/lang.php
+++ b/modules/system/lang/fr/lang.php
@@ -311,6 +311,7 @@ return [
         'created_at' => 'Date et heure',
         'message' => 'Message',
         'level' => 'Niveau',
+        'preview_title' => 'Évènement',
     ],
     'request_log' => [
         'hint' => 'Ce journal affiche une liste de requêtes potentiellement suspectes. par exemple, si un visiteur ouvre une page introuvable du CMS, une ligne avec le statut code 404 est alors créée.',


### PR DESCRIPTION
Improves the backend event preview page : 
- Keep the raw message in another tab
- Added a button to show/hide the stacktrace
- Fixes Windows paths parsing
- Translate the page title

#### Initial state
![image](https://cloud.githubusercontent.com/assets/1851314/15522974/cc34f00c-2216-11e6-824d-0db8b5140bf8.png)

#### Mouse hover
![image](https://cloud.githubusercontent.com/assets/1851314/15522984/dd0b6f32-2216-11e6-866e-8a3ef72f1063.png)

#### Deployed
![image](https://cloud.githubusercontent.com/assets/1851314/15522982/d5e39996-2216-11e6-89c1-60a8c159ab19.png)

#### Raw
![image](https://cloud.githubusercontent.com/assets/1851314/15522991/f62b8cd6-2216-11e6-95a3-7d2e357feab6.png)
