### PR TITLE
Update modules/system/lang/en/lang.php

### DIFF
--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -34,7 +34,7 @@ return [
         'ru' => 'Русский',
         'sv' => 'Svenska',
         'sk' => 'Slovenský',
-        'tr' => 'Türk',
+        'tr' => 'Türkçe',
         'zh-cn' => '简体中文',
         'zh-tw' => '繁體中文'
     ],


### PR DESCRIPTION
For Turkish language we use "Türkçe", not "Türk". "Türk" is a person (adjective), "Türkçe" is a language name.

Example:

- We speak Türkçe.
- I am a Türk.