### PR TITLE
Pass current model to RelationController view & manage scopes

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -645,7 +645,7 @@ class RelationController extends ControllerBehavior
             }
             elseif ($scopeMethod = $this->getConfig('view[scope]')) {
                 $widget->bindEvent('list.extendQueryBefore', function($query) use ($scopeMethod) {
-                    $query->$scopeMethod();
+                    $query->$scopeMethod($this->model);
                 });
             }
             else {
@@ -775,7 +775,7 @@ class RelationController extends ControllerBehavior
             }
             elseif ($scopeMethod = $this->getConfig('manage[scope]')) {
                 $widget->bindEvent('list.extendQueryBefore', function($query) use ($scopeMethod) {
-                    $query->$scopeMethod();
+                    $query->$scopeMethod($this->model);
                 });
             }
             else {


### PR DESCRIPTION
This improves the extensibility of the relation controller by passing the parent relation model to the query scope that will be applied to both the view and manage options. It allows the use of attributes of the parent relation model in the query scope applied to the relation.

This is a mirror of #2419, except for the relation controller instead of the record finder widget. If necessary, I can create a case in the test plugin, but if this is simple enough with the added reference to the prior PR to not require a case in the test plugin, that would be simpler for me :) 

@daftspunk, let me know what you think.