### PR TITLE
Fix for #2450

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -2,6 +2,10 @@
     $fieldOptions = $field->options();
     $useSearch = $field->getConfig('showSearch', true);
     $allowClear = $field->getConfig('allowClear', false);
+    if ($allowClear == true && !$field->placeholder)
+    {
+        $field->placeholder = e(trans('backend::lang.form.select_placeholder'));
+    }
 ?>
 <!-- Dropdown -->
 <?php if ($this->previewMode): ?>

--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -10,10 +10,9 @@
         id="<?= $field->getId() ?>"
         name="<?= $field->getName() ?>"
         class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?>"
-        <?= $field->getAttributes() ?>>
-        <?php if ($field->placeholder): ?>
-            <option value=""><?= e(trans($field->placeholder)) ?></option>
-        <?php endif ?>
+        <?= $field->getAttributes() ?>
+        <?= $field->placeholder ? 'data-placeholder="'.e(trans($field->placeholder)).'"' : '' ?>
+        >
         <?php foreach ($fieldOptions as $value => $option): ?>
             <?php
                 if (!is_array($option)) $option = [$option];

--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -2,9 +2,10 @@
     $fieldOptions = $field->options();
     $useSearch = $field->getConfig('showSearch', true);
     $allowClear = $field->getConfig('allowClear', false);
-    if ($allowClear == true && !$field->placeholder)
+    // If allowClear is true, define a default placeholder in case there is not one already defined.
+    if ($allowClear == true)
     {
-        $field->placeholder = e(trans('backend::lang.form.select_placeholder'));
+        $field->placeholder = $field->getConfig('placeholder', e(trans('backend::lang.form.select_placeholder')));
     }
 ?>
 <!-- Dropdown -->

--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -1,6 +1,7 @@
 <?php
     $fieldOptions = $field->options();
     $useSearch = $field->getConfig('showSearch', true);
+    $allowClear = $field->getConfig('allowClear', false);
 ?>
 <!-- Dropdown -->
 <?php if ($this->previewMode): ?>
@@ -9,7 +10,7 @@
     <select
         id="<?= $field->getId() ?>"
         name="<?= $field->getName() ?>"
-        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?>"
+        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?> <?= $allowClear ? 'select-allow-clear' : '' ?>"
         <?= $field->getAttributes() ?>
         <?= $field->placeholder ? 'data-placeholder="'.e(trans($field->placeholder)).'"' : '' ?>
         >

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -95,6 +95,11 @@
                 extraOptions.placeholder =  placeholder;
             }
 
+            if ($element.hasClass('select-allow-clear'))
+            {
+                extraOptions.allowClear = true;
+            }
+
 
             $element.select2($.extend({}, selectOptions, extraOptions))
         })

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -89,6 +89,13 @@
                 }
             }
 
+            var placeholder = $element.data('placeholder')
+            if (placeholder)
+            {
+                extraOptions.placeholder =  placeholder;
+            }
+
+
             $element.select2($.extend({}, selectOptions, extraOptions))
         })
     })


### PR DESCRIPTION
1. Added the placeholder behavior of the Select2 library into october's dropdown and relation widgets.
2. Added `allowClear` option into dropdown and relation widgets.
Now it's possible to add the `allowClear` option into relation and dropdown, adding the Select2 clear behavior into those widgets. Since select2 library forces to have a defined placeholder, also added a default placeholder text in case there is not an user defined one.

How to use it:

```yaml
        Foo:
            label: Mofu!
            type: dropdown
            placeholder: My little placeholder text
            span: left
            allowClear: true
            options:
              1: Value 1
              2: Value 2
```