### PR TITLE
Enable refresh on form controller requests (correct branch)

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -389,6 +389,10 @@ class FormController extends ControllerBehavior
         if (post('close') && !ends_with($context, '-close')) {
             $context .= '-close';
         }
+        
+        if (post('refresh', false)) {
+	        return Redirect::refresh();
+        }
 
         if (post('redirect', true)) {
             $redirectUrl = $this->getRedirectUrl($context);


### PR DESCRIPTION
This adds support for a redirect to the current page (a refresh) to be returned by the form controller. An example use case is adding `data-request-data="refresh:1"` to the save button on an update form. I'm using it for an update form that disables certain fields (including a relationRender partial) based on values submitted on that page. Refreshing the view after saving allows my disabling rules to take effect.