### PR TITLE
Allow using zero-keys in Filter widget options

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -742,7 +742,8 @@ class Filter extends WidgetBase
         }
 
         foreach ($options as $option) {
-            if (!$id = array_get($option, 'id')) {
+            $id = array_get($option, 'id');
+            if ($id === null) {
                 continue;
             }
             $processed[$id] = array_get($option, 'name');


### PR DESCRIPTION
This little change will allow using zero key in options array, like:


```
scopes:
    status:
        label: Status
        type: group
        scope: filterByStatus
        options:
            0: 'Default status'
            1: 'Defined status one'
            2: 'Defined status two'
```