### PR TITLE
Respect whitespace on disabled codeeditors

### DIFF
--- a/modules/backend/formwidgets/codeeditor/partials/_codeeditor.htm
+++ b/modules/backend/formwidgets/codeeditor/partials/_codeeditor.htm
@@ -1,5 +1,7 @@
 <?php if ($this->previewMode): ?>
-    <div class="form-control"><?= e($value) ?></div>
+    <div class="form-control">
+        <pre><?= e($value) ?></pre>
+    </div>
 <?php else: ?>
     <div
         id="<?= $this->getId() ?>"


### PR DESCRIPTION
This wraps the contents of a disabled codeeditor field in an `pre` element so that the browser renders it respecting the formatting / whitespace of the contents (code in this widgets case) instead of squishing it all down.