### PR TITLE
error on saving attachment config when in pivot form of a relation

### DIFF
--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -296,6 +296,8 @@ class FileUpload extends FormWidgetBase
             $this->vars['file'] = $file;
             $this->vars['displayMode'] = $this->getDisplayMode();
             $this->vars['cssDimensions'] = $this->getCssDimensions();
+            $this->vars['relationManageId'] = post('manage_id');
+            $this->vars['relationField'] = post('_relation_field');
 
             return $this->makePartial('config_form');
         }

--- a/modules/backend/formwidgets/fileupload/partials/_config_form.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_config_form.htm
@@ -1,6 +1,8 @@
 <div class="fileupload-config-form">
     <?= Form::open() ?>
         <input type="hidden" name="file_id" value="<?= $file->id ?>" />
+        <input type="hidden" name="manage_id" value="<?= $relationManageId ?>" />
+        <input type="hidden" name="_relation_field" value="<?= $relationField ?>" />
 
         <?php if (starts_with($displayMode, 'image')): ?>
             <div class="file-upload-modal-image-header">


### PR DESCRIPTION
There is a error when you enter title and description of a attachment popup, if the attachment is put in a pivot form of a relation.

https://octobercms.com/forum/post/pivot-edit-form-and-image-upload

This is because the popup does not have manage_id and _related_field to pass back to the ajax handler once save is clicked form the popup.