### PR TITLE
Pass the router reference on beforeRoute event

### DIFF
--- a/modules/cms/classes/Router.php
+++ b/modules/cms/classes/Router.php
@@ -80,7 +80,7 @@ class Router
         $this->url = $url;
         $url = RouterHelper::normalizeUrl($url);
 
-        $apiResult = Event::fire('cms.router.beforeRoute', [$url], true);
+        $apiResult = Event::fire('cms.router.beforeRoute', [$url, $this], true);
         if ($apiResult !== null) {
             return $apiResult;
         }


### PR DESCRIPTION
I need to access the ``Router`` in the ``cms.router.beforeRoute`` event and this was the easiest change to enable that.

If there is any other way to access it please let me know.