### PR TITLE
Add keyboard shortcut to close tabs

### DIFF
--- a/modules/system/assets/ui/js/tab.js
+++ b/modules/system/assets/ui/js/tab.js
@@ -109,6 +109,12 @@
             $(li).append($('<span class="tab-close"><i>&times;</i></span>').click(function(){
                 $(this).trigger('close.oc.tab')
                 return false
+            }).hotKey({
+                hotkey: 'ctrl+q, cmd+q',
+                callback: function(element){
+                    $(element).trigger('close.oc.tab');
+                    return false
+                }
             }))
         }
 

--- a/modules/system/assets/ui/js/tab.js
+++ b/modules/system/assets/ui/js/tab.js
@@ -110,7 +110,7 @@
                 $(this).trigger('close.oc.tab')
                 return false
             }).hotKey({
-                hotkey: 'ctrl+q, cmd+q',
+                hotkey: 'alt+w',
                 callback: function(element){
                     $(element).trigger('close.oc.tab');
                     return false


### PR DESCRIPTION
Add "ctrl/cmd+q" keyboard shortcut to close the active tab.
Currently "ctrl+w" (it would be my first choice) cannot be used due to browser's reserved shortcuts, see https://bugs.chromium.org/p/chromium/issues/detail?id=119881