### PR TITLE
AssetMaker Improvements

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -404,7 +404,7 @@ class CombineAssets
         $filesSalt = null;
         foreach ($assets as $asset) {
             $filters = $this->getFilters(File::extension($asset)) ?: [];
-            $path = File::symbolizePath($asset, null) ?: $this->localPath . $asset;
+            $path = file_exists($asset) ? $asset : File::symbolizePath($asset, null) ?: $this->localPath . $asset;
             $files[] = new FileAsset($path, $filters, public_path());
             $filesSalt .= $this->localPath . $asset;
         }
@@ -458,7 +458,7 @@ class CombineAssets
         $key = '';
 
         $assetFiles = array_map(function ($file) {
-            return File::symbolizePath($file, null) ?: $this->localPath . $file;
+            return file_exists($file) ? $file : File::symbolizePath($file, null) ?: $this->localPath . $file;
         }, $assets);
 
         foreach ($assetFiles as $file) {

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -4,6 +4,7 @@ use Url;
 use Html;
 use System\Models\Parameter;
 use System\Models\PluginVersion;
+use System\Classes\CombineAssets;
 
 /**
  * Asset Maker Trait
@@ -110,6 +111,10 @@ trait AssetMaker
      */
     public function addJs($name, $attributes = [])
     {
+        if (is_array($name)) {
+            $name = $this->combineAssets($name);
+        }
+
         $jsPath = $this->getAssetPath($name);
 
         if (isset($this->controller)) {
@@ -136,6 +141,10 @@ trait AssetMaker
      */
     public function addCss($name, $attributes = [])
     {
+        if (is_array($name)) {
+            $name = $this->combineAssets($name);
+        }
+
         $cssPath = $this->getAssetPath($name);
 
         if (isset($this->controller)) {
@@ -177,6 +186,18 @@ trait AssetMaker
         if (!in_array($rssPath, $this->assets['rss'])) {
             $this->assets['rss'][] = ['path' => $rssPath, 'attributes' => $attributes];
         }
+    }
+
+    /**
+     * Run the provided assets through the Asset Combiner
+     * @param array $assets Collection of assets
+     * @param string $localPath Prefix all assets with this path (optional)
+     * @return string
+     */
+    public function combineAssets(array $assets, $localPath = '')
+    {
+        $assetPath = !empty($localPath) ? $localPath : $this->assetPath;
+        return Url::to(CombineAssets::combine($assets, $assetPath));
     }
 
     /**

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -196,6 +196,10 @@ trait AssetMaker
      */
     public function combineAssets(array $assets, $localPath = '')
     {
+        // Short circuit if no assets actually provided
+	    if (empty($assets)) {
+		    return '';
+        }
         $assetPath = !empty($localPath) ? $localPath : $this->assetPath;
         return Url::to(CombineAssets::combine($assets, $assetPath));
     }


### PR DESCRIPTION
Improvements to the System\Traits\AssetMaker trait to support combining assets passed to the `$this->addCss()` and `$this->addJs()` methods. As a result of this, LESS and SCSS files will now also be able to be passed to the the `addCss()` method and combined on the fly.

Assets can now be combined when using these methods by passing an array of assets:
```php
$pathToCss = plugins_path('myvendor/myplugin/assets/css');

$this->addCss([
    "$pathToCss/base.css",
    "$pathToCss/special.css",
]);
```
As usual with the AssetMaker trait, you can specify `$this->assetPath` to provide a path to prepend to all the assets passed in to simplify your code. The following example is from a backend controller class where the CSS files are stored in **plugins/myvendor/myplugin/controllers/mycontroller/assets**

```php
class MyController extends Controller
{
    public function __construct()
    {
        parent::__construct();
        $this->assetPath = $this->guessViewPath('/assets', true);
        $this->addCss(['base.css', 'special.less']);
     }
}
```
Finally, using the combiner grants the ability to compile LESS and SCSS files on the fly, just like you can do with the `|theme` filter in Twig:
```php
$this->addCss(['base.less']);
```