### PR TITLE
Support Bootstrap field error state

### DIFF
--- a/modules/system/assets/js/framework.extras.js
+++ b/modules/system/assets/js/framework.extras.js
@@ -41,6 +41,8 @@
             $container = $('[data-validate-error]', $this),
             messages = [],
             $field
+        
+        $('.form-group.has-error', $this).removeClass('has-error')
 
         $.each(fields, function(fieldName, fieldMessages) {
             $field = $('[data-validate-for='+fieldName+']', $this)
@@ -52,6 +54,7 @@
                         .text(fieldMessages.join(', '))
                 }
                 $field.addClass('visible')
+                $field.closest('.form-group', $this).addClass('has-error')
             }
         })
 


### PR DESCRIPTION
Toggles the `has-error` class on the surrounding `.form-group` when a field has errors, allowing us to style the actual input as well as the error text.

![2016-11-20-233751](https://cloud.githubusercontent.com/assets/1521802/20467209/5ce5504c-af7a-11e6-920a-b4fa29b82d3a.png)
