### PR TITLE
Do not change behavior: pass request data back to the options object

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -78,15 +78,15 @@ if (window.jQuery.request !== undefined) {
             $.extend(data, paramToObj('data-request-data', $(this).data('request-data')))
         })
 
-        if (options.data !== undefined && !$.isEmptyObject(options.data)) {
-            $.extend(data, options.data)
-        }
-
         if ($el.is(':input') && !$form.length) {
             inputName = $el.attr('name')
             if (inputName !== undefined && options.data[inputName] === undefined) {
-                data[inputName] = $el.val()
+                options.data[inputName] = $el.val()
             }
+        }
+
+        if (options.data !== undefined && !$.isEmptyObject(options.data)) {
+            $.extend(data, options.data)
         }
 
         if (useFiles) {


### PR DESCRIPTION
Current changes to the ``framework.js`` led to a breaking change due to the fact, that ``options.data`` was no longer populated with the request data. The ``options`` object is part of the ``context`` object, which is later beeing passed to ``ajaxBeforeSend``
The two relevant versions of the file show the change of behavior:
https://github.com/octobercms/october/blob/b6fedfb688e2d99461fd62b99bc8412f38502180/modules/system/assets/js/framework.js#L56 => https://github.com/octobercms/october/blob/develop/modules/system/assets/js/framework.js#L88
The change is required to remain consistent with the old behavior. This code is tested and appears to be working as it did formerly.