### PR TITLE
Add support for hasManyThrough in the RelationController

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1402,6 +1402,7 @@ class RelationController extends ControllerBehavior
             case 'morphToMany':
             case 'morphedByMany':
             case 'belongsToMany':
+            case 'hasManyThrough':
                 return 'multi';
 
             case 'hasOne':


### PR DESCRIPTION
Fixes #2508 by setting the view mode for `hasManyThrough` relationships to `multi` just like that of `hasMany` relationships.