### PR TITLE
Fixing default import template doesn't extract columns from the latest uploaded file.

### DIFF
--- a/modules/backend/models/ImportModel.php
+++ b/modules/backend/models/ImportModel.php
@@ -195,7 +195,7 @@ abstract class ImportModel extends Model
         $file = $this
             ->import_file()
             ->withDeferred($sessionKey)
-            ->orderBy('updated_at', 'desc')
+            ->orderBy('id', 'desc')
             ->first()
         ;
 

--- a/modules/backend/models/ImportModel.php
+++ b/modules/backend/models/ImportModel.php
@@ -195,6 +195,7 @@ abstract class ImportModel extends Model
         $file = $this
             ->import_file()
             ->withDeferred($sessionKey)
+            ->orderBy('updated_at', 'desc')
             ->first()
         ;
 


### PR DESCRIPTION
This MR fixes the issue described below.
##### Expected behavior

When the user decided he wants to replace the previously uploaded CSV file with another one, the updated columns should be extracted from the latest uploaded file.
##### Actual behavior

The columns are always extracted from the first uploaded file, regardless of subsequent changes to the file.
##### Reproduce steps

On the default CVS import template:
1. Upload a file.
2. Upload another totally different file. Should see that the columns are still from the first file.
##### October build

Master at 2659ae7
