### PR TITLE
Add 'normal' field preset type

### DIFF
--- a/modules/system/assets/ui/js/input.preset.js
+++ b/modules/system/assets/ui/js/input.preset.js
@@ -244,7 +244,10 @@
     }
 
     InputPreset.prototype.formatValue = function() {
-        if (this.options.inputPresetType == 'namespace') {
+        if (this.options.inputPresetType == 'exact') {
+            return this.$src.val();
+        }
+        else if (this.options.inputPresetType == 'namespace') {
             return this.formatNamespace()
         }
 

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3883,7 +3883,8 @@ $el.val(prefix+self.formatValue())})
 this.$el.on('change',function(){self.cancelled=true})}
 InputPreset.prototype.formatNamespace=function(){var value=toCamel(this.$src.val())
 return value.substr(0,1).toUpperCase()+value.substr(1)}
-InputPreset.prototype.formatValue=function(){if(this.options.inputPresetType=='namespace'){return this.formatNamespace()}
+InputPreset.prototype.formatValue=function(){if(this.options.inputPresetType=='exact'){return this.$src.val();}
+else if(this.options.inputPresetType=='namespace'){return this.formatNamespace()}
 if(this.options.inputPresetType=='camel'){var value=toCamel(this.$src.val())}
 else{var value=slugify(this.$src.val())}
 if(this.options.inputPresetType=='url'){value='/'+value}


### PR DESCRIPTION
Currently the preset field option does not allow to preset with the exact same value as the other field, but formats it as slug, url etc.

This PR adds a 'normal' preset type, that simply copies the value from the other field.

My use case was i needed to preset a pluralized word from the singular version, since they are the same in many cases.

Will add to documentation if merged.