### PR TITLE
Autoredirect option added to main menu items in plugins

### DIFF
--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -105,13 +105,23 @@ class PluginBase extends ServiceProviderBase
             $navigation = $configuration['navigation'];
 
             if (is_array($navigation)) {
+
+                foreach ($navigation as $key => $item) {
+                    if (isset($item['autoredirect']) && $item['autoredirect'] && isset($item['sideMenu'])) {
+                        if($url = $this->findAccessableItemUrl($item['sideMenu'])){
+                            $navigation[$key]['url'] = $url;
+                        }
+                    }
+                }
+
                 array_walk_recursive($navigation, function(&$item, $key){
                     if ($key === 'url') {
                         $item = Backend::url($item);
                     }
                 });
-            }
 
+            }
+            
             return $navigation;
         }
     }
@@ -242,5 +252,22 @@ class PluginBase extends ServiceProviderBase
         }
 
         return $this->loadedYamlConfigration;
+    }
+
+    /**
+     * Finds the url of the first accessable side menu item
+     * 
+     * @param array $navigation Side menu items
+     * @return string|null Url
+     */
+    public function findAccessableItemUrl($navigation){
+        if ($user = BackendAuth::getUser()) {
+            foreach ($navigation as $key => $item) {
+                if (isset($item['url']) && (!isset($item['permissions']) || $user->hasAnyAccess($item['permissions']))) {
+                    return $item['url'];
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
I've added quite useful feature allowing automatic redirection from main menu item to first accessable side menu item. Developers don't have to specify the url of main menu items.

To enable autoredirecting, add `autoredirect: 1` in your "plugin.yaml" file:

```
navigation:
    menu-item-1:
        autoredirect: 1
        ...
        sideMenu:
            side-menu-item1:
                permissions:
                    - blog
                ...
            side-menu-item2:
                permissions:
                    - livechat
                ...
```

When the user with permissions "blog" click on "menu-item-1", he will go to the "side-menu-item-1".
When the user with permissions "livechat" click on "menu-item-1", he will go to the "side-menu-item-2".

I've updated also Rainlab Builder plugin to work with this new feature.
