### PR TITLE
Add method to easily extend filter scopes

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -572,7 +572,7 @@ class ListController extends ControllerBehavior
             if (!is_a($widget->getController(), $calledClass)) {
                 return;
             }
-            call_user_func_array($callback, [$widget, $widget->model]);
+            call_user_func_array($callback, [$widget]);
         });
     }
 }

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -543,4 +543,20 @@ class ListController extends ControllerBehavior
             call_user_func_array($callback, [$widget, $widget->model]);
         });
     }
+    
+     /**
+     * Static helper for extending filter scopes.
+     * @param  callable $callback
+     * @return void
+     */
+    public static function extendFilterScopes($callback)
+    {
+        $calledClass = self::getCalledExtensionClass();
+        Event::listen('backend.filter.extendScopes', function ($widget) use ($calledClass, $callback) {
+            if (!is_a($widget->getController(), $calledClass)) {
+                return;
+            }
+            call_user_func_array($callback, [$widget, $widget->model]);
+        });
+    }
 }

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -240,6 +240,13 @@ class ListController extends ControllerBehavior
             $filterWidget->bindEvent('filter.update', function () use ($widget, $filterWidget) {
                 return $widget->onRefresh();
             });
+            
+            /*
+             * Filter Widget with extensibility
+             */
+            $filterWidget->bindEvent('filter.extendScopes', function () use ($filterWidget) {
+                $this->controller->filterExtendScopes($filterWidget);
+            });
 
             /*
              * Extend the query of the list of options
@@ -447,6 +454,15 @@ class ListController extends ControllerBehavior
      * @return void
      */
     public function listExtendColumns($host)
+    {
+    }
+    
+    /**
+     * Called after the filter scopes are defined.
+     * @param \Backend\Widgets\Filter $host The hosting filter widget
+     * @return void
+     */
+    public function filterExtendScopes($host)
     {
     }
 


### PR DESCRIPTION
Hello,

I thought an interface similar to the one provided for extending list columns would be useful for filter scopes as well. At least I need that feature currently to add some dynamic filters.

