### PR TITLE
Fix searching in non text fields under Postgres

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -343,7 +343,6 @@ class Lists extends WidgetBase
                     $columnName = isset($column->sqlSelect)
                         ? DbDongle::raw($this->parseTableName($column->sqlSelect, $table))
                         : $table . '.' . $column->valueFrom;
-                    $columnName = DbDongle::cast($columnName, 'text');
                     $relationSearchable[$column->relation][] = $columnName;
                 }
                 /*

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -308,6 +308,13 @@ class Lists extends WidgetBase
     {
         return str_replace('@', $table.'.', $sql);
     }
+    
+    protected function castForPostgres($columnName, $column){
+      if($this->model->getConnection() instanceof \Illuminate\Database\PostgresConnection  && $column->type == 'number'){
+        return 'CAST('. $columnName .' as TEXT)';
+      }
+      return $columnName;
+    }
 
     /**
      * Applies any filters to the model.
@@ -352,7 +359,7 @@ class Lists extends WidgetBase
                 else {
                     $columnName = isset($column->sqlSelect)
                         ? DbDongle::raw($this->parseTableName($column->sqlSelect, $primaryTable))
-                        : Db::getTablePrefix() . $primaryTable . '.' . $column->columnName;
+                        : $this->castForPostgres(Db::getTablePrefix() . $primaryTable . '.' . $column->columnName, $column);
 
                     $primarySearchable[] = $columnName;
                 }

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -308,13 +308,6 @@ class Lists extends WidgetBase
     {
         return str_replace('@', $table.'.', $sql);
     }
-    
-    protected function castForPostgres($columnName, $column){
-      if($this->model->getConnection() instanceof \Illuminate\Database\PostgresConnection  && $column->type == 'number'){
-        return 'CAST('. $columnName .' as TEXT)';
-      }
-      return $columnName;
-    }
 
     /**
      * Applies any filters to the model.
@@ -350,7 +343,7 @@ class Lists extends WidgetBase
                     $columnName = isset($column->sqlSelect)
                         ? DbDongle::raw($this->parseTableName($column->sqlSelect, $table))
                         : $table . '.' . $column->valueFrom;
-
+                    $columnName = DbDongle::cast($columnName, 'text');
                     $relationSearchable[$column->relation][] = $columnName;
                 }
                 /*
@@ -358,8 +351,8 @@ class Lists extends WidgetBase
                  */
                 else {
                     $columnName = isset($column->sqlSelect)
-                        ? DbDongle::raw($this->parseTableName($column->sqlSelect, $primaryTable))
-                        : $this->castForPostgres(Db::getTablePrefix() . $primaryTable . '.' . $column->columnName, $column);
+                       ? DbDongle::raw($this->parseTableName($column->sqlSelect, $primaryTable))
+                       : DbDongle::cast(Db::getTablePrefix() . $primaryTable . '.' . $column->columnName,'text');
 
                     $primarySearchable[] = $columnName;
                 }


### PR DESCRIPTION
When using postgres the List Widgets threw an error for non text fields (e.g. integer). With this fix searching for an id or in other numerical columns works.

Please let me know if my solutions suits you, I might add it for the relation columns above too. I didn't yet because I have no example and would have to create on to test it.