### PR TITLE
Fix the background for flex-layout panel like in RainLab.Builder

### DIFF
--- a/modules/backend/assets/less/controls/common.less
+++ b/modules/backend/assets/less/controls/common.less
@@ -45,7 +45,8 @@
 }
 
 .layout.control-tabs.oc-logo-transparent:not(.has-tabs),
-.layout-cell.oc-logo-transparent {
+.layout-cell.oc-logo-transparent,
+.flex-layout-column.oc-logo-transparent {
     background-size: 50% auto;
     background-repeat: no-repeat;
     background-image: url(../images/october-logo.svg);


### PR DESCRIPTION
The custom background transparency CSS was not set for panels like in Builder plugin.
Did not dig to see if it applies elsewhere too.

![image](https://cloud.githubusercontent.com/assets/1851314/17269181/60130bb0-5642-11e6-93f1-a1455b800acd.png)
