### PR TITLE
Fix list refresh with multiple definitions after the index_onDelete method is ca…

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -313,7 +313,7 @@ class ListController extends ControllerBehavior
             Flash::error(Lang::get('backend::lang.list.delete_selected_empty'));
         }
 
-        return $this->controller->listRefresh();
+        return $this->controller->listRefresh($definition);
     }
 
     /**


### PR DESCRIPTION
When a controller has multiple list definitions, his backend list is not correctly refreshed after index_onDelete method is called. This pull request fixes this problem.