### PR TITLE
Support yearRange property for datepicker form field

### DIFF
--- a/modules/backend/formwidgets/DatePicker.php
+++ b/modules/backend/formwidgets/DatePicker.php
@@ -40,6 +40,12 @@ class DatePicker extends FormWidgetBase
      */
     public $maxDate = null;
 
+    /**
+     * @var string number of years either side or array of upper/lower range
+     * eg: 10 or [1900,1999]
+     */
+    public $yearRange = null;
+
     //
     // Object properties
     //
@@ -59,6 +65,7 @@ class DatePicker extends FormWidgetBase
             'mode',
             'minDate',
             'maxDate',
+            'yearRange',
         ]);
 
         $this->mode = strtolower($this->mode);
@@ -104,6 +111,7 @@ class DatePicker extends FormWidgetBase
         $this->vars['mode'] = $this->mode;
         $this->vars['minDate'] = $this->minDate;
         $this->vars['maxDate'] = $this->maxDate;
+        $this->vars['yearRange'] = $this->yearRange;
         $this->vars['format'] = $this->format;
         $this->vars['formatMoment'] = $this->getDateFormatMoment();
         $this->vars['formatAlias'] = $this->getDateFormatAlias();

--- a/modules/backend/formwidgets/datepicker/partials/_datepicker.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_datepicker.htm
@@ -13,6 +13,7 @@
         <?php if ($formatMoment): ?>data-format="<?= $formatMoment ?>"<?php endif ?>
         <?php if ($minDate): ?>data-min-date="<?= $minDate ?>"<?php endif ?>
         <?php if ($maxDate): ?>data-max-date="<?= $maxDate ?>"<?php endif ?>
+        <?php if ($yearRange): ?>data-year-range="<?= $yearRange ?>"<?php endif ?>
     >
 
         <?php if ($mode == 'date'): ?>


### PR DESCRIPTION
Every other [supported data attribute](https://github.com/octobercms/october/blob/master/modules/system/assets/ui/docs/datepicker.md#supported-data-attributes) is a configurable property, why not make `yearRange` one as well