### PR TITLE
Fix for #2765

### DIFF
--- a/modules/cms/widgets/mediamanager/assets/js/mediamanager-browser-min.js
+++ b/modules/cms/widgets/mediamanager/assets/js/mediamanager-browser-min.js
@@ -343,7 +343,8 @@ $.oc.confirm(this.options.deleteConfirm,this.proxy(this.deleteConfirmation))}
 MediaManager.prototype.deleteConfirmation=function(confirmed){if(!confirmed)
 return
 var items=this.$el.get(0).querySelectorAll('[data-type="media-item"].selected'),paths=[]
-for(var i=0,len=items.length;i<len;i++){paths.push({'path':items[i].getAttribute('data-path'),'type':items[i].getAttribute('data-item-type')})}
+for(var i=0,len=items.length;i<len;i++){if(items[i].hasAttribute('data-root')){continue;}
+paths.push({'path':items[i].getAttribute('data-path'),'type':items[i].getAttribute('data-item-type')})}
 var data={paths:paths}
 $.oc.stripeLoadIndicator.show()
 this.$form.request(this.options.alias+'::onDeleteItem',{data:data}).always(function(){$.oc.stripeLoadIndicator.hide()}).done(this.proxy(this.afterNavigate))}

--- a/modules/cms/widgets/mediamanager/assets/js/mediamanager.js
+++ b/modules/cms/widgets/mediamanager/assets/js/mediamanager.js
@@ -199,7 +199,7 @@
     }
 
     MediaManager.prototype.isSearchMode = function() {
-        return this.$el.find('[data-type="search-mode"]').val() == 'true' 
+        return this.$el.find('[data-type="search-mode"]').val() == 'true'
     }
 
     MediaManager.prototype.initScroll = function() {
@@ -264,7 +264,7 @@
         if (this.isPreviewSidebarVisible()) {
             // Use the timeout to prevent too many AJAX requests
             // when the selection changes too quickly (with the keyboard arrows)
-            this.selectTimer = setTimeout(this.proxy(this.updateSidebarPreview), 100) 
+            this.selectTimer = setTimeout(this.proxy(this.updateSidebarPreview), 100)
         }
 
         // Disable delete and move buttons
@@ -407,7 +407,7 @@
                 this.resetSearch()
                 this.gotoFolder($item.data('path'), true)
             }
-        } 
+        }
         else if ($item.data('item-type') == 'file') {
             // Trigger the Insert popup command if a file item
             // was double clicked or Enter key was pressed.
@@ -432,7 +432,7 @@
             $sidebar.removeClass('hide')
             this.updateSidebarPreview()
             $button.removeClass('sidebar-hidden')
-        } 
+        }
         else {
             $sidebar.addClass('hide')
             $button.addClass('sidebar-hidden')
@@ -597,8 +597,8 @@
         for (var i = (placeholders.length-1); i >= 0; i--)
             this.thumbnailQueue.push({
                 id: placeholders[i].getAttribute('id'),
-                width: placeholders[i].getAttribute('data-width'), 
-                height: placeholders[i].getAttribute('data-height'), 
+                width: placeholders[i].getAttribute('data-width'),
+                height: placeholders[i].getAttribute('data-height'),
                 path: placeholders[i].getAttribute('data-path'),
                 lastModified: placeholders[i].getAttribute('data-last-modified')
             })
@@ -919,6 +919,10 @@
             paths = []
 
         for (var i=0, len=items.length; i<len; i++) {
+            // Skip the 'return to parent' item
+            if (items[i].hasAttribute('data-root')) {
+                continue;
+            }
             paths.push({
                 'path': items[i].getAttribute('data-path'),
                 'type': items[i].getAttribute('data-item-type')
@@ -1015,7 +1019,7 @@
                 originalPath: $(ev.target).find('input[name=originalPath]').val(),
                 files: [],
                 folders: []
-            } 
+            }
 
         for (var i = 0, len = items.length; i < len; i++) {
             var item = items[i],
@@ -1113,9 +1117,9 @@
     }
 
     MediaManager.prototype.onItemTouch = function(ev) {
-        // The 'click' event is triggered after 'touchend', 
+        // The 'click' event is triggered after 'touchend',
         // so we can prevent handling it.
-        ev.preventDefault() 
+        ev.preventDefault()
         ev.stopPropagation()
 
         if (this.dblTouchFlag) {
@@ -1129,7 +1133,7 @@
 
         this.clearDblTouchTimer()
 
-        this.dblTouchTimer = setTimeout(this.proxy(this.clearDblTouchFlag), 300) 
+        this.dblTouchTimer = setTimeout(this.proxy(this.clearDblTouchFlag), 300)
     }
 
     MediaManager.prototype.onListMouseDown = function(ev) {
@@ -1173,7 +1177,7 @@
                     if (!ev.shiftKey)
                         item.setAttribute('class', 'selected')
                     else {
-                        if (item.getAttribute('class') == 'selected') 
+                        if (item.getAttribute('class') == 'selected')
                             item.setAttribute('class', '')
                         else
                             item.setAttribute('class', 'selected')
@@ -1198,7 +1202,7 @@
             deltaY = relativePosition.y - this.selectionStartPoint.y
 
         if (!this.selectionStarted && (Math.abs(deltaX) > 2 || Math.abs(deltaY) > 2)) {
-            // Start processing the selection only if the mouse was moved by 
+            // Start processing the selection only if the mouse was moved by
             // at least 2 pixels.
             this.createSelectionMarker()
 
@@ -1209,20 +1213,20 @@
 
         if (this.selectionStarted) {
             if (deltaX >= 0) {
-                this.selectionMarker.style.left = this.selectionStartPoint.x + 'px' 
-                this.selectionMarker.style.width = deltaX + 'px' 
+                this.selectionMarker.style.left = this.selectionStartPoint.x + 'px'
+                this.selectionMarker.style.width = deltaX + 'px'
             }
             else {
-                this.selectionMarker.style.left = relativePosition.x + 'px' 
-                this.selectionMarker.style.width = Math.abs(deltaX) + 'px' 
+                this.selectionMarker.style.left = relativePosition.x + 'px'
+                this.selectionMarker.style.width = Math.abs(deltaX) + 'px'
             }
 
             if (deltaY >= 0) {
-                this.selectionMarker.style.height = deltaY + 'px' 
+                this.selectionMarker.style.height = deltaY + 'px'
                 this.selectionMarker.style.top = this.selectionStartPoint.y + 'px'
             }
             else {
-                this.selectionMarker.style.top = relativePosition.y + 'px' 
+                this.selectionMarker.style.top = relativePosition.y + 'px'
                 this.selectionMarker.style.height = Math.abs(deltaY) + 'px'
             }
         }
@@ -1285,7 +1289,7 @@
     var old = $.fn.mediaManager
 
     $.fn.mediaManager = function (option) {
-        var args = Array.prototype.slice.call(arguments, 1), 
+        var args = Array.prototype.slice.call(arguments, 1),
             result = undefined
 
         this.each(function () {
@@ -1296,7 +1300,7 @@
             if (typeof option == 'string') result = data[option].apply(data, args)
             if (typeof result != 'undefined') return false
         })
-        
+
         return result ? result : this
     }
 


### PR DESCRIPTION
Actual changes are in `MediaManager.prototype.deleteConfirmation`, apologies for the trailing whitespace removals, my editor auto does that and I didn't feel like removing it since there shouldn't really be trailing whitespace anyways.

Fixes #2675 (and probably other potential oopsies) by skipping over the "return to parent" item in the deletion handling method. The "return to parent" item contains a reference to the folder above the current folder, which could potentially cause the entire media folder to be deleted; and would certainly remove a lot more than actually intended.