### PR TITLE
bug fix in taglist widget with nameFrom option

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -61,6 +61,7 @@ class TagList extends FormWidgetBase
             'customTags',
             'options',
             'mode',
+            'nameFrom',
         ]);
     }
 


### PR DESCRIPTION
**Problem:**

If using taglist widget with mode relation, nameFrom is set as name by default and custom value don't worked.

```
   groups:
        label: Groups
        type: taglist
        mode: relation
        nameFrom: label
```