### PR TITLE
Update SettingManager.php add array_merge for defination

### DIFF
--- a/modules/system/classes/SettingsManager.php
+++ b/modules/system/classes/SettingsManager.php
@@ -252,6 +252,10 @@ class SettingsManager
     {
         $itemKey = $this->makeItemKey($owner, $code);
 
+        if (isset($this->items[$itemKey])) {
+            $definition = array_merge((array) $this->items[$itemKey], $definition);
+        }
+
         $item = array_merge(self::$itemDefaults, array_merge($definition, [
             'code' => $code,
             'owner' => $owner


### PR DESCRIPTION
I'm trying change only icon for some system menu item, but I get a error: "**ERROR: Undefined property: stdClass::$description**". Seems like using "**addSettingItems**" partially is not possible.

Other hand, "addMainMenuItems" no have any error. I compare **NavigationManager** with **SettingsManager** and find [missing code](https://github.com/octobercms/october/blob/master/modules/backend/classes/NavigationManager.php#L216) on **SettingsManager**. With adding this code fragment working without error.

```php
if (isset($this->items[$itemKey])) {
    $definition = array_merge((array) $this->items[$itemKey], $definition);
}
```


My sample code for test

```php
public $elevated = true;

Event::listen('system.settings.extendItems', function($manager)
{
    // ERROR: Undefined property: stdClass::$description
    $manager->addSettingItems('October.System', [
        'updates' => [
            'icon' => 'icon-lemon-o',
        ],
    ]);
});

Event::listen('backend.menu.extendItems', function($manager)
{
    // No any problem
    $manager->addMainMenuItems('October.Backend', [
        'dashboard' => [
            'icon' => 'icon-leaf'
        ]
    ]);
});
```