### PR TITLE
Ensure Richeditor loads correct value when it's within MLRepeater

### DIFF
--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -71,7 +71,7 @@ class RichEditor extends FormWidgetBase
         $this->vars['stretch'] = $this->formField->stretch;
         $this->vars['size'] = $this->formField->size;
         $this->vars['name'] = $this->getFieldName();
-        $this->vars['value'] = $this->getLoadValue();
+        $this->vars['value'] = $this->formField->value;
         $this->vars['toolbarButtons'] = $this->evalToolbarButtons();
 
         $this->vars['allowEmptyTags'] = EditorSetting::getConfigured('html_allow_empty_tags');


### PR DESCRIPTION
Fixes octobercms/october#2662
Fixes rainlab/translate-plugin#218