### PR TITLE
customViewPath in relationConfig

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -609,6 +609,7 @@ class RelationController extends ControllerBehavior
             $config->recordsPerPage = $this->getConfig('view[recordsPerPage]');
             $config->showCheckboxes = $this->getConfig('view[showCheckboxes]', !$this->readOnly);
             $config->recordUrl = $this->getConfig('view[recordUrl]', null);
+            $config->customViewPath = $this->getConfig('view[customViewPath]', null);
 
             $defaultOnClick = sprintf(
                 "$.oc.relationBehavior.clickViewListRecord(':%s', '%s', '%s')",


### PR DESCRIPTION
Only way I was able to edit the view partials in a relation was by adding `_relation_container.htm` or `_relation_view.htm` to my plugin controller, but that didn't provide the same ability as `customViewPath` or passed the data to view despite what I found in docs.

Couldn't use `customViewPath` within `relationConfig` as I was able to in `listConfig`, so I ended up adding the line from the ListController in backend behaviors to the RelationController.