### PR TITLE
Add 'logging' language variable for logging setting tab.

### DIFF
--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -353,7 +353,7 @@ return [
     'log' => [
         'menu_label' => 'Log settings',
         'menu_description' => 'Specify which areas should use logging.',
-        'logging' => 'Logging',
+        'default_tab' => 'Logging',
         'log_events' => 'Log system events',
         'log_events_comment' => 'Browser requests that may require attention, such as 404 errors.',
         'log_requests' => 'Log bad requests',

--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -353,6 +353,7 @@ return [
     'log' => [
         'menu_label' => 'Log settings',
         'menu_description' => 'Specify which areas should use logging.',
+        'logging' => 'Logging',
         'log_events' => 'Log system events',
         'log_events_comment' => 'Browser requests that may require attention, such as 404 errors.',
         'log_requests' => 'Log bad requests',

--- a/modules/system/models/logsetting/fields.yaml
+++ b/modules/system/models/logsetting/fields.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 tabs:
-    defaultTab: Logging
+    defaultTab: system::lang.log.logging
     fields:
 
         log_requests:

--- a/modules/system/models/logsetting/fields.yaml
+++ b/modules/system/models/logsetting/fields.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 tabs:
-    defaultTab: system::lang.log.logging
+    defaultTab: system::lang.log.default_tab
     fields:
 
         log_requests:


### PR DESCRIPTION
- Add 'logging' language variable for logging setting tab.
- "defaultTab: Logging" defination is hard coded. I am change it with "system::lang.log.logging", language variable is "Logging".