### PR TITLE
Adding getStatusCode() in Cms\Classes\Controller

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1022,6 +1022,15 @@ class Controller
     // Getters
     //
 
+     /**
+     * Returns the status code for the current web response.
+     * @return int Status code
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
     /**
      * Returns an existing instance of the controller.
      * If the controller doesn't exists, returns null.


### PR DESCRIPTION
Referring to the issue #2953 which is no fault of the October CMS.
The problem was that a plugin which I'm using [xeor-minify](https://octobercms.com/plugin/xeor-minify) sets the http status code hardcoded. So I want to improve it and add the ability to get the current http status code of the page (which can use the plugin above in the next version).