### PR TITLE
Provides event to extend relation's configuration

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -301,6 +301,11 @@ class RelationController extends ControllerBehavior
 
         $this->alias = camel_case('relation ' . $field);
         $this->config = $this->makeConfig($this->getConfig($field), $this->requiredRelationProperties);
+        
+        /*
+         * Extend the field's config
+         */
+        Event::fire('backend.relationController.modifyFieldConfig', [$field, $this->config, $model]);
 
         /*
          * Relationship details


### PR DESCRIPTION
Provides the `backend.relationController.modifyFieldConfig` event to extend the configuration of individual relation fields based on the model data.