### PR TITLE
Fix missing sprintf in exception message (wrong signature)

### DIFF
--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -49,7 +49,7 @@ class PluginBase extends ServiceProviderBase
             'method in the plugin class.', $thisClass));
 
         if (!array_key_exists('plugin', $configuration)) {
-            throw new SystemException('The plugin configuration file plugin.yaml should contain the "plugin" section: %s.', $thisClass);
+            throw new SystemException(sprintf('The plugin configuration file plugin.yaml should contain the "plugin" section: %s.', $thisClass));
         }
 
         return $configuration['plugin'];


### PR DESCRIPTION
Fix this : 

![image](https://cloud.githubusercontent.com/assets/1851314/17269067/b5170962-563e-11e6-9081-ba50fafca474.png)
