### PR TITLE
Do not render the Theme Widget if CMS not loaded

### DIFF
--- a/modules/cms/reportwidgets/ActiveTheme.php
+++ b/modules/cms/reportwidgets/ActiveTheme.php
@@ -2,6 +2,7 @@
 
 use Lang;
 use Cms\Classes\Theme;
+use Cms\ServiceProvider;
 use Cms\Models\MaintenanceSetting;
 use Backend\Classes\ReportWidgetBase;
 use ApplicationException;
@@ -25,6 +26,12 @@ class ActiveTheme extends ReportWidgetBase
      */
     public function render()
     {
+        /**
+         * If the Cms module is not loaded, it makes no sense to render this widget.
+         */
+        if(!array_key_exists(ServiceProvider::class, app()->getLoadedProviders())) {
+            return false;
+        }
         try {
             $this->loadData();
         }


### PR DESCRIPTION
So, if the CMS module is not loaded, the default Theme report widget is still shown on the dashboard. This looks nasty, because translations are not resolved.

Also it makes no sense to render this widget. No CMS => no themes at all.

This PR returns false in the render function for the widget if the CMS module is not loaded.
<img width="570" alt="screen shot 2017-07-15 at 00 46 33" src="https://user-images.githubusercontent.com/271155/28232047-4f8126b0-68f7-11e7-95f9-0dc9498d336f.png">
