### PR TITLE
Backend List - make switch columns clickable for reverse the value

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -327,6 +327,30 @@ class ListController extends ControllerBehavior
     }
 
     /**
+     * Switch a boolean value of a model field
+     * @return void
+     */
+    public function index_onSwitchField()
+    {
+        $field = post('field');
+        $id = post('id');
+        $modelClass = post('model');
+
+        if (empty($field) || empty($id) || empty($modelClass)) {
+            Flash::error('Following parameters are required : id, field, model');
+            return;
+        }
+
+        $model = new $modelClass;
+        $item = $model::find($id);
+        $item->{$field} = !$item->{$field};
+
+        $item->save();
+
+        return $this->controller->listRefresh($this->primaryDefinition);
+    }
+
+    /**
      * Renders the widget collection.
      * @param  string $definition Optional list definition.
      * @return string Rendered HTML for the list.

--- a/modules/backend/classes/ListColumn.php
+++ b/modules/backend/classes/ListColumn.php
@@ -92,6 +92,26 @@ class ListColumn
     public $path;
 
     /**
+     * @var bool If set to yes convert switch column into a button
+     */
+    public $switchable = false;
+
+    /**
+     * @var bool If set to yes display tick/cross instead of yes/no
+     */
+    public $icon = false;
+
+    /**
+     * @var string Default lang string displayed on switch buttons for advise change to false
+     */
+    public $switchLinkTitleTrue = 'backend::lang.list.column_switch_link_title_true';
+
+    /**
+     * @var string Default lang string displayed on switch buttons for advise change to true
+     */
+    public $switchLinkTitleFalse = 'backend::lang.list.column_switch_link_title_false';
+
+    /**
      * @var array Raw field configuration.
      */
     public $config;
@@ -162,6 +182,18 @@ class ListColumn
         }
         if (isset($config['path'])) {
             $this->path = $config['path'];
+        }
+        if (isset($config['switchable'])) {
+            $this->switchable = $config['switchable'];
+        }
+        if (isset($config['icon'])) {
+            $this->icon = $config['icon'];
+        }
+        if (isset($config['switchLinkTitleFalse'])) {
+            $this->switchLinkTitleFalse = $config['switchLinkTitleFalse'];
+        }
+        if (isset($config['switchLinkTitleTrue'])) {
+            $this->switchLinkTitleTrue = $config['switchLinkTitleTrue'];
         }
 
         return $config;

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -184,7 +184,9 @@ return [
         'delete_selected_confirm' => 'Delete the selected records?',
         'delete_selected_success' => 'Deleted selected records.',
         'column_switch_true' => 'Yes',
-        'column_switch_false' => 'No'
+        'column_switch_false' => 'No',
+        'column_switch_link_title_true' => 'Click to switch to No',
+        'column_switch_link_title_false' => 'Click to switch to Yes'
     ],
     'fileupload' => [
         'attachment' => 'Attachment',

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -887,6 +887,40 @@ class Lists extends WidgetBase
         return $value;
     }
 
+    /**
+     * Return data-request-data params for the switch button
+     * @param Model                      $record
+     * @param Backend\Classes\ListColumn $column
+     * @return string
+     */
+    public function getSwitchFieldRequestData($record, $column)
+    {
+        $modelClass = str_replace('\\', '\\\\', get_class($record));
+
+        return implode(', ', [
+            "id: $record->id",
+            "field: '$column->columnName'",
+            "model: '$modelClass'"
+        ]);
+    }
+
+    /*
+     * Return translated linkTitle for the current status of the field (true/false)
+     * @param Model                      $record
+     * @param Backend\Classes\ListColumn $column
+     * @return string
+     */
+    public function getSwitchFieldLinkTitle($record, $column)
+    {
+        $value = $this->getColumnValueRaw($record, $column);
+
+        if ($value) {
+            return e(trans($column->switchLinkTitleTrue));
+        }
+
+        return e(trans($column->switchLinkTitleFalse));
+    }
+
     //
     // Value processing
     //
@@ -965,7 +999,13 @@ class Lists extends WidgetBase
     {
         $contents = '';
 
-        if ($value) {
+        if ($value && $column->icon) {
+            $contents = '<i class="oc-icon-check"></i>';
+        }
+        elseif (!$value && $column->icon) {
+            $contents = '<i class="oc-icon-times"></i>';
+        }
+        elseif ($value) {
             $contents = Lang::get('backend::lang.list.column_switch_true');
         }
         else {

--- a/modules/backend/widgets/lists/partials/_list_body_row.htm
+++ b/modules/backend/widgets/lists/partials/_list_body_row.htm
@@ -18,9 +18,17 @@
 
     <?php $index = $url = 0; foreach ($columns as $key => $column): ?>
         <?php $index++; ?>
-        <td class="list-cell-index-<?= $index ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->clickable ? '' : 'nolink' ?> <?= $column->cssClass ?>">
+        <td class="list-cell-index-<?= $index ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= (!$column->switchable && $column->clickable)  ? '' : 'nolink' ?> <?= $column->cssClass ?>">
             <?php if ($column->clickable && !$url && ($url = $this->getRecordUrl($record))): ?>
                 <a <?= $this->getRecordOnClick($record) ?> href="<?= $url ?>">
+                    <?= $this->getColumnValue($record, $column) ?>
+                </a>
+            <?php elseif ($column->type == 'switch' && $column->switchable) : ?>
+                <a href="javascript:;"
+                   data-request="onSwitchField"
+                   data-request-data="<?= $this->getSwitchFieldRequestData($record, $column) ?>"
+                   data-stripe-load-indicator
+                   title="<?= $this->getSwitchFieldLinkTitle($record, $column) ?>">
                     <?= $this->getColumnValue($record, $column) ?>
                 </a>
             <?php else: ?>


### PR DESCRIPTION
This PR add the possibility to replace Backend list switch by clickable buttons that reverse the value of the field : That allow you to create a publish / unpublish button on the lists backend (see bellow for demo).

These changes introduced will not change something on existing switch, for apply this behavior you need to edit the `columns.yaml` field for add `switchable: true` see bellow.

This PR add the following configuration parameters for `columns.yaml` 
```yaml
    your_field:
        label: 'Your Label'
        type: switch
        switchable: true # This is that parameter that convert a switch column to a button
        icon: true # If true replace Yes/No text by ✓/✗ icons

        # With the two following params, you can override 
        # the default title displayed on the button hover
        switchLinkTitleTrue: "Unpublish item" # by default : Click to switch to No
        switchLinkTitleFalse: "Publish item" # by default : Click to switch to Yes
```

## Demo
*Behavior with ` icon: true`*
![switch-icon](https://cloud.githubusercontent.com/assets/12028540/23846134/2e0245c8-07cc-11e7-82a6-c5c0c940b453.gif)

*Behavior with ` icon: false` (or without icon field)*
![switch-text](https://cloud.githubusercontent.com/assets/12028540/23846200/a88ac8c4-07cc-11e7-89fd-ccb61a701b82.gif)

*With custom titles*
![switch-icon-custom-titles](https://cloud.githubusercontent.com/assets/12028540/23846367/69e1f89e-07cd-11e7-9f8b-943aa9301464.gif)

I have just one problem, after have edited the value, when I update the list (`return $this->controller->listRefresh($this->primaryDefinition);`)  I can't redirect to the rights pagination page.
That make the following behavior : 
![switch-paginate-error](https://cloud.githubusercontent.com/assets/12028540/23846924/380992de-07d0-11e7-8e55-164e535237a6.gif)


related to issue #2739