### PR TITLE
Add more granular permissions for editing themes

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -243,6 +243,11 @@ class ServiceProvider extends ModuleServiceProvider
                     'tab' => 'cms::lang.permissions.name',
                     'order' => 100
                 ],
+                'cms.manage_theme_options' => [
+                    'label' => 'cms::lang.permissions.manage_theme_options',
+                    'tab' => 'cms::lang.permissions.name',
+                    'order' => 100
+                ],
                 'media.manage_media' => [
                     'label' => 'cms::lang.permissions.manage_media',
                     'tab' => 'cms::lang.permissions.name',
@@ -276,7 +281,7 @@ class ServiceProvider extends ModuleServiceProvider
                     'category'    => SettingsManager::CATEGORY_CMS,
                     'icon'        => 'icon-picture-o',
                     'url'         => Backend::url('cms/themes'),
-                    'permissions' => ['cms.manage_themes'],
+                    'permissions' => ['cms.manage_themes', 'cms.manage_theme_options'],
                     'order'       => 200
                 ],
                 'maintenance_settings' => [

--- a/modules/cms/lang/en/lang.php
+++ b/modules/cms/lang/en/lang.php
@@ -35,7 +35,7 @@ return [
             'not_match' => "The object you're trying to access doesn't belong to the theme being edited. Please reload the page."
         ],
         'settings_menu' => 'Front-end theme',
-        'settings_menu_description' => 'Preview the list of installed themes and select an active theme.',
+        'settings_menu_description' => 'Manage the front-end theme',
         'default_tab' => 'Properties',
         'name_label' => 'Name',
         'name_create_placeholder' => 'New theme name',
@@ -259,6 +259,7 @@ return [
         'manage_layouts' => 'Create, modify and delete CMS layouts',
         'manage_partials' => 'Create, modify and delete CMS partials',
         'manage_themes' => 'Activate, deactivate and configure CMS themes',
+        'manage_theme_options' => 'Configure the currently active CMS theme',
         'manage_media' => 'Upload and manage media contents - images, videos, sounds, documents'
     ],
     'mediafinder' => [

--- a/modules/cms/twig/ComponentTokenParser.php
+++ b/modules/cms/twig/ComponentTokenParser.php
@@ -47,7 +47,7 @@ class ComponentTokenParser extends Twig_TokenParser
 
                 default:
                     throw new Twig_Error_Syntax(
-                        sprintf('Invalid syntax in the partial tag. Line %s', $lineno),
+                        sprintf('Invalid syntax in the component tag. Line %s', $lineno),
                         $stream->getCurrent()->getLine(),
                         $stream->getFilename()
                     );


### PR DESCRIPTION
Fixes #2930 by adding a new permission `edit_theme_options`, which provides the ability to manage only the currently selected theme's options. `edit_themes` retains its previous level of access, this is merely the addition of a new, more restrictive, theme managing permission.

```php
/**
 * Permission States:
 *      - cms.manage_themes
 *          - Can do everything
 *      - cms.manage_theme_options
 *          - Can only manage the currently active theme's options
 *          - All else gets redirected to the update screen for the current theme
 *      - none
 *          - deny all
 */
```