### PR TITLE
fix for array fields validation in client-side framework

### DIFF
--- a/modules/system/assets/js/framework.extras.js
+++ b/modules/system/assets/js/framework.extras.js
@@ -43,7 +43,7 @@
             $field
 
         $.each(fields, function(fieldName, fieldMessages) {
-            $field = $('[data-validate-for='+fieldName+']', $this)
+            $field = $('[data-validate-for="'+fieldName+'"]', $this)
             messages = $.merge(messages, fieldMessages)
             if (!!$field.length) {
                 if (!$field.text().length || $field.data('emptyMode') == true) {


### PR DESCRIPTION
Commit fixes error message I've got when tried to validate array field (user[email]).

Uncaught Error: Syntax error, unrecognized expression: [data-validate-for=user.email]