### PR TITLE
Replace sensitive config values with defaults for october:env command

### DIFF
--- a/modules/system/console/OctoberEnv.php
+++ b/modules/system/console/OctoberEnv.php
@@ -31,6 +31,11 @@ class OctoberEnv extends Command
     protected $config;
 
     /**
+     * Default configuration.
+     */
+    protected $defaultConfig = $this->protectedConfig();
+
+    /**
      * The current database connection cursor.
      */
     protected $connection;
@@ -63,7 +68,7 @@ class OctoberEnv extends Command
     protected function getOptions()
     {
         return [
-            ['protect', null, InputOption::VALUE_NONE, 'Make sure to replace sensitive config values by the default ones.'],
+            ['protect', null, InputOption::VALUE_NONE, 'Replaces sensitive config values in the config files with the default values.'],
         ];
     }
 

--- a/modules/system/console/OctoberEnv.php
+++ b/modules/system/console/OctoberEnv.php
@@ -1,6 +1,7 @@
 <?php namespace System\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Console command to convert configuration to use .env files.
@@ -54,6 +55,16 @@ class OctoberEnv extends Command
         $this->overwriteConfig();
 
         $this->info('.env configuration file has been created.');
+    }
+
+    /**
+     * Get the console command options.
+     */
+    protected function getOptions()
+    {
+        return [
+            ['protect', null, InputOption::VALUE_NONE, 'Make sure to replace sensitive config values by the default ones.'],
+        ];
     }
 
     /**
@@ -183,6 +194,10 @@ class OctoberEnv extends Command
             $value = $this->envValue($configKey);
 
             $this->saveEnvSettings($envKey, $value);
+
+            if ($this->option('protect') && array_key_exists($envKey, $this->protectedConfig())) {
+                $value = $this->normalize($this->protectedConfig()[$envKey]);
+            }
 
             return $this->isEnv($matches[0]) ? $matches[0] : "'$configKey' => env('$envKey', {$value}),";
         };
@@ -391,6 +406,33 @@ class OctoberEnv extends Command
                 'REDIS_PASSWORD' => 'password',
                 'REDIS_PORT' => 'port',
             ],
+        ];
+    }
+
+    /**
+     * Config (env) keys of which the value should not be included in orginal config files anymore.
+     *
+     * @return array
+     */
+    private function protectedConfig()
+    {
+        return [
+            'APP_KEY' => 'CHANGE_ME!!!!!!!!!!!!!!!!!!!!!!!',
+
+            'DB_HOST' => 'localhost',
+            'DB_PORT' => 3306,
+            'DB_DATABASE' => 'database',
+            'DB_USERNAME' => 'root',
+            'DB_PASSWORD' => '',
+
+            'REDIS_HOST' => '127.0.0.1',
+            'REDIS_PASSWORD' => null,
+            'REDIS_PORT' => 6379,
+
+            'MAIL_HOST' => 'smtp.mailgun.org',
+            'MAIL_PORT' => 587,
+            'MAIL_USERNAME' => null,
+            'MAIL_PASSWORD' => null,
         ];
     }
 

--- a/modules/system/console/OctoberEnv.php
+++ b/modules/system/console/OctoberEnv.php
@@ -33,7 +33,24 @@ class OctoberEnv extends Command
     /**
      * Default configuration.
      */
-    protected $defaultConfig = $this->protectedConfig();
+    protected $defaultConfig = [
+        'APP_KEY' => 'CHANGE_ME!!!!!!!!!!!!!!!!!!!!!!!',
+
+        'DB_HOST' => 'localhost',
+        'DB_PORT' => 3306,
+        'DB_DATABASE' => 'database',
+        'DB_USERNAME' => 'root',
+        'DB_PASSWORD' => '',
+
+        'REDIS_HOST' => '127.0.0.1',
+        'REDIS_PASSWORD' => null,
+        'REDIS_PORT' => 6379,
+
+        'MAIL_HOST' => 'smtp.mailgun.org',
+        'MAIL_PORT' => 587,
+        'MAIL_USERNAME' => null,
+        'MAIL_PASSWORD' => null,
+    ];
 
     /**
      * The current database connection cursor.
@@ -200,8 +217,8 @@ class OctoberEnv extends Command
 
             $this->saveEnvSettings($envKey, $value);
 
-            if ($this->option('protect') && array_key_exists($envKey, $this->protectedConfig())) {
-                $value = $this->normalize($this->protectedConfig()[$envKey]);
+            if ($this->option('protect') && array_key_exists($envKey, $defaultConfig)) {
+                $value = $this->normalize($defaultConfig[$envKey]);
             }
 
             return $this->isEnv($matches[0]) ? $matches[0] : "'$configKey' => env('$envKey', {$value}),";
@@ -413,32 +430,4 @@ class OctoberEnv extends Command
             ],
         ];
     }
-
-    /**
-     * Config (env) keys of which the value should not be included in orginal config files anymore.
-     *
-     * @return array
-     */
-    private function protectedConfig()
-    {
-        return [
-            'APP_KEY' => 'CHANGE_ME!!!!!!!!!!!!!!!!!!!!!!!',
-
-            'DB_HOST' => 'localhost',
-            'DB_PORT' => 3306,
-            'DB_DATABASE' => 'database',
-            'DB_USERNAME' => 'root',
-            'DB_PASSWORD' => '',
-
-            'REDIS_HOST' => '127.0.0.1',
-            'REDIS_PASSWORD' => null,
-            'REDIS_PORT' => 6379,
-
-            'MAIL_HOST' => 'smtp.mailgun.org',
-            'MAIL_PORT' => 587,
-            'MAIL_USERNAME' => null,
-            'MAIL_PASSWORD' => null,
-        ];
-    }
-
 }

--- a/modules/system/console/OctoberEnv.php
+++ b/modules/system/console/OctoberEnv.php
@@ -217,8 +217,8 @@ class OctoberEnv extends Command
 
             $this->saveEnvSettings($envKey, $value);
 
-            if ($this->option('protect') && array_key_exists($envKey, $defaultConfig)) {
-                $value = $this->normalize($defaultConfig[$envKey]);
+            if ($this->option('protect') && array_key_exists($envKey, $this->defaultConfig)) {
+                $value = $this->normalize($this->defaultConfig[$envKey]);
             }
 
             return $this->isEnv($matches[0]) ? $matches[0] : "'$configKey' => env('$envKey', {$value}),";


### PR DESCRIPTION
My suggestion to fix issue #2949 

Added an option (`--protect`) to the `october:env` command, to replace some config values by a default, generic, value.