### PR TITLE
Styles for markdown generated tables in the plugin details view

### DIFF
--- a/modules/system/assets/css/updates/details.css
+++ b/modules/system/assets/css/updates/details.css
@@ -52,3 +52,18 @@
   margin-left: -50px;
   padding-left: 50px;
 }
+.plugin-details-content table th {
+    font-weight: bold
+}
+.plugin-details-content table th,
+.plugin-details-content table td {
+    padding: 6px 13px;
+    border: 1px solid #ddd
+}
+.plugin-details-content table tr {
+    background-color: #fff;
+    border-top: 1px solid #ccc
+}
+.plugin-details-content table tr:nth-child(2n) {
+    background-color: #f8f8f8
+}

--- a/modules/system/assets/less/updates/details.less
+++ b/modules/system/assets/less/updates/details.less
@@ -48,4 +48,24 @@
         margin-left: -((@padding-standard * 2) + @padding-container);
         padding-left: ((@padding-standard * 2) + @padding-container);
     }
+
+    table {
+        th {
+            font-weight: bold;
+        }
+
+        th, td {
+            padding: 6px 13px;
+            border: 1px solid #ddd;
+        }
+
+        tr {
+            background-color: #fff;
+            border-top: 1px solid #ccc;
+
+            &:nth-child(2n) {
+                background-color: #f8f8f8;
+            }
+        }
+    }
 }


### PR DESCRIPTION
The plugin details page did not style HTML tables. I have copied the CSS from GitHub.

The LESS file is not compiled through the OctoberCMS assets compile utility so I have bundled the final CSS in the PR.