### PR TITLE
Show multi-line version details from plugin changelog

### DIFF
--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -171,7 +171,7 @@ class Updates extends Controller
 
             foreach ($updates as $version => $details) {
                 $contents[$version] = is_array($details)
-                    ? array_shift($details)
+                    ? implode($details, "\n")
                     : $details;
             }
         }

--- a/modules/system/controllers/updates/details.htm
+++ b/modules/system/controllers/updates/details.htm
@@ -78,7 +78,7 @@
                         <dl>
                             <?php foreach ($changelog as $version => $comment): ?>
                                 <dt><?= e($version) ?></dt>
-                                <dd><?= e($comment) ?></dd>
+                                <dd><?= nl2br(e($comment)) ?></dd>
                             <?php endforeach ?>
                         </dl>
                     <?php else: ?>


### PR DESCRIPTION
Version details displayed under the `Changelog` tab on the plugin page are currently truncated to the first entry if they are defined as an array in the plugin `updates/version.yaml`.

This pull request adds support for rendering those details as additional lines in the changelog.