### PR TITLE
Re-apply the crop-insert selection mode after the first use

### DIFF
--- a/modules/cms/widgets/mediamanager/assets/js/mediamanager.imagecroppopup.js
+++ b/modules/cms/widgets/mediamanager/assets/js/mediamanager.imagecroppopup.js
@@ -403,6 +403,7 @@
 
         this.initRulers()
         this.initJCrop()
+        this.applySelectionMode()
     }
 
     MediaManagerImageCropPopup.prototype.onSelectionModeChanged = function() {


### PR DESCRIPTION
The crop-insert options are kept in session across requests. This fix applies the selection mode after the popup is shown to reflect the displayed options of the UI.

Fixes #2022