### PR TITLE
Critical bugFix in themeData.php

### DIFF
--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -207,6 +207,11 @@ class ThemeData extends Model
     public static function applyAssetVariablesToCombinerFilters($filters)
     {
         $theme = CmsTheme::getActiveTheme();
+        
+        if(!$theme){
+            return;
+        }
+        
         if (!$theme->hasCustomData()) {
             return;
         }


### PR DESCRIPTION
Additional check is added, without it there is a critical error "Call to a member function hasCustomData() on null"

![2016-06-20 16 14 11](https://cloud.githubusercontent.com/assets/4133683/16195531/b549902c-3702-11e6-8be2-66348ebe8b88.png)
