### PR TITLE
Format the formatted tab for mail logs

### DIFF
--- a/modules/system/assets/js/eventlogs/exception-beautifier.js
+++ b/modules/system/assets/js/eventlogs/exception-beautifier.js
@@ -324,6 +324,10 @@
             '<div class="tab-pane pane-inset" id="beautifier-tab-raw"></div>' +
             '</div></div>')
 
+        if (source.indexOf('Message-ID:') > 0) {
+            markup = '<div class="beautifier-raw-content">' + source.trim().replace(/\r\n|\r|\n/g, '<br>').replace(/ {2}/g, '&nbsp;&nbsp;') + '</div>'
+        }
+
         tabs.find('#beautifier-tab-formatted').append(markup)
         tabs.find('#beautifier-tab-raw').append('<div class="beautifier-raw-content">' + $.oc.escapeHtmlString(source.trim()).replace(/\r\n|\r|\n/g, '<br>').replace(/ {2}/g, '&nbsp;&nbsp;') + '</div>')
 


### PR DESCRIPTION
Formatting was previously applied accidentally on the Raw tab for emails, due to raw data not being escaped. Since that was fixed, both tabs would show raw data for email logs.

This PR checks for a Message-ID: string in the source to identify email logs, and uses the unescaped content of the raw tab to show the formatted source as you'd expect to see on the Formatted tab.