### PR TITLE
Fixed double escaping

### DIFF
--- a/themes/demo/pages/home.htm
+++ b/themes/demo/pages/home.htm
@@ -89,11 +89,11 @@ layout = "default"
     <div class="row">
         <div class="col-md-6">
             Layout file:
-            <pre>{% filter escape %}{% content "placeholder/layout.txt" %}{% endfilter %}</pre>
+            <pre>{% content "placeholder/layout.txt" %}</pre>
         </div>
         <div class="col-md-6">
             Page file:
-            <pre>{% filter escape %}{% content "placeholder/page.txt" %}{% endfilter %}</pre>
+            <pre>{% content "placeholder/page.txt" %}</pre>
         </div>
     </div>
 


### PR DESCRIPTION
This double escaping, due to the escape filter + the <pre> tag, was
visualizing escaped HTML in the main demo page. Fixed it.