### PR TITLE
The sorting error in preview context

### DIFF
--- a/modules/backend/behaviors/relationcontroller/partials/_view.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_view.htm
@@ -1,1 +1,6 @@
-<?= $relationViewWidget->render() ?>
+<div
+    id="<?= $this->relationGetId() ?>"
+    data-request-data="_relation_field: '<?= $relationField ?>', _relation_read_only: <?= $relationReadOnly ?>"
+    class="relation-behavior relation-view-<?= $relationViewMode ?>">
+    <?= $relationViewWidget->render() ?>
+</div>


### PR DESCRIPTION
The error "A widget with class name ':name' has not been bound to the controller" is fixed in preview context
