### PR TITLE
ImportModel didnt respect encoding

### DIFF
--- a/modules/backend/models/ImportModel.php
+++ b/modules/backend/models/ImportModel.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\Models;
 
+use Backend\Behaviors\ImportExportController\TranscodeFilter;
 use Str;
 use Lang;
 use Model;
@@ -96,7 +97,8 @@ abstract class ImportModel extends Model
             'firstRowTitles' => true,
             'delimiter' => null,
             'enclosure' => null,
-            'escape' => null
+            'escape' => null,
+            'encoding' => null
         ];
 
         $options = array_merge($defaultOptions, $options);
@@ -125,6 +127,18 @@ abstract class ImportModel extends Model
 
         if ($options['firstRowTitles']) {
             $reader->setOffset(1);
+        }
+
+        if (
+            $options['encoding'] !== null &&
+            $reader->isActiveStreamFilter()
+        ) {
+            $reader->appendStreamFilter(sprintf(
+                '%s%s:%s',
+                TranscodeFilter::FILTER_NAME,
+                strtolower($options['encoding']),
+                'utf-8'
+            ));
         }
 
         $result = [];


### PR DESCRIPTION
In contrast to the preview CSV reader, the actual ``ImportModel`` did not respect any encoding values provided. This leads to bugs with any non utf8-compliant characters. This PR fixes the problem by adding the appropriate encoding filter (copied from the preview reader).