### PR TITLE
asset cache fix

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -104,15 +104,16 @@ class CombineAssets
          * Register CSS filters
          */
         $this->registerFilter('css', new \Assetic\Filter\CssImportFilter);
-        $this->registerFilter(['css', 'less'], new \Assetic\Filter\CssRewriteFilter);
+        $this->registerFilter(['css', 'less', 'scss'], new \Assetic\Filter\CssRewriteFilter);
         $this->registerFilter('less', new \October\Rain\Parse\Assetic\LessCompiler);
+        $this->registerFilter('scss', new \October\Rain\Parse\Assetic\ScssCompiler);
 
         /*
          * Minification filters
          */
         if ($this->useMinify) {
             $this->registerFilter('js', new \Assetic\Filter\JSMinFilter);
-            $this->registerFilter(['css', 'less'], new \October\Rain\Parse\Assetic\StylesheetMinify);
+            $this->registerFilter(['css', 'less', 'scss'], new \October\Rain\Parse\Assetic\StylesheetMinify);
         }
 
         /*

--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -267,7 +267,7 @@ class CombineAssets
     }
 
     /**
-     * Combines asset file references of a single type to produce 
+     * Combines asset file references of a single type to produce
      * a URL reference to the combined contents.
      * @var array List of asset files.
      * @var string File extension, used for aesthetic purposes only.
@@ -313,38 +313,45 @@ class CombineAssets
      * Returns the combined contents from a prepared cache identifier.
      * @return string Combined file contents.
      */
-    protected function prepareCombiner(array $assets, $rewritePath = null)
-    {
-        /*
-         * Extensibility
-         */
-        Event::fire('cms.combiner.beforePrepare', [$this, $assets]);
+     protected function prepareCombiner(array $assets, $rewritePath = null)
+     {
+         /*
+          * Extensibility
+          */
+         Event::fire('cms.combiner.beforePrepare', [$this, $assets]);
 
-        $files = [];
-        $filesSalt = null;
-        foreach ($assets as $asset) {
-            $filters = $this->getFilters(File::extension($asset)) ?: [];
-            $path = File::symbolizePath($asset, null) ?: $this->localPath . $asset;
-            $files[] = new FileAsset($path, $filters, public_path());
-            $filesSalt .= $this->localPath . $asset;
-        }
-        $filesSalt = md5($filesSalt);
+         $files = [];
+         $filesSalt = null;
+         foreach ($assets as $asset) {
+             $filters = $this->getFilters(File::extension($asset)) ?: [];
+             $path = File::symbolizePath($asset, null) ?: $this->localPath . $asset;
+             $files[] = new FileAsset($path, $filters, public_path());
+             $filesSalt .= $this->localPath . $asset;
+         }
+         $filesSalt = md5($filesSalt);
 
-        $collection = new AssetCollection($files, [], $filesSalt);
-        $collection->setTargetPath($this->getTargetPath($rewritePath));
+         $collection = new AssetCollection($files, [], $filesSalt);
+         $collection->setTargetPath($this->getTargetPath($rewritePath));
 
-        if ($this->storagePath === null) {
-            return $collection;
-        }
+         if ($this->storagePath === null) {
+             return $collection;
+         }
 
-        if (!File::isDirectory($this->storagePath)) {
-            File::makeDirectory($this->storagePath);
-        }
+         if (!File::isDirectory($this->storagePath)) {
+             File::makeDirectory($this->storagePath);
+         }
 
-        $cache = new FilesystemCache($this->storagePath);
-        $cachedCollection = new AssetCache($collection, $cache);
-        return $cachedCollection;
-    }
+         $cache = new FilesystemCache($this->storagePath);
+
+         $cachedFiles = [];
+         foreach ($files as $file) {
+             $cachedFiles[] = new AssetCache($file, $cache);
+         }
+
+         $cachedCollection = new AssetCollection($cachedFiles, [], $filesSalt);
+         $cachedCollection->setTargetPath($this->getTargetPath($rewritePath));
+         return $cachedCollection;
+     }
 
     /**
      * Returns the URL used for accessing the combined files.


### PR DESCRIPTION
Hi,
this changes will make it possible to use a `HashableInterface` for the cache generation.

So you can make a hash with the modification dates from the included files.

And than changes in the included files will be displayed without saving the parent asset.