### PR TITLE
Add readonly / disabled support for checkboxlist (relation form widget)

### DIFF
--- a/modules/backend/widgets/form/partials/_field_checkboxlist.htm
+++ b/modules/backend/widgets/form/partials/_field_checkboxlist.htm
@@ -2,9 +2,10 @@
     $fieldOptions = $field->options();
     $checkedValues = (array) $field->value;
     $isScrollable = count($fieldOptions) > 10;
+    $readOnly = $this->previewMode || $field->readOnly || $field->disabled;
 ?>
 <!-- Checkbox List -->
-<?php if (($this->previewMode || $field->readOnly || $field->disabled) && $field->value): ?>
+<?php if ($readOnly && $field->value): ?>
 
     <div class="field-checkboxlist">
         <?php $index = 0; foreach ($fieldOptions as $value => $option): ?>
@@ -33,7 +34,7 @@
         <?php endforeach ?>
     </div>
 
-<?php elseif (!$this->previewMode && !$field->readOnly && !$field->disabled && count($fieldOptions)): ?>
+<?php elseif (!$readOnly && count($fieldOptions)): ?>
 
     <div class="field-checkboxlist <?= $isScrollable ? 'is-scrollable' : '' ?>">
         <?php if ($isScrollable): ?>

--- a/modules/backend/widgets/form/partials/_field_checkboxlist.htm
+++ b/modules/backend/widgets/form/partials/_field_checkboxlist.htm
@@ -4,7 +4,7 @@
     $isScrollable = count($fieldOptions) > 10;
 ?>
 <!-- Checkbox List -->
-<?php if ($this->previewMode && $field->value): ?>
+<?php if (($this->previewMode || $field->readOnly || $field->disabled) && $field->value): ?>
 
     <div class="field-checkboxlist">
         <?php $index = 0; foreach ($fieldOptions as $value => $option): ?>
@@ -33,7 +33,7 @@
         <?php endforeach ?>
     </div>
 
-<?php elseif (!$this->previewMode && count($fieldOptions)): ?>
+<?php elseif (!$this->previewMode && !$field->readOnly && !$field->disabled && count($fieldOptions)): ?>
 
     <div class="field-checkboxlist <?= $isScrollable ? 'is-scrollable' : '' ?>">
         <?php if ($isScrollable): ?>


### PR DESCRIPTION
Relations rendered with the relation formwidget using checkboxlist are now correctly rendered like in the previewMode. This issue was described here #1866. 