### PR TITLE
Show 404 page when directly visiting /error

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -194,7 +194,7 @@ class Controller
         /*
          * If the page was not found, render the 404 page - either provided by the theme or the built-in one.
          */
-        if (!$page || $url === '404') {
+        if (!$page || $url == '404' || $url == 'error') {
             if (!Request::ajax()) {
                 $this->setStatusCode(404);
             }


### PR DESCRIPTION
Currently when visiting /error, the actual 500 error page is shown, with status code 200. Since the /error url is a hardcoded error page, it should not be visited directly, and should instead show the 404 page with 404 status code. #1723 
