### PR TITLE
Extend the licence file name list

### DIFF
--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -110,7 +110,7 @@ class Updates extends Controller
 
             $readmeFiles = ['README.md', 'readme.md'];
             $upgradeFiles = ['UPGRADE.md', 'upgrade.md'];
-            $licenceFiles = ['LICENCE.md', 'licence.md'];
+            $licenceFiles = ['LICENCE.md', 'licence.md', 'LICENSE.md', 'license.md'];
 
             $readme = $changelog = $upgrades = $licence = $name = null;
             $code = str_replace('-', '.', $urlCode);


### PR DESCRIPTION
Some plugin use the LICENSE.md file name instead of LICENCE.md.