### PR TITLE
fix - spaces in |media filter

### DIFF
--- a/modules/cms/classes/MediaLibrary.php
+++ b/modules/cms/classes/MediaLibrary.php
@@ -346,7 +346,7 @@ class MediaLibrary
     {
         if (Str::lower($originalPath) !== Str::lower($newPath)) {
             // If there is no risk that the directory was renamed
-            // by just changing the letter case in the name - 
+            // by just changing the letter case in the name -
             // copy the directory to the destination path and delete
             // the source directory.
 
@@ -438,6 +438,8 @@ class MediaLibrary
         if (preg_match($regex, $path) !== 0 || strpos($path, '//') !== false) {
             throw new ApplicationException(Lang::get('cms::lang.media.invalid_path', compact('path')));
         }
+
+        $path = str_replace('', '%20', $path);
 
         return $path;
     }


### PR DESCRIPTION
This PR is a fix for spaces in `|media` url.

Steps to reproduce:
In a layout put some inline style like this:

``` html
<div style="background: url({{ var | media }})"></div>
```

If the path contains a space the image was not showed. 

This simple fix change spaces by `%20` and everything works.
