### PR TITLE
Ability to add field after another field when extending a backend form

### DIFF
--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -171,6 +171,11 @@ class FormField
     public $preset;
 
     /**
+     * @var string Specifies another field this field should be positioned directly after
+     */
+    public $after;
+
+    /**
      * Constructor.
      * @param string $fieldName
      * @param string $label
@@ -281,6 +286,7 @@ class FormField
             'trigger',
             'preset',
             'path',
+            'after',
         ];
 
         foreach ($applyConfigValues as $value) {


### PR DESCRIPTION
Hi, 

This was posted a while ago on the forum - http://octobercms.com/forum/post/ability-to-add-field-after-another-field-when-extend-form

We regularly find ourselves removing many fields to re-add them (KurtJensen suggestion). So would like to see this as a built in feature.

My first pull request, please advise if I have done anything wrong.

Thanks,
Matt