### PR TITLE
Remove composer.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ nginx-ssl.error.log
 php-errors.log
 sftp-config.json
 selenium.php
-composer.lock
 
 # for netbeans
 nbproject


### PR DESCRIPTION
Here is why:
https://ilikekillnerds.com/2014/09/should-you-commit-composer-lock-into-your-git-repository/