### PR TITLE
Backend login allow user to have not persistent connection

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -53,6 +53,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Back-end login remember
+    |--------------------------------------------------------------------------
+    |
+    | Define live duration of backend sessions :
+    |
+    | true  - session never expire (cookie expiration in 5 years)
+    |
+    | false - session have a limited time (see session.lifetime)
+    |
+    | null  - The form login display a checkbox that allow user to choose
+    |         wanted behavior
+    |
+    */
+
+    'backendForceRemember' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Back-end timezone
     |--------------------------------------------------------------------------
     |
@@ -329,21 +347,4 @@ return [
 
     'forceBytecodeInvalidation' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Backend login remember
-    |--------------------------------------------------------------------------
-    |
-    | Define live duration of backend sessions :
-    |
-    | true  - session never expire (cookie expiration in 5 years)
-    |
-    | false - session have a limited time (see session.lifetime)
-    |
-    | null  - The form login display a checkbox that allow user to choose
-    |         wanted behavior
-    |
-    */
-
-    'backendLoginRemember' => true,
 ];

--- a/config/cms.php
+++ b/config/cms.php
@@ -329,4 +329,21 @@ return [
 
     'forceBytecodeInvalidation' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Backend login remember
+    |--------------------------------------------------------------------------
+    |
+    | Define live duration of backend sessions :
+    |
+    | true  - session never expire (cookie expiration in 5 years)
+    |
+    | false - session have a limited time (see session.lifetime)
+    |
+    | null  - The form login display a checkbox that allow user to choose
+    |         wanted behavior
+    |
+    */
+
+    'backendLoginRemember' => true,
 ];

--- a/modules/backend/assets/css/october.css
+++ b/modules/backend/assets/css/october.css
@@ -819,6 +819,7 @@ body.outer .layout > .layout-row > .layout-cell .outer-form-container h2{font-si
 body.outer .layout > .layout-row > .layout-cell .outer-form-container .horizontal-form{font-size:0;display:-webkit-box;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
 body.outer .layout > .layout-row > .layout-cell .outer-form-container .horizontal-form input{vertical-align:top;margin-right:9px;display:inline-block;border:none;-webkit-border-radius:2px;-moz-border-radius:2px;border-radius:2px}
 body.outer .layout > .layout-row > .layout-cell .outer-form-container .horizontal-form button{background:#0181b9;text-align:center;font-size:13px;font-weight:600;height:40px;vertical-align:top;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+body.outer .layout > .layout-row > .layout-cell .outer-form-container .remember label {color:rgba(255,255,255,0.44)}
 body.outer .layout > .layout-row > .layout-cell .outer-form-container .forgot-password{margin-top:30px;font-size:13px;top:8px}
 body.outer .layout > .layout-row > .layout-cell .outer-form-container .forgot-password a{color:rgba(255,255,255,0.44)}
 body.outer .layout > .layout-row > .layout-cell .outer-form-container .forgot-password:before{color:rgba(255,255,255,0.44);font-size:14px;position:relative;margin-right:5px}

--- a/modules/backend/assets/less/layout/outerlayout.less
+++ b/modules/backend/assets/less/layout/outerlayout.less
@@ -74,6 +74,12 @@ body.outer {
                         }
                     }
 
+                    .remember {
+                        label {
+                            color: @color-outer-muted-text;
+                        }
+                    }
+
                     .forgot-password {
                         margin-top: 30px;
                         font-size: 13px;

--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -69,11 +69,15 @@ class Auth extends Controller
             throw new ValidationException($validation);
         }
 
+        if (is_null($remember = config('cms.backendLoginRemember', true))) {
+            $remember = (bool) post('remember');
+        }
+
         // Authenticate user
         $user = BackendAuth::authenticate([
             'login' => post('login'),
             'password' => post('password')
-        ], true);
+        ], $remember);
 
         // Load version updates
         UpdateManager::instance()->update();

--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -69,7 +69,7 @@ class Auth extends Controller
             throw new ValidationException($validation);
         }
 
-        if (is_null($remember = config('cms.backendLoginRemember', true))) {
+        if (is_null($remember = config('cms.backendForceRemember', true))) {
             $remember = (bool) post('remember');
         }
 

--- a/modules/backend/controllers/auth/signin.htm
+++ b/modules/backend/controllers/auth/signin.htm
@@ -32,7 +32,7 @@
             </button>
         </div>
 
-        <?php if (is_null(config('cms.backendLoginRemember', true))) : ?>
+        <?php if (is_null(config('cms.backendForceRemember', true))) : ?>
         <!-- Remember checkbox -->
         <div class="form-group checkbox-field horizontal-form remember">
             <div class="checkbox custom-checkbox">

--- a/modules/backend/controllers/auth/signin.htm
+++ b/modules/backend/controllers/auth/signin.htm
@@ -33,18 +33,18 @@
         </div>
 
         <?php if (is_null(config('cms.backendForceRemember', true))) : ?>
-        <!-- Remember checkbox -->
-        <div class="form-group checkbox-field horizontal-form remember">
-            <div class="checkbox custom-checkbox">
-                <input
-                    type="checkbox"
-                    id="remember"
-                    name="remember" />
-                <label for="remember">
-                    <?= e(trans('backend::lang.account.remember_me')) ?>
-                </label>
+            <!-- Remember checkbox -->
+            <div class="form-group checkbox-field horizontal-form remember">
+                <div class="checkbox custom-checkbox">
+                    <input
+                        type="checkbox"
+                        id="remember"
+                        name="remember" />
+                    <label for="remember">
+                        <?= e(trans('backend::lang.account.remember_me')) ?>
+                    </label>
+                </div>
             </div>
-        </div>
         <?php endif; ?>
 
         <p class="oc-icon-lock pull-right forgot-password">

--- a/modules/backend/controllers/auth/signin.htm
+++ b/modules/backend/controllers/auth/signin.htm
@@ -32,6 +32,21 @@
             </button>
         </div>
 
+        <?php if (is_null(config('cms.backendLoginRemember', true))) : ?>
+        <!-- Remember checkbox -->
+        <div class="form-group checkbox-field horizontal-form remember">
+            <div class="checkbox custom-checkbox">
+                <input
+                    type="checkbox"
+                    id="remember"
+                    name="remember" />
+                <label for="remember">
+                    <?= e(trans('backend::lang.account.remember_me')) ?>
+                </label>
+            </div>
+        </div>
+        <?php endif; ?>
+
         <p class="oc-icon-lock pull-right forgot-password">
             <!-- Forgot your password? -->
             <a href="<?= Backend::url('backend/auth/restore') ?>" class="text-muted">

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -39,6 +39,7 @@ return [
         'restore' => 'Restore',
         'login_placeholder' => 'login',
         'password_placeholder' => 'password',
+        'remember_me' => 'Keep me logged in?',
         'forgot_password' => 'Forgot your password?',
         'enter_email' => 'Enter your email',
         'enter_login' => 'Enter your login',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -39,7 +39,7 @@ return [
         'restore' => 'Restore',
         'login_placeholder' => 'login',
         'password_placeholder' => 'password',
-        'remember_me' => 'Keep me logged in?',
+        'remember_me' => 'Stay logged in',
         'forgot_password' => 'Forgot your password?',
         'enter_email' => 'Enter your email',
         'enter_login' => 'Enter your login',

--- a/modules/backend/lang/fr/lang.php
+++ b/modules/backend/lang/fr/lang.php
@@ -39,6 +39,7 @@ return [
         'restore' => 'Restaurer',
         'login_placeholder' => 'identifiant',
         'password_placeholder' => 'mot de passe',
+        'remember_me' => 'Rester connecté ?',
         'forgot_password' => 'Mot de passe oublié ?',
         'enter_email' => 'Saisir votre adresse e-mail',
         'enter_login' => 'Saisir votre identifiant',

--- a/modules/backend/lang/fr/lang.php
+++ b/modules/backend/lang/fr/lang.php
@@ -39,7 +39,7 @@ return [
         'restore' => 'Restaurer',
         'login_placeholder' => 'identifiant',
         'password_placeholder' => 'mot de passe',
-        'remember_me' => 'Rester connecté ?',
+        'remember_me' => 'Rester connecté',
         'forgot_password' => 'Mot de passe oublié ?',
         'enter_email' => 'Saisir votre adresse e-mail',
         'enter_login' => 'Saisir votre identifiant',


### PR DESCRIPTION
Currently all backend connection are persistent ( the lifetime of the cookie is 5 year ), this is perfect for many case. But for project that require more security this is not very good.

This PR add a config parameter `cms.backendLoginRemember` that allow administrators to choose the wanted behavior of this remember me feature.

value | description
-- | :---
true (by default) | like now : session not expire
false | session life time is the value of `session.lifetime` (2 hours by default)
null | display a checkbox on the login page that allow user to choose 

This PR can fix the following issue #2394

*This commit is inspired from the PR of @Nyorai ( https://github.com/Nyorai/october/pull/1)*