### PR TITLE
Reverse proxy support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "october/backend": "~1.0",
         "october/cms": "~1.0",
         "laravel/framework": "5.1.*",
-        "wikimedia/composer-merge-plugin": "dev-master"
+        "wikimedia/composer-merge-plugin": "dev-master",
+        "fideloper/proxy": "^3.1"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+
+    /*
+     * Set trusted proxy IP addresses.
+     *
+     * Both IPv4 and IPv6 addresses are
+     * supported, along with CIDR notation.
+     *
+     * The "*" character is syntactic sugar
+     * within TrustedProxy to trust any proxy;
+     * a requirement when you cannot know the address
+     * of your proxy (e.g. if using Rackspace balancers).
+     *
+     * To trust all proxies, simply assign '*' to 'proxies'
+     */
+    'proxies' => null,
+
+    /*
+     * Default Header Names
+     *
+     * Change these if the proxy does
+     * not send the default header names.
+     *
+     * Note that headers such as X-Forwarded-For
+     * are transformed to HTTP_X_FORWARDED_FOR format.
+     *
+     * The following are Symfony defaults, found in
+     * \Symfony\Component\HttpFoundation\Request::$trustedHeaders
+     */
+    'headers' => [
+        \Illuminate\Http\Request::HEADER_CLIENT_IP    => 'X_FORWARDED_FOR',
+        \Illuminate\Http\Request::HEADER_CLIENT_HOST  => 'X_FORWARDED_HOST',
+        \Illuminate\Http\Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
+        \Illuminate\Http\Request::HEADER_CLIENT_PORT  => 'X_FORWARDED_PORT',
+    ]
+];

--- a/modules/system/console/OctoberEnv.php
+++ b/modules/system/console/OctoberEnv.php
@@ -351,6 +351,9 @@ class OctoberEnv extends Command
                 'LINK_POLICY' => 'linkPolicy',
                 'ENABLE_CSRF' => 'enableCsrfProtection',
             ],
+            'trustedproxy' => [
+                'TRUSTED_PROXIES' => 'proxies',
+            ],
         ];
     }
 

--- a/modules/system/providers.php
+++ b/modules/system/providers.php
@@ -38,4 +38,8 @@ return [
     October\Rain\Mail\MailServiceProvider::class,
     October\Rain\Argon\ArgonServiceProvider::class,
 
+    /**
+     * Third party providers
+     */
+    Fideloper\Proxy\TrustedProxyServiceProvider::class,
 ];


### PR DESCRIPTION
This one is a bit tricky. In order for October to handle reverse proxies correctly then this package needs to be added to October. https://github.com/octobercms/library also needs a new global middleware to handle it. I'm not sure if this is the best way to do it, but it works. I'm open to suggestions for how to implement this change in a better way.