### PR TITLE
Update RelationController::onRelationManageUpdate

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1061,7 +1061,7 @@ class RelationController extends ControllerBehavior
             $this->viewModel->save();
         }
 
-        return ['#'.$this->relationGetId('view') => $this->relationRenderView()];
+        return $this->relationRefresh();
     }
 
     /**


### PR DESCRIPTION
As in `onRelationManageCreate()`, `onRelationManageDelete()`, `onRelationManageAdd()`, etc, it needs to return `$this->relationRefresh()` for `relationExtendRefreshResults()` to be executed