### PR TITLE
Added `--relative` option to the `october:mirror` command

### DIFF
--- a/modules/system/composer.json
+++ b/modules/system/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.5.9",
         "composer/installers": "~1.0",
-        "october/rain": "~1.0"
+        "october/rain": "~1.0",
+        "symfony/filesystem": "2.7.*|2.8.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Disclaimer: this PR adds another dependency on `symfony/filesystem` and I was not sure if it is allowed to put it here.

I have added a `--relative` option to the `october:mirror` command.

Example of use:

    php artisan october:mirror public/ --relative

The purpose:

In some environments (eg: I personally do that) the project build is a proper separate step and the result of running the build is a deployable artifact (eg. `.tgz` or a `.deb` file).

And that would mean that the project path in the build environment might be (and often would not be) different from the path in the production environment. And this also means that in production environment you don't even have composer or other tools, and deployment is simply unpacking an archive without running additional commands (like `php artisan october:mirror`).

With this PR if you use a `--relative` option - the paths in the public directory are generated relatively to the path to the core `october`.

Example of the resulted directory listing:

    $ ls -la public/
    total 20
    drwxr-xr-x  5 vagrant vagrant 4096 Nov  3 14:58 .
    drwxr-xr-x 13 vagrant vagrant 4096 Nov  3 14:58 ..
    lrwxrwxrwx  1 vagrant vagrant   12 Nov  3 14:58 .htaccess -> ../.htaccess
    lrwxrwxrwx  1 vagrant vagrant   12 Nov  3 14:58 index.php -> ../index.php
    drwxr-xr-x  5 vagrant vagrant 4096 Nov  3 14:58 modules
    drwxr-xr-x  4 vagrant vagrant 4096 Nov  3 14:58 storage
    drwxr-xr-x  3 vagrant vagrant 4096 Nov  3 14:58 themes

or

    $ ls -la public/storage/app/
    total 12
    drwxr-xr-x 3 vagrant vagrant 4096 Nov  3 14:58 .
    drwxr-xr-x 4 vagrant vagrant 4096 Nov  3 14:58 ..
    lrwxrwxrwx 1 vagrant vagrant   26 Nov  3 14:58 media -> ../../../storage/app/media
    drwxr-xr-x 2 vagrant vagrant 4096 Nov  3 14:58 uploads
