### PR TITLE
Improve support for scope properties

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -463,17 +463,33 @@ class Filter extends WidgetBase
             }
 
             /*
-             * Ensure dates options are set
+             * Ensure scope type options are set
              */
-            if (!isset($config['minDate'])) {
-                $scopeObj->minDate = '2000-01-01';
-                $scopeObj->maxDate = '2099-12-31';
+            $scopeProperties = [];
+            switch ($scopeObj->type) {
+                case 'date':
+                case 'daterange':
+                    $scopeProperties = [
+                        'minDate'   => '2000-01-01',
+                        'maxDate'   => '2099-12-31',
+                        'yearRange' => 10,
+                    ];
+
+                    break;
+            }
+
+            foreach ($scopeProperties as $property => $value) {
+                if (isset($config[$property])) {
+                    $value = $config[$property];
+                }
+
+                $scopeObj->{$property} = $value;
             }
 
             $this->allScopes[$name] = $scopeObj;
         }
     }
-    
+
     /**
      * Programatically remove a scope, used for extensibility.
      * @param string $scopeName Scope name

--- a/modules/backend/widgets/filter/partials/_scope_date.htm
+++ b/modules/backend/widgets/filter/partials/_scope_date.htm
@@ -5,8 +5,9 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'date' => isset($date) ? $date : null,
-        'minDate' => $scope->minDate ? $scope->minDate : '2000-01-01' ,
-        'maxDate' => $scope->maxDate ? $scope->maxDate : '2099-12-31',
+        'minDate' => $scope->minDate,
+        'maxDate' => $scope->maxDate,
+        'yearRange' => $scope->yearRange,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>

--- a/modules/backend/widgets/filter/partials/_scope_daterange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_daterange.htm
@@ -5,8 +5,9 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'dates' =>  [isset($after) ? $after : null, isset($before) ? $before : null],
-        'minDate' => $scope->minDate ? $scope->minDate : '2000-01-01',
-        'maxDate' => $scope->maxDate ? $scope->maxDate : '2099-12-31',
+        'minDate' => $scope->minDate,
+        'maxDate' => $scope->maxDate,
+        'yearRange' => $scope->yearRange,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>

--- a/modules/cms/widgets/MediaManager.php
+++ b/modules/cms/widgets/MediaManager.php
@@ -660,7 +660,7 @@ class MediaManager extends WidgetBase
             throw new ApplicationException('Invalid input data');
         }
 
-        return $this->putSession('media_filter', $filter);
+        $this->putSession('media_filter', $filter);
     }
 
     protected function getFilter()
@@ -688,7 +688,7 @@ class MediaManager extends WidgetBase
             throw new ApplicationException('Invalid input data');
         }
 
-        return $this->putSession('media_sort_by', $sortBy);
+        $this->putSession('media_sort_by', $sortBy);
     }
 
     protected function getSortBy()
@@ -741,7 +741,7 @@ class MediaManager extends WidgetBase
             throw new ApplicationException('Invalid input data');
         }
 
-        return $this->putSession('media_crop_selection_params', [
+        $this->putSession('media_crop_selection_params', [
             'mode'   => $selectionMode,
             'width'  => $selectionWidth,
             'height' => $selectionHeight
@@ -750,7 +750,7 @@ class MediaManager extends WidgetBase
 
     protected function setSidebarVisible($visible)
     {
-        return $this->putSession('sidebar_visible', !!$visible);
+        $this->putSession('sidebar_visible', !!$visible);
     }
 
     protected function getSidebarVisible()
@@ -800,7 +800,7 @@ class MediaManager extends WidgetBase
             throw new ApplicationException('Invalid input data');
         }
 
-        return $this->putSession('view_mode', $viewMode);
+        $this->putSession('view_mode', $viewMode);
     }
 
     protected function getViewMode()

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -253,7 +253,7 @@
                 defaults = {
                     minDate: new Date(scopeData.minDate),
                     maxDate: new Date(scopeData.maxDate),
-                    yearRange: 10,
+                    yearRange: scopeData.yearRange,
                     setDefaultDate: '' !== defaultValue ? defaultValue.toDate() : '',
                     format: self.getDateFormat(),
                     i18n: self.getLang('datepicker')


### PR DESCRIPTION
Fixes #3019.

Enables defining `minDate`, `maxDate`, and `yearRange` on `date` and `daterange` filter scope types in the YAML configuration.

Example:
```yaml
created_at:
    type: date
    minDate: '2001-04-01'  # The earliest date than can be selected by this filter
    maxDate: '2016-02-18' # The latest date that can be selected by this filter
    yearRange: 2 # How many years should be displayed to choose between above and below the current year in the year selection dropdown
```