### PR TITLE
[bugFix] RelationController manage[title] not respected in Create contexts

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -326,14 +326,14 @@ class RelationController extends ControllerBehavior
         $this->relationObject = $this->model->{$field}();
         $this->relationModel = $this->relationObject->getRelated();
 
+        $this->manageId = post('manage_id');
+        $this->foreignId = post('foreign_id');
         $this->readOnly = $this->getConfig('readOnly');
         $this->deferredBinding = $this->getConfig('deferredBinding') || !$this->model->exists;
         $this->toolbarButtons = $this->evalToolbarButtons();
         $this->viewMode = $this->evalViewMode();
         $this->manageMode = $this->evalManageMode();
         $this->manageTitle = $this->evalManageTitle();
-        $this->manageId = post('manage_id');
-        $this->foreignId = post('foreign_id');
 
         /*
          * Toolbar widget
@@ -1435,8 +1435,11 @@ class RelationController extends ControllerBehavior
                 if ($this->readOnly) {
                     return 'backend::lang.relation.preview_name';
                 }
-                else {
+                elseif ($this->manageId) {
                     return 'backend::lang.relation.update_name';
+                }
+                else {
+                    return 'backend::lang.relation.create_name';
                 }
                 break;
         }

--- a/modules/backend/behaviors/relationcontroller/partials/_manage_form.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_form.htm
@@ -57,7 +57,7 @@
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="popup">&times;</button>
                 <h4 class="modal-title">
-                    <?= e(trans('backend::lang.relation.create_name', ['name' => trans($relationLabel)])) ?>
+                    <?= e(trans($relationManageTitle, ['name' => trans($relationLabel)])) ?>
                 </h4>
             </div>
             <div class="modal-body">


### PR DESCRIPTION
This fixes the issue of the `manage[title]` config value not being respected in Create contexts of the RelationController manage_form. 

The issue arises from the use of a hardcoded title value in the create context of the `_manage_form.htm` partial due to the inability of `evalManageTitle()` to correctly evaluate the Create context and utilize the default translation value for that context.

To recreate the issue I'm talking about, create a relation controller for a relation type that has you create the records via the relation controller. Next, add a custom title to your manage context of the config for that relation like so:
```yaml
manage:
    title: Custom Title
```
and then attempt to create a record. The modal that pops up will have the default Create translation string displayed. After creating the record, clicking on the record again to popup the Update modal will display your custom title that you set.