### PR TITLE
add KEY taglist

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -41,6 +41,11 @@ class TagList extends FormWidgetBase
      * @var string If mode is relation, model column to use for the name reference.
      */
     public $nameFrom = 'name';
+	
+	/**
+     * @var bool Use the key instead of value for saving and reading data
+     */
+    public $useKey = false;
 
     //
     // Object properties
@@ -62,6 +67,7 @@ class TagList extends FormWidgetBase
             'options',
             'mode',
             'nameFrom',
+            'useKey'
         ]);
     }
 
@@ -71,7 +77,12 @@ class TagList extends FormWidgetBase
     public function render()
     {
         $this->prepareVars();
-        return $this->makePartial('taglist');
+		
+		if (($this->mode !== static::MODE_RELATION) && ($this->useKey === true)) {
+			return $this->makePartial('taglist_key');
+		}else{
+			return $this->makePartial('taglist');
+		}
     }
 
     /**
@@ -134,6 +145,10 @@ class TagList extends FormWidgetBase
     public function getLoadValue()
     {
         $value = parent::getLoadValue();
+		
+		// BUGFIX: return empty if there is no value
+		if(!$value || ($value == NULL))
+			return NULL;
 
         if ($this->mode === static::MODE_RELATION) {
             return $this->getRelationObject()->lists($this->nameFrom);

--- a/modules/backend/formwidgets/taglist/partials/_taglist_key.htm
+++ b/modules/backend/formwidgets/taglist/partials/_taglist_key.htm
@@ -1,0 +1,17 @@
+<?php
+    $selectedValues = is_array($selectedValues) ? $selectedValues : [];
+    $availableOptions = $fieldOptions;
+?>
+<!-- Tag List -->
+<select
+    id="<?= $field->getId() ?>"
+    name="<?= $field->getName() ?>[]"
+    class="form-control custom-select <?= !count($fieldOptions) ? 'select-no-dropdown' : '' ?> select-hide-selected"
+    <?php if ($customSeparators): ?>data-token-separators="<?= $customSeparators ?>"<?php endif ?>
+    multiple
+    <?= $field->getAttributes() ?>>
+    <?php foreach ($availableOptions as $key => $option): ?>
+        <?php if (!strlen($option)) continue ?>
+        <option value="<?= e($key) ?>" <?= in_array($key, $selectedValues) ? 'selected="selected"' : '' ?>><?= e(trans($option)) ?></option>
+    <?php endforeach ?>
+</select>


### PR DESCRIPTION
Add the ability to make a taglist formwidget, but use the key instead of the value to save data.
See my merge request on "oc-test-plugin" for examples.

Many times we want to save a huge list of tags into a field, but we can't use the name (or value). We want a list of IDs or keys to create very fast queries.
______________________________________________________
Sorry,
there was something missing in my commit.
Updated my commit:
https://github.com/sewagolubkow/october/commit/59a66fec60348c6782d634770cb6116993307675

(In case the link doesn't work - it was a forced commit update)
______________________________________________________
And here is the updated "oc-test-plugin":
https://github.com/daftspunk/oc-test-plugin/pull/40

