### PR TITLE
Pass current model to record finder scope method

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -272,7 +272,7 @@ class RecordFinder extends FormWidgetBase
         }
         elseif ($scopeMethod = $this->scope) {
             $widget->bindEvent('list.extendQueryBefore', function($query) use ($scopeMethod) {
-                $query->$scopeMethod();
+                $query->$scopeMethod($this->model);
             });
         }
         else {


### PR DESCRIPTION
This improves the extensibility of the record finder form widget by passing the current model to the query scope that will be applied to the records being displayed. It allows the use of attributes of the current model in the query scope applied to the records being displayed as options to select.

In my use case, I have a main Survey model with related Field models. Field models can have parents and children for a tree structure, but I only want fields to have parents and children that are:
**a) Not the main record itself**
**and b) Members of / related to the same Survey model**

By passing the current model to my query scope, I can filter out ineligible records like so:
```
/**
 * Limit results to only records that are eligible to be parents of the provided model
 *
 * @param Query $query
 * @param Model $model The model to check for eligible parents against
 * @return Query
 */
public function scopeEligibleParents($query, $model) {
    return $query->where('id', '!=', $model->id)
            ->where('parent_id', '!=', $model->id)
            ->where('survey_id', '=', $model->survey_id);
}
```