### PR TITLE
Added Extensibility to ReportWidgets

### DIFF
--- a/modules/backend/classes/WidgetManager.php
+++ b/modules/backend/classes/WidgetManager.php
@@ -223,9 +223,11 @@ class WidgetManager
     }
 
     /**
-     * Removes a single report widget item
+     * Remove a registered ReportWidget.
+     * @param string $className Widget class name.
+     * @return void
      */
-    public function removeReportWidgetItem($className)
+    public function removeReportWidget($className)
     {
         if (!$this->reportWidgets) {
             throw new SystemException('Unable to remove a widget before widgets are loaded.');

--- a/modules/backend/classes/WidgetManager.php
+++ b/modules/backend/classes/WidgetManager.php
@@ -2,6 +2,7 @@
 
 use Str;
 use System\Classes\PluginManager;
+use Event;
 
 /**
  * Widget manager
@@ -188,6 +189,11 @@ class WidgetManager
             }
         }
 
+        /*
+         * Extensibility
+         */
+        Event::fire('system.reportwidgets.extendItems', [$this]);
+
         return $this->reportWidgets;
     }
 
@@ -215,4 +221,17 @@ class WidgetManager
     {
         $this->reportWidgetCallbacks[] = $definitions;
     }
+
+    /**
+     * Removes a single report widget item
+     */
+    public function removeReportWidgetItem($className)
+    {
+        if (!$this->reportWidgets) {
+            throw new SystemException('Unable to remove a widget before widgets are loaded.');
+        }
+
+        unset($this->reportWidgets[$className]);
+    }
+
 }

--- a/tests/unit/backend/classes/WidgetManagerTest.php
+++ b/tests/unit/backend/classes/WidgetManagerTest.php
@@ -13,4 +13,36 @@ class WidgetManagerTest extends TestCase
         $this->assertArrayHasKey('TestVendor\Test\FormWidgets\Sample', $widgets);
         $this->assertArrayHasKey('October\Tester\FormWidgets\Preview', $widgets);
     }
+
+    public function testIfWidgetsCanBeExtended()
+    {
+        $manager = WidgetManager::instance();
+        $manager->registerReportWidget('Acme\Fake\ReportWidget\HelloWorld', [
+            'name' => 'Hello World Test',
+            'context' => 'dashboard'
+        ]);
+        $widgets = $manager->listReportWidgets();
+
+        $this->assertArrayHasKey('Acme\Fake\ReportWidget\HelloWorld', $widgets);
+    }
+
+    public function testIfWidgetsCanBeRemoved()
+    {
+        $manager = WidgetManager::instance();
+        $manager->registerReportWidget('Acme\Fake\ReportWidget\HelloWorld', [
+            'name' => 'Hello World Test',
+            'context' => 'dashboard'
+        ]);
+        $manager->registerReportWidget('Acme\Fake\ReportWidget\ByeWorld', [
+            'name' => 'Hello World Bye',
+            'context' => 'dashboard'
+        ]);
+
+        $manager->removeReportWidgetItem('Acme\Fake\ReportWidget\ByeWorld');
+
+        $widgets = $manager->listReportWidgets();
+
+        $this->assertCount(1, $widgets);
+    }
+
 }

--- a/tests/unit/backend/classes/WidgetManagerTest.php
+++ b/tests/unit/backend/classes/WidgetManagerTest.php
@@ -38,7 +38,7 @@ class WidgetManagerTest extends TestCase
             'context' => 'dashboard'
         ]);
 
-        $manager->removeReportWidgetItem('Acme\Fake\ReportWidget\ByeWorld');
+        $manager->removeReportWidget('Acme\Fake\ReportWidget\ByeWorld');
 
         $widgets = $manager->listReportWidgets();
 


### PR DESCRIPTION
Added an extensibility Event to the WidgetManager class to be able to "extends" or "remove" a *report widget*

Now we can hide default report widgets without touch nothing on the backend

```php
\Event::listen('system.reportwidgets.extendItems', function ($manager) {
            $manager->removeReportWidgetItem('Cms\ReportWidgets\ActiveTheme');
            $manager->removeReportWidgetItem('System\ReportWidgets\Status');
        });
```

PS.
I added two Unit Tests