### PR TITLE
Fix readOnly initialization for RelationController when using options

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -380,6 +380,13 @@ class RelationController extends ControllerBehavior
      */
     public function relationRender($field, $options = [])
     {
+        /*
+         * Read only mode
+         */
+        if (isset($options['readOnly']) && $options['readOnly'] && property_exists($this->originalConfig, $field)) {
+            $this->originalConfig->{$field}['readOnly'] = true;
+        }
+
         $field = $this->validateField($field);
 
         if (is_string($options)) {
@@ -391,13 +398,6 @@ class RelationController extends ControllerBehavior
          */
         if (isset($options['sessionKey'])) {
             $this->sessionKey = $options['sessionKey'];
-        }
-
-        /*
-         * Read only mode
-         */
-        if (isset($options['readOnly']) && $options['readOnly']) {
-            $this->makeReadOnly();
         }
 
         $this->prepareVars();
@@ -603,7 +603,7 @@ class RelationController extends ControllerBehavior
                 $this->relationModel->getKeyName(),
                 $this->field,
                 $this->relationGetSessionKey(),
-                $this->readOnly ? 1 : 0
+                $this->getConfig('readOnly') ? 1 : 0
             );
 
             if ($config->recordUrl) {


### PR DESCRIPTION
The proposed PR, injects the `readOnly` property inside the original configuration for the given relation field. The `initRelation` method will clone this config and read the readOnly property from this config.

The `makeReadOnly` is called at the end of the `initRelation` method, using the post value and defaulting to the config value.

====

While testing after #2295 has been merged I figured out that the `readOnly` option is set to `true` after the widgets are rendered (so the links are rendered with `readOnly = false` ).
So the first relation rendered is always editable (links in the list open the form) and all the others are readOnly (links open the preview).

```
 public function relationRender($field, $options = [])
    {
        $field = $this->validateField($field);           // THIS RENDERS THE WIDGETS
    ...
        /*
         * Read only mode
         */
        if (isset($options['readOnly']) && $options['readOnly']) {
            $this->makeReadOnly();                         // THIS SETS THE READONLY
        }
    }
```

It requires to set the `$this->readOnly = true` before calling the widgets render method while `makeReadOnly` must still be called after the widgets are rendered (for the toolbar and view widgets to be available).

There is also a `makeReadOnly` called inside the `initRelation` to detect `$_POST` vars. Maybe it can all be centralized in the `initRelation` method.

Also the `readOnly` attribute is set in the RelationController instance so shared across all the widgets for the edited model. This implies that with the current version we can't make some of the widgets "not read only" after one has been set to read only using the `$options`. With this PR the readOnly config is read per widget and not globally.

Maybe there is a nicer way to inject the value into the original config.