### PR TITLE
Add this.app.name & this.app.tagline to the default theme variables

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -15,6 +15,7 @@ use Response;
 use Exception;
 use BackendAuth;
 use Twig_Environment;
+use Backend\Models\BrandSetting;
 use Cms\Twig\Loader as TwigLoader;
 use Cms\Twig\DebugExtension;
 use Cms\Twig\Extension as CmsTwigExtension;
@@ -292,6 +293,10 @@ class Controller
             'controller'  => $this,
             'environment' => App::environment(),
             'session'     => App::make('session'),
+            'app'         => [
+                'name'    => BrandSetting::get('app_name'),
+                'tagline' => BrandSetting::get('app_tagline'),
+            ],
         ];
 
         /*


### PR DESCRIPTION
Issue: #2337

This enables theme authors to access the name and tagline of the app as set in the backend settings within their themes, allowing for a more standardized way of accessing these settings within themes.