### PR TITLE
Add current url to ajax requests in requestOptions used in XHR full pageloads

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -81,6 +81,7 @@ if (window.jQuery === undefined)
             data.push($.param(options.data))
 
         var requestOptions = {
+            url : window.location.href,
             context: context,
             headers: {
                 'X-OCTOBER-REQUEST-HANDLER': handler,


### PR DESCRIPTION
Hi

I'm building a project using XHR full page navigation(look at soundcloud for example) and thereby changing the history and current url trough html history API. I succesfully made a plugin using the CMS events to respond correctly to these requests.

Now the problem with using the ajax framework was that it got initiated in the first page load, so all ajax request through it used the original page url instead of the current page url. Therefore I kept getting the error message ajaxHandler not found.

I fixed it by explicitly stating the current document location href in the requestOptions.

Just a small addition but I hope this helps!
