### PR TITLE
Reorder partial should use the model key name attribute to display the ID

### DIFF
--- a/modules/backend/behaviors/reordercontroller/partials/_records.htm
+++ b/modules/backend/behaviors/reordercontroller/partials/_records.htm
@@ -1,10 +1,10 @@
 <?php foreach ($records as $record): ?>
 
-    <li data-record-id="<?= $record->id ?>" data-record-sort-order="<?= $record->sort_order ?>">
+    <li data-record-id="<?= $record->getKey() ?>" data-record-sort-order="<?= $record->sort_order ?>">
         <div class="record">
             <a href="javascript:;" class="move"></a>
             <span><?= $this->reorderGetRecordName($record) ?></span>
-            <input name="record_ids[]" type="hidden" value="<?= $record->id ?>" />
+            <input name="record_ids[]" type="hidden" value="<?= $record->getKey() ?>" />
         </div>
 
         <?php if ($reorderShowTree): ?>


### PR DESCRIPTION
##### Expected behavior
Reorder controller should use the model primary key attribute to fill the records IDs.

##### Actual behavior
Reorder controller uses a hardcoded `->id` reference in it's partial.

##### Reproduce steps
Set the primary key name of a model used by a controller with `ReorderController` behavior to something different than `id`.

```
public $primaryKey = 'uuid';
```

##### October build
develop
