### PR TITLE
Add 'iconSvg' to $purgeable

### DIFF
--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -25,7 +25,7 @@ class PluginVersion extends Model
     /**
      * @var array List of attribute names which should not be saved to the database.
      */
-    protected $purgeable = ['name', 'description', 'orphaned', 'author', 'icon', 'homepage'];
+    protected $purgeable = ['name', 'description', 'orphaned', 'author', 'icon', 'iconSvg', 'homepage'];
 
     public $timestamps = false;
 


### PR DESCRIPTION
This is needed for the Updates controller to function properly. Otherwise, on plugin enable/freeze, it tries to actually set that column value and leads to a column not found error.

Not sure why this has not been spotted earlier, as the interface really no longer works: [Screenshot](https://www.dropbox.com/s/ga14k2e8wfo36qr/Screenshot%202017-03-25%2021.51.53.png?dl=0)