### PR TITLE
Fix inflexible relation toolbar

### DIFF
--- a/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
@@ -4,7 +4,7 @@
 
         <?php if ($button == 'update'): ?>
             <?= $this->relationMakePartial('button_update', [
-                'relationManageId' => $relationViewModel->id
+                'relationManageId' => $relationViewModel->getKey()
             ]) ?>
         <?php else: ?>
             <?= $this->relationMakePartial('button_'.$button) ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
@@ -5,6 +5,7 @@
         <?php if ($button == 'update'): ?>
             <?= $this->relationMakePartial('button_update', [
                 'relationManageId' => $relationViewModel->getKey()
+
             ]) ?>
         <?php else: ?>
             <?= $this->relationMakePartial('button_'.$button) ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
@@ -5,7 +5,6 @@
         <?php if ($button == 'update'): ?>
             <?= $this->relationMakePartial('button_update', [
                 'relationManageId' => $relationViewModel->getKey()
-
             ]) ?>
         <?php else: ?>
             <?= $this->relationMakePartial('button_'.$button) ?>


### PR DESCRIPTION
Not all models use 'id'  as primary key.

This way the models that use $primaryKey = 'foobar' can work too :-)