### PR TITLE
Add support for hasManyThrough relationships in backend lists

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1413,6 +1413,7 @@ class RelationController extends ControllerBehavior
             case 'morphToMany':
             case 'morphedByMany':
             case 'belongsToMany':
+            case: 'hasManyThrough':
                 return 'multi';
 
             case 'hasOne':


### PR DESCRIPTION
When trying to show a list of hasManyThrough relationships, the backend is unable to create the widget because it does not have the hasManyThrough relationship type identified in the evalViewMode method.  By adding this value in the check, the backend is able to successfully render the relationship list.