### PR TITLE
added support for globally modifying rich editor toolbar buttons #2384

### DIFF
--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -85,6 +85,7 @@ class RichEditor extends FormWidgetBase
         $this->vars['value'] = $this->getLoadValue();
         $this->vars['toolbarButtons'] = $this->evalToolbarButtons();
 
+        $this->vars['globalToolbarButtons'] = EditorSetting::getConfigured('html_toolbar_buttons');
         $this->vars['allowEmptyTags'] = EditorSetting::getConfigured('html_allow_empty_tags');
         $this->vars['allowTags'] = EditorSetting::getConfigured('html_allow_tags');
         $this->vars['noWrapTags'] = EditorSetting::getConfigured('html_no_wrap_tags');

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -8,7 +8,8 @@
         <?php if ($fullPage): ?>data-fullpage="true"<?php endif ?>
         <?php if ($readOnly): ?>data-read-only="true"<?php endif ?>
         <?php if ($editorLang): ?>data-editor-lang="<?= $editorLang ?>"<?php endif ?>
-        <?php if ($toolbarButtons): ?>data-toolbar-buttons="<?= implode(',', $toolbarButtons) ?>"<?php elseif ($globalToolbarButtons): ?>data-toolbar-buttons="<?= str_replace(" ", "", $globalToolbarButtons) ?>"<?php endif ?>
+        <?php if ($toolbarButtons): ?>data-toolbar-buttons="<?= implode(',', $toolbarButtons) ?>"
+        <?php elseif ($globalToolbarButtons): ?>data-toolbar-buttons="<?= str_replace(" ", "", $globalToolbarButtons) ?>"<?php endif ?>
         <?php if ($allowEmptyTags): ?>data-allow-empty-tags="<?= e($allowEmptyTags) ?>"<?php endif ?>
         <?php if ($allowTags): ?>data-allow-tags="<?= e($allowTags) ?>"<?php endif ?>
         <?php if ($noWrapTags): ?>data-no-wrap-tags="<?= e($noWrapTags) ?>"<?php endif ?>

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -8,7 +8,7 @@
         <?php if ($fullPage): ?>data-fullpage="true"<?php endif ?>
         <?php if ($readOnly): ?>data-read-only="true"<?php endif ?>
         <?php if ($editorLang): ?>data-editor-lang="<?= $editorLang ?>"<?php endif ?>
-        <?php if ($toolbarButtons): ?>data-toolbar-buttons="<?= implode(',', $toolbarButtons) ?>"<?php endif ?>
+        <?php if ($toolbarButtons): ?>data-toolbar-buttons="<?= implode(',', $toolbarButtons) ?>"<?php elseif ($globalToolbarButtons): ?>data-toolbar-buttons="<?= str_replace(" ", "", $globalToolbarButtons) ?>"<?php endif ?>
         <?php if ($allowEmptyTags): ?>data-allow-empty-tags="<?= e($allowEmptyTags) ?>"<?php endif ?>
         <?php if ($allowTags): ?>data-allow-tags="<?= e($allowTags) ?>"<?php endif ?>
         <?php if ($noWrapTags): ?>data-no-wrap-tags="<?= e($noWrapTags) ?>"<?php endif ?>

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -362,7 +362,7 @@ return [
         'remove_tags' => 'Remove tags',
         'remove_tags_comment' => 'The list of tags that are removed together with their content.',
         'toolbar_buttons' => 'Toolbar Buttons',
-        'toolbar_buttons_comment' => 'The Toolbar Buttons to be displayed in the Rich Editor. [fullscreen, bold, italic, underline, strikeThrough, subscript, superscript, fontFamily, fontSize, |, color, emoticons, inlineStyle, paragraphStyle, |, paragraphFormat, align, formatOL, formatUL, outdent, indent, quote, insertHR, -, insertLink, insertImage, insertVideo, insertAudio, insertFile, insertTable, undo, redo, clearFormatting, selectAll, html]',
+        'toolbar_buttons_comment' => 'The Toolbar Buttons to be displayed in the Rich Editor by default. [fullscreen, bold, italic, underline, strikeThrough, subscript, superscript, fontFamily, fontSize, |, color, emoticons, inlineStyle, paragraphStyle, |, paragraphFormat, align, formatOL, formatUL, outdent, indent, quote, insertHR, -, insertLink, insertImage, insertVideo, insertAudio, insertFile, insertTable, undo, redo, clearFormatting, selectAll, html]',
     ],
     'tooltips' => [
         'preview_website' => 'Preview the website'

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -360,7 +360,9 @@ return [
         'no_wrap' => 'Do not wrap tags',
         'no_wrap_comment' => 'The list of tags that should not be wrapped inside block tags.',
         'remove_tags' => 'Remove tags',
-        'remove_tags_comment' => 'The list of tags that are removed together with their content.'
+        'remove_tags_comment' => 'The list of tags that are removed together with their content.',
+        'toolbar_buttons' => 'Toolbar Buttons',
+        'toolbar_buttons_comment' => 'The Toolbar Buttons to be displayed in the Rich Editor. [fullscreen, bold, italic, underline, strikeThrough, subscript, superscript, fontFamily, fontSize, |, color, emoticons, inlineStyle, paragraphStyle, |, paragraphFormat, align, formatOL, formatUL, outdent, indent, quote, insertHR, -, insertLink, insertImage, insertVideo, insertAudio, insertFile, insertTable, undo, redo, clearFormatting, selectAll, html]',
     ],
     'tooltips' => [
         'preview_website' => 'Preview the website'

--- a/modules/backend/models/editorsetting/fields.yaml
+++ b/modules/backend/models/editorsetting/fields.yaml
@@ -95,3 +95,10 @@ tabs:
             tab: backend::lang.editor.markup_tags
             type: textarea
             span: auto
+
+        html_toolbar_buttons:
+            label: backend::lang.editor.toolbar_buttons
+            comment: backend::lang.editor.toolbar_buttons_comment
+            tab: backend::lang.editor.toolbar_buttons
+            type: textarea
+            span: auto


### PR DESCRIPTION
This PR adds another tab to the administrator panel's editor settings: Toolbar Buttons.
You can configurate your global RichEditor toolbar buttons there.

If you've included the rich editor via a YAML file your toolbarButtons option will still override the global setting.

Please note that there is currently a CSS bug with horizontal rules not clearing floats in the Froala Editor.