### PR TITLE
[!!!] Fix for postgresql: you cannot compare a boolean column with integers

### DIFF
--- a/modules/backend/controllers/users/config_filter.yaml
+++ b/modules/backend/controllers/users/config_filter.yaml
@@ -8,8 +8,8 @@ scopes:
         label: backend::lang.user.superuser
         type: switch
         conditions:
-            - is_superuser = 0
-            - is_superuser = 1
+            - is_superuser = false
+            - is_superuser = true
 
     login_date:
         label: backend::lang.user.last_login


### PR DESCRIPTION
This exception would appear if you try to use the filter by `is_superuser` in the administrators backend

```
SQLSTATE[42883]: Undefined function: 7 ERROR:  operator doesnot exist: boolean = integer
LINE 1: ...(*) as aggregate from "backend_users" where is_superuser = 1                                
                                                                    ^
HINT:  No operator matches thegiven name and argument type(s). You might need to add explicit typecasts.
```

I only run postgresql here, but it should work for any ANSI-compliant RDBMS