### PR TITLE
Added double quote for the description of the theme

### DIFF
--- a/themes/demo/theme.yaml
+++ b/themes/demo/theme.yaml
@@ -1,4 +1,4 @@
 name: Demo
-description: Demo OctoberCMS theme. Demonstrates the basic concepts of the front-end theming: layouts, pages, partials, components, content blocks, AJAX framework.
+description: "Demo OctoberCMS theme. Demonstrates the basic concepts of the front-end theming: layouts, pages, partials, components, content blocks, AJAX framework."
 author: OctoberCMS
 homepage: 'http://octobercms.com'


### PR DESCRIPTION
Because there is colon in the description, I added double quotes to it to eliminate this error in the backend's theme page:

> A colon cannot be used in an unquoted mapping value at line 2 (near "description: Demo OctoberCMS theme. Demonstrates the basic concepts of the front-end theming: layouts, pages, partials, components, content blocks, AJAX framework.").