### PR TITLE
Removes hardcoded "Misc" settings group translation.

### DIFF
--- a/modules/system/classes/SettingsManager.php
+++ b/modules/system/classes/SettingsManager.php
@@ -124,7 +124,7 @@ class SettingsManager
          */
         $catItems = [];
         foreach ($this->items as $item) {
-            $category = $item->category ?: 'Misc';
+            $category = $item->category ?: self::CATEGORY_MISC;
             if (!isset($catItems[$category])) {
                 $catItems[$category] = [];
             }


### PR DESCRIPTION
This pull request allows to properly show "Misc" setting group in other languages.

![2016-06-12_14-25-54](https://cloud.githubusercontent.com/assets/7204866/15990872/ae5fb02a-30a9-11e6-9a62-334fe090fb84.png)