### PR TITLE
If CMS module is loaded (and MediaManager exists) bind it

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -153,8 +153,10 @@ class Controller extends Extendable
         /*
          * Media Manager widget is available on all back-end pages
          */
-        $manager = new MediaManager($this, 'ocmediamanager');
-        $manager->bindToController();
+        if (class_exists('\\Cms\\Widgets\\MediaManager')) {
+            $manager = new MediaManager($this, 'ocmediamanager');
+            $manager->bindToController();
+        }
     }
 
     /**


### PR DESCRIPTION
I am using OctoberCMS without the CMS module (removed from modules directory and turned off in cms.php) and I am getting an error in the backend regarding missing `MediaManager` class. I wrapped this in a class_exists to check that MediaManager exists before binding it.

Let me know your thoughts.