### PR TITLE
Filter lists by switch or group query scopes

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -616,6 +616,20 @@ class Filter extends WidgetBase
                  * Scope
                  */
                 elseif ($scopeMethod = $scope->scope) {
+                    /*
+                     * Switch scope: multiple scopes
+                     */
+                    if(is_array($scopeMethod)) {
+                        $scopeNum = is_array($value) ? 0 : $value - 1;
+                        list($scopeMethod) = array_slice($scopeMethod, $scopeNum);
+                    }
+                    /*
+                     * Group scope
+                     */
+                    elseif(Str::contains($scopeMethod, ':filtered')) {
+                        $replace = (is_array($value)) ? $value[0] : $value;
+                        $scopeMethod = str_replace(':filtered', $replace, $scopeMethod);
+                    }
                     $query->$scopeMethod($value);
                 }
 


### PR DESCRIPTION
Add the ability to filter by multiples scopes using `group` filter or switching between two scopes, using `switch` filter.

```yaml

    # EXAMPLE 1
    # Just choose by multiple scopes at a time
    status:
        label: Status
        type: group
        scope: :filtered
        options:
            pending: Pending
            active: Active
            closed: Closed

    # EXAMPLE 2
    # On this case, a Blog post, can be published on Facebook has a related model to store the Facebook link and published date
    # The method scopeIsFbPublished run $query->has('related_model') and scopeIsNotFbPublished run the opposite $query->doesntHave('related_model') 
    fb_published:
        label: Published on Facebook
        type: switch
        scope:
            - isFbPublished
            - isNotFbPublished
```

Sorry my english.