### PR TITLE
Added path

### DIFF
--- a/modules/system/console/OctoberMirror.php
+++ b/modules/system/console/OctoberMirror.php
@@ -58,6 +58,7 @@ class OctoberMirror extends Command
         'plugins/*/*/reportwidgets/*/assets',
         'plugins/*/*/reportwidgets/*/resources',
         'plugins/*/*/formwidgets/*/assets',
+        'plugins/*/*/formwidgets/*/widget/assets',
         'plugins/*/*/formwidgets/*/resources',
         'plugins/*/*/widgets/*/assets',
         'plugins/*/*/widgets/*/resources',


### PR DESCRIPTION
During creation of a mirror, symlink on assets wasn't created. Many widgets use this way. For example: https://github.com/october-widgets/hasmany
