### PR TITLE
If the relationModel is empty it still is "true"

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -209,7 +209,7 @@ class RecordFinder extends FormWidgetBase
 
     public function getKeyValue()
     {
-        if (!$this->relationModel) {
+        if ($this->relationModel->isEmpty()) {
             return null;
         }
 
@@ -218,7 +218,7 @@ class RecordFinder extends FormWidgetBase
 
     public function getNameValue()
     {
-        if (!$this->relationModel || !$this->nameFrom) {
+        if ($this->relationModel->isEmpty() || !$this->nameFrom) {
             return null;
         }
 
@@ -227,7 +227,7 @@ class RecordFinder extends FormWidgetBase
 
     public function getDescriptionValue()
     {
-        if (!$this->relationModel || !$this->descriptionFrom) {
+        if ($this->relationModel->isEmpty() || !$this->descriptionFrom) {
             return null;
         }
 


### PR DESCRIPTION
Currently the check is if

    !$this->relationModel

And all that does too check if it is true/false. That doesn't work for Collections as they are always true, regardless if they are full or not.

We need too check using `isEmpty()` or a similar function too determine if there are results.