### PR TITLE
Style fix on secondary tabs.

### DIFF
--- a/modules/system/assets/ui/less/tab.base.less
+++ b/modules/system/assets/ui/less/tab.base.less
@@ -81,7 +81,6 @@
             &:hover,
             &:focus {
                 color: @nav-tabs-active-link-hover-color;
-                background-color: @nav-tabs-active-link-hover-bg;
                 border: 1px solid @nav-tabs-active-link-hover-border-color;
                 border-bottom-color: transparent;
                 cursor: default;

--- a/modules/system/assets/ui/less/tab.less
+++ b/modules/system/assets/ui/less/tab.less
@@ -48,7 +48,6 @@
 
 .control-tabs {
     position: relative;
-
     margin-bottom: 20px;
 
     &:last-child {
@@ -85,12 +84,11 @@
             }
 
             a {
-                border-left: none!important;
-                border-top: none!important;
-                border-right: none!important;
+                border-left: none !important;
+                border-top: none !important;
+                border-right: none !important;
                 padding: 0 0 10px 0;
                 color: @color-tab-inactive-text;
-                background: @body-bg;
                 font-weight: 400;
 
                 overflow: hidden;

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -1511,7 +1511,7 @@ to{background-position:0 0}
 .nav-tabs > li{float:left;margin-bottom:-1px}
 .nav-tabs > li > a{margin-right:2px;line-height:1.42857143;border:1px solid transparent;border-radius:3px 3px 0 0}
 .nav-tabs > li > a:hover{border-color:#eeeeee #eeeeee #dddddd}
-.nav-tabs > li.active > a,.nav-tabs > li.active > a:hover,.nav-tabs > li.active > a:focus{color:#555555;background-color:#f9f9f9;border:1px solid #dddddd;border-bottom-color:transparent;cursor:default}
+.nav-tabs > li.active > a,.nav-tabs > li.active > a:hover,.nav-tabs > li.active > a:focus{color:#555555;border:1px solid #dddddd;border-bottom-color:transparent;cursor:default}
 .nav-tabs.nav-justified{width:100%;border-bottom:0}
 .nav-tabs.nav-justified > li{float:none}
 .nav-tabs.nav-justified > li > a{text-align:center;margin-bottom:5px}
@@ -1559,7 +1559,7 @@ to{background-position:0 0}
 .control-tabs > ul.nav-tabs,.control-tabs > div > ul.nav-tabs,.control-tabs > div > div > ul.nav-tabs{white-space:nowrap;font-size:0;overflow:hidden;border-bottom:none;vertical-align:bottom}
 .control-tabs > ul.nav-tabs > li,.control-tabs > div > ul.nav-tabs > li,.control-tabs > div > div > ul.nav-tabs > li{font-size:15px;float:none;display:inline-block;vertical-align:bottom;margin-right:20px;position:relative;z-index:8}
 .control-tabs > ul.nav-tabs > li:last-child,.control-tabs > div > ul.nav-tabs > li:last-child,.control-tabs > div > div > ul.nav-tabs > li:last-child{margin-right:0}
-.control-tabs > ul.nav-tabs > li a,.control-tabs > div > ul.nav-tabs > li a,.control-tabs > div > div > ul.nav-tabs > li a{border-left:none !important;border-top:none !important;border-right:none !important;padding:0 0 10px 0;color:rgba(0,0,0,0.4);background:#f9f9f9;font-weight:400;overflow:hidden}
+.control-tabs > ul.nav-tabs > li a,.control-tabs > div > ul.nav-tabs > li a,.control-tabs > div > div > ul.nav-tabs > li a{border-left:none !important;border-top:none !important;border-right:none !important;padding:0 0 10px 0;color:rgba(0,0,0,0.4);font-weight:400;overflow:hidden}
 .control-tabs > ul.nav-tabs > li a:hover,.control-tabs > div > ul.nav-tabs > li a:hover,.control-tabs > div > div > ul.nav-tabs > li a:hover{background-color:transparent;border-bottom-color:transparent}
 .control-tabs > ul.nav-tabs > li a:before,.control-tabs > div > ul.nav-tabs > li a:before,.control-tabs > div > div > ul.nav-tabs > li a:before{font-size:14px}
 .control-tabs > ul.nav-tabs > li a > span.title > span,.control-tabs > div > ul.nav-tabs > li a > span.title > span,.control-tabs > div > div > ul.nav-tabs > li a > span.title > span{max-width:150px;overflow:hidden;text-overflow:ellipsis;display:inline-block;border-top:2px solid #e0e0e0;margin-top:-4px;padding-top:7px}


### PR DESCRIPTION
The tab titles in the secondary panel were highlighted.

Before:
![kepernyofoto 2016-12-07 - 15 39 55](https://cloud.githubusercontent.com/assets/3843377/20972137/3b370f7c-bc94-11e6-849a-64c5ec621cc7.png)


After:
![kepernyofoto 2016-12-07 - 15 39 20](https://cloud.githubusercontent.com/assets/3843377/20972121/29a578fc-bc94-11e6-97e8-89dacbef827b.png)
