### PR TITLE
input: on paste

### DIFF
--- a/modules/system/assets/ui/js/input.preset.js
+++ b/modules/system/assets/ui/js/input.preset.js
@@ -231,6 +231,12 @@
 
             $el.val(prefix + self.formatValue())
         })
+        this.$src.on('paste', function() {
+            if (self.cancelled)
+                return
+
+            setTimeout(function() {$el.val(prefix + self.formatValue())}, 100)
+        })
 
         this.$el.on('change', function() {
             self.cancelled = true


### PR DESCRIPTION
slug remain empty when I paste title by mouse
(for example in blog)
video (rus): https://drive.google.com/file/d/0B8p5fhrZDlHhT25UaXlBdkRRWDQ/view?usp=sharing