### PR TITLE
Added instantiation of relationships if they do not exist on save

### DIFF
--- a/modules/backend/traits/FormModelSaver.php
+++ b/modules/backend/traits/FormModelSaver.php
@@ -37,6 +37,25 @@ trait FormModelSaver
     }
 
     /**
+     * Initialise a singular relation object if it doesn't exist yet.
+     * @param Model $model
+     * @param string $attribute
+     */
+    protected function initSingularRelationObject($model, $attribute) {
+
+        $relation = $model->makeRelation($attribute);
+
+        switch($model->getRelationType($attribute)) {
+
+            case 'belongsTo' : $model->{$attribute}()->associate($relation);break;
+            case 'hasOne' : $model->{$attribute}()->add($relation);break;
+            case 'morphOne' : $model->{$attribute}()->add($relation);
+
+        }
+
+    }
+    
+    /**
      * Sets a data collection to a model attributes, relations will also be set.
      * @param array $saveData Data to save.
      * @param \October\Rain\Database\Model $model Model to save to
@@ -58,6 +77,12 @@ trait FormModelSaver
             );
 
             if ($isNested && is_array($value)) {
+                 $relationModel = $model->{$attribute};
+
+                if(is_null($relationModel)) {
+                    $this->initSingularRelationObject($model,$attribute);
+                }
+                
                 $this->setModelAttributes($model->{$attribute}, $value);
             }
             elseif ($value !== FormField::NO_SAVE_DATA) {


### PR DESCRIPTION
When a model has a belongsTo relationship, and a formfield is named

`SomeModelName[relationshipname][field]` and the relationship does not exist on the model the following warning appears:

"Call to a member function hasRelation() on null" on line 74 of F:\xxxxxxxxx\modules\backend\traits\FormModelSaver.php"

This code hopes to address that non existing relation ship and initialise it.


