### PR TITLE
Fix nested repeater sorting

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -38,15 +38,15 @@
 
         var sortableOptions = {
             // useAnimation: true,
-            handle: '.repeater-item-handle',
+            handle: this.$el.data('sortable-handle'),
             nested: false
         }
 
-        $('ul.field-repeater-items', this.$el).sortable(sortableOptions)
+        $(this.$el.data('sortable-container'), this.$el).sortable(sortableOptions)
     }
 
     Repeater.prototype.unbind = function() {
-        this.$el.find('ul.field-repeater-items').sortable('destroy')
+        this.$el.find(this.$el.data('sortable-container')).sortable('destroy')
         this.$el.removeData('oc.repeater')
     }
 

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -1,4 +1,7 @@
-<div class="field-repeater" data-control="fieldrepeater">
+<div class="field-repeater"
+     data-control="fieldrepeater"
+     data-sortable-container="#<?= $this->getId('items') ?>"
+     data-sortable-handle=".<?= $this->getId('items') ?>-handle">
 
     <ul id="<?= $this->getId('items') ?>" class="field-repeater-items">
         <?php foreach ($this->formWidgets as $index => $widget): ?>

--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -1,6 +1,6 @@
 <li class="field-repeater-item">
 
-    <div class="repeater-item-handle">
+    <div class="repeater-item-handle <?= $this->getId('items') ?>-handle">
         <i class="icon-bars"></i>
     </div>
 


### PR DESCRIPTION
This should fix https://github.com/octobercms/october/issues/1679

Basically I used an id to initialize a sortable plugin instead of a class. "Handles" now have unique classes as well.