### PR TITLE
Add 7.1 and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,15 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
+  - nightly
 
 matrix:
   allow_failures:
     - php: 7.0
+    - php: 7.1
+    - php: nightly
 
 sudo: false
 


### PR DESCRIPTION
Laravel framework tests on 7.1, and there is no harm in testing a few extra versions.