### PR TITLE
Fixed the slow query when Files are attached

### DIFF
--- a/modules/system/database/migrations/2017_08_04_121309_Db_Deferred_Bindings_Add_Index_Session.php
+++ b/modules/system/database/migrations/2017_08_04_121309_Db_Deferred_Bindings_Add_Index_Session.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class DbDeferredBindingsAlterSlaveToIntAndAddUniqueSession extends Migration
+class DbDeferredBindingsAddIndexSession extends Migration
 {
     /**
      * Run the migrations.

--- a/modules/system/database/migrations/2017_08_04_121309_Db_Deferred_Bindings_Add_Index_Session.php
+++ b/modules/system/database/migrations/2017_08_04_121309_Db_Deferred_Bindings_Add_Index_Session.php
@@ -13,7 +13,6 @@ class DbDeferredBindingsAlterSlaveToIntAndAddUniqueSession extends Migration
     public function up()
     {
         Schema::table('deferred_bindings', function (Blueprint $table) {
-            $table->integer('slave_id')->unsigned()->change();
             $table->index('session_key');
         });
     }
@@ -26,7 +25,6 @@ class DbDeferredBindingsAlterSlaveToIntAndAddUniqueSession extends Migration
     public function down()
     {
         Schema::table('deferred_bindings', function (Blueprint $table) {
-            $table->string('slave_id')->change();
             $table->dropIndex(['session_key']);
         });
     }

--- a/modules/system/database/migrations/2017_08_04_121309_Db_Deferred_Bindings_Alter_Slave_To_Int_And_Add_Unique_Session.php
+++ b/modules/system/database/migrations/2017_08_04_121309_Db_Deferred_Bindings_Alter_Slave_To_Int_And_Add_Unique_Session.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DbDeferredBindingsAlterSlaveToIntAndAddUniqueSession extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('deferred_bindings', function (Blueprint $table) {
+            $table->integer('slave_id')->unsigned()->change();
+            $table->index('session_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('deferred_bindings', function (Blueprint $table) {
+            $table->string('slave_id')->change();
+            $table->dropIndex(['session_key']);
+        });
+    }
+}


### PR DESCRIPTION
Created a migration that fixes this adding an index to session_key and changed slave_id to unsigned int in deferred_bindings

This fixes #2877 

I did it on master because it's a majority fix and it has to merged as soon as possible, if you don't accept, I can do it again on develop branch.