### PR TITLE
Cache flush problem

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -142,7 +142,6 @@ class UpdateManager
         }
 
         Parameter::set('system::update.count', 0);
-        CacheHelper::clear();
 
         /*
          * Seed modules


### PR DESCRIPTION
I noticed that when you login in the backend, this function delete all the cache stored. I was trying to create a plugin to store in Redis all the visited pages. After the login in the backend i saw that all element in the cache was gone.
