### PR TITLE
DependsOn in repeater

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -158,4 +158,12 @@ class Repeater extends FormWidgetBase
         // Useful for deleting relations
     }
 
+    public function onRefresh()
+    {
+        $index = post('_index');
+
+        $widget = $this->makeItemFormWidget($index);
+
+        return $widget->onRefresh();
+    }
 }

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -13,7 +13,8 @@
         <a
             href="javascript:;"
             data-load-indicator
-            data-request="<?= $this->getEventHandler('onAddItem') ?>">
+            data-request="<?= $this->getEventHandler('onAddItem') ?>"
+            data-request-success="$('#<?= $this->getId('items') ?> .field-repeater-form:last').formWidget()">
             <?= e(trans($prompt)) ?>
         </a>
     </div>

--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -17,7 +17,10 @@
         </button>
     </div>
 
-    <div class="field-repeater-form">
+    <div class="field-repeater-form"
+         data-control="formwidget"
+         data-refresh-handler="<?= $this->getEventHandler('onRefresh') ?>"
+         data-refresh-data='{"_index": "<?= $indexValue ?>"}'>
         <?php foreach ($widget->getFields() as $field): ?>
             <?= $widget->renderField($field) ?>
         <?php endforeach ?>


### PR DESCRIPTION
This fixes https://github.com/octobercms/october/issues/1891

I revisited this old issue, since I experienced the same problem myself. When we use ``DependsOn`` in a repeater field, dependent fields don't update properly.

To solve this issue I had to update the ``formwidget`` jQuery plugin to work in nested situations. With this solution, we can now use the following configuration:

```yaml
fields:
    Locations:
        label: Locations
        prompt: 'Add new location'
        span: full
        type: repeater
        form:
            fields:
                country:
                    label: 'Country'
                    span: auto
                    type: dropdown
                state:
                    label: 'State'
                    span: auto
                    dependsOn: country
                    type: dropdown
```

In the model we can define ``getStateOptions()`` as usual, but this time ``$this`` variable can be used to access repeater data:

```php
public function getStateOptions() {
    return State::where('country', $this->country)->lists('title', 'id');
}
```

