### PR TITLE
Ability to sync data for *Many relations on Saving Form.

### DIFF
--- a/modules/backend/traits/FormModelSaver.php
+++ b/modules/backend/traits/FormModelSaver.php
@@ -51,16 +51,23 @@ trait FormModelSaver
         }
 
         $singularTypes = ['belongsTo', 'hasOne', 'morphOne'];
+        $multipleTypes = ['belongsToMany', 'hasMany'];
         foreach ($saveData as $attribute => $value) {
             $isNested = $attribute == 'pivot' || (
                 $model->hasRelation($attribute) &&
                 in_array($model->getRelationType($attribute), $singularTypes)
             );
+            
+            $isMultiple = (
+                $model->hasRelation($attribute) &&
+                in_array($model->getRelationType($attribute), $multipleTypes)
+            );
 
             if ($isNested && is_array($value)) {
                 $this->setModelAttributes($model->{$attribute}, $value);
-            }
-            elseif ($value !== FormField::NO_SAVE_DATA) {
+            } elseif($model->exists && $isMultiple && is_array($value)) {
+                $model->{$attribute}()->sync($value);
+            } elseif ($value !== FormField::NO_SAVE_DATA) {
                 $model->{$attribute} = $value;
             }
         }


### PR DESCRIPTION
Fixes: Ability to sync data for *Many relations on Saving Form.

No idea why it was not there in the first place?

Missing pull request functionality (save relations after model create).