### PR TITLE
Fix list searching with additional scope

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1185,10 +1185,9 @@ class Lists extends WidgetBase
                 $q->$scopeMethod($term);
             });
         }
-        else {
-            $searchMethod = $boolean == 'and' ? 'searchWhere' : 'orSearchWhere';
-            $query->$searchMethod($term, $columns, $this->searchMode);
-        }
+        
+        $searchMethod = $boolean == 'and' ? 'searchWhere' : 'orSearchWhere';
+        $query->$searchMethod($term, $columns, $this->searchMode);
     }
 
     //


### PR DESCRIPTION
Just becaue the ``searchScope`` is present, it shouldnt ignore the usual searching implementation at all. This fixes the mentionned issue.