### PR TITLE
Prevent preloading files in advance

### DIFF
--- a/modules/cms/classes/MediaViewHelper.php
+++ b/modules/cms/classes/MediaViewHelper.php
@@ -94,11 +94,11 @@ class MediaViewHelper
     {
         switch ($type) {
             case 'video':
-                return '<video src="'.e($src).'" controls></video>';
+                return '<video src="'.e($src).'" controls preload="metadata"></video>';
             break;
 
             case 'audio':
-                return '<audio src="'.e($src).'" controls></audio>';
+                return '<audio src="'.e($src).'" controls preload="metadata"></audio>';
             break;
         }
     }


### PR DESCRIPTION
Files should be loaded on user click. Huge amount of data is loaded on page load, especially if many audio/VIDEO instances are on page. This is temporary solution. Ultimately widget should support params to match html5 audio/video tags.