### PR TITLE
Support readOnly extra config as string

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1509,6 +1509,13 @@ class RelationController extends ControllerBehavior
             $field = $this->field;
         }
 
+        if (isset($config['readOnly'])) {
+			if (strtolower($config['readOnly']) === 'false') {
+		        $config['readOnly'] = false;
+	        } else {
+		        $config['readOnly'] = (bool) $config['readOnly'];
+	        }
+	    }
         $parsedConfig = array_only($config, ['readOnly']);
         $parsedConfig['view'] = array_only($config, ['recordUrl']);
 


### PR DESCRIPTION
Supports the readOnly extra config value being provided as a string of 'false' due to incorrect content encoding passed via the AJAX framework. Temporary solution in relation to octobercms/october#2417