### PR TITLE
Fix field dependencies for RecordFinder

### DIFF
--- a/modules/backend/formwidgets/recordfinder/assets/js/recordfinder.js
+++ b/modules/backend/formwidgets/recordfinder/assets/js/recordfinder.js
@@ -63,6 +63,7 @@
     RecordFinder.prototype.updateRecord = function(linkEl, recordId) {
         if (!this.options.dataLocker) return
         var $locker = $(this.options.dataLocker)
+        var $container = this.$el.parent().parent();
 
         $locker.val(recordId)
 
@@ -70,7 +71,7 @@
         this.$el.request(this.options.refreshHandler, {
             success: function(data) {
                 this.success(data)
-                $locker.trigger('change')
+                $container.trigger('change') // call change on the container
             }
         })
 


### PR DESCRIPTION
This fixed a bug where the RecordFinder field is the master field.
The problem is, that the change event needs to be triggered on the container (div): https://github.com/octobercms/october/blob/2659ae708f0c4cd45b48e4eaaac9e042d1a06649/modules/backend/widgets/form/assets/js/october.form.js#L126
The current implementation triggers the change on the input element (dataLocker), which does not trigger this behavior.
There might be a better implementation, however this is a working fix.