### PR TITLE
Only public folder should be mirrored

### DIFF
--- a/modules/system/console/OctoberMirror.php
+++ b/modules/system/console/OctoberMirror.php
@@ -34,7 +34,7 @@ class OctoberMirror extends Command
     ];
 
     protected $directories = [
-        'storage/app/uploads',
+        'storage/app/uploads/public',
         'storage/app/media',
         'storage/temp/public',
     ];


### PR DESCRIPTION
`storage/app/uploads` may also contain private data. Only `storage/app/uploads/public` is public