### PR TITLE
Add scrolling to JS TreeView when dragging sortable elements

### DIFF
--- a/modules/backend/assets/js/october.treeview.js
+++ b/modules/backend/assets/js/october.treeview.js
@@ -71,6 +71,7 @@
 
     TreeView.prototype.dispose = function() {
         this.unregisterHandlers()
+        this.clearScrollTimeout()
 
         this.options = null
         this.$el.removeData('oc.treeView')
@@ -210,6 +211,7 @@
             useAnimation: false,
             usePlaceholderClone: true,
             handle: 'span.drag-handle',
+            onDrag: this.proxy(this.onDrag),
             tolerance: -20 // Give 20px of carry between containers
         })
 
@@ -294,6 +296,66 @@
     TreeView.prototype.onItemExpandClick = function(ev) {
         this.toggleGroup($(ev.currentTarget).closest('li'))
         return false
+    }
+    
+    // TREEVIEW SCROLL ON DRAG
+    // ============================
+    
+    TreeView.prototype.onDrag = function ($item, position, _super, event) {
+        
+        this.dragCallback = function() {
+            _super($item, position, null, event)
+        };
+        
+        this.clearScrollTimeout()
+        this.dragCallback()
+        
+        if (!this.$scrollbar || this.$scrollbar.length === 0)
+            return
+        
+        if (position.top < 0)
+            this.scrollOffset = -10 + Math.floor(position.top / 5)
+        else if (position.top > this.$scrollbar.height())
+            this.scrollOffset = 10 + Math.ceil((position.top - this.$scrollbar.height()) / 5)
+        else
+            return
+        
+        this.scrollMax = function() {
+            return this.$el.height() - this.$scrollbar.height()
+        };
+        
+        this.dragScroll()
+    }
+    
+    TreeView.prototype.dragScroll = function() {
+        var startScrollTop = this.$scrollbar.scrollTop()
+        var changed
+
+        this.scrollTimeout = null
+
+        this.$scrollbar.scrollTop( Math.min(startScrollTop + this.scrollOffset, this.scrollMax()) )
+        changed = this.$scrollbar.scrollTop() - startScrollTop
+        if (changed === 0)
+            return
+
+        this.$el.children('ol').each(function() {
+            var sortable = $(this).data('oc.sortable')
+
+            sortable.refresh()
+            sortable.cursorAdjustment.top -= changed // Keep cursor adjustment in sync with scroll
+        });
+
+        this.dragCallback()
+        this.$scrollbar.data('oc.scrollbar').setThumbPosition() // Update scrollbar position
+        
+        this.scrollTimeout = window.setTimeout(this.proxy(this.dragScroll), 100)
+    }
+    
+    TreeView.prototype.clearScrollTimeout = function() {
+        if (this.scrollTimeout) {
+            window.clearTimeout(this.scrollTimeout)
+            this.scrollTimeout = null
+        }
     }
 
     // TREEVIEW PLUGIN DEFINITION


### PR DESCRIPTION
##### Expected behavior
When interacting with UI using core's JS TreeView (nothing in core that I'm aware of, but Pages, Sitemap, possibly other plugins), when I drag an element, I expect the list to scroll if necessary so I can place my element where I want it to be.

##### Actual behavior
The list does not scroll, requiring dragging, dropping, scrolling, dragging again, etc. if the element's desired placement is significantly away from its existing location.

##### Reproduce steps
- Install Pages plugin
- Create a few dummy pages to at least partially fill up the sidebar
- Shrink the browser height (if necessary) to where not all pages can be displayed in the sidebar without scrolling
- Drag a page entry past the visible list but where elements exist above or below what's visible.

#### Implementation
With the TreeView/Scrollbar/Sortable mix, it's not an entirely straightforward issue, so I understand if there's a better way to do this, or if maybe you'd like to do something like this at a different layer so that it's closer to the Sortable level, benefiting more than just TreeView.  I saw the DragScroll plugin, which I had hoped would be what I needed, but that seemed closer to Scrollbar functionality.

I chose to access Scrollbar and Sortable objects directly for this initial pull request.  I saw at least one other instance where that had been done elsewhere, but I'd understand if that's frowned on.  Particularly updating Sortable's cursor adjustment from TreeView could be seen as breaking scope.  If you'd rather access functionality through the public interface of the jQuery plugin, I believe there will need to be edits to both Scrollbar and Sortable plugin functions, as there are a couple of issues with context and argument lists.

Let me know if there's anything I should do to make this a better fit.  Hopefully this code ends up being helpful in some form.