### PR TITLE
Add afterSort event to ReorderController's onReorder method

### DIFF
--- a/modules/backend/behaviors/ReorderController.php
+++ b/modules/backend/behaviors/ReorderController.php
@@ -136,6 +136,11 @@ class ReorderController extends ControllerBehavior
                     break;
             }
         }
+
+        $model->fireEvent('model.afterSort');
+        if ($model->methodExists('afterSort')) {
+            $model->afterSort();
+        }
     }
 
     //


### PR DESCRIPTION
I needed an event to listen to when a list has been reordered in the backend. So I added this event which fires every time a list has been reordered (either with the Nested Tree or the simple Sortable trait).