### PR TITLE
Dynamic plugin dependencies

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -635,6 +635,10 @@ class PluginManager
         if (is_string($plugin) && (!$plugin = $this->findByIdentifier($plugin))) {
             return false;
         }
+        
+        if (method_exists($plugin, 'setRequiredPlugins')) {
+		    $plugin->require = $plugin->setRequiredPlugins();
+	    }
 
         if (!isset($plugin->require) || !$plugin->require) {
             return null;


### PR DESCRIPTION
This allows plugins the ability to declare their dependencies at run time and solves an issue where Plugin A can optionally extend Plugin B and Plugin C. 

When running `october:up` - the dependency order won't be set correctly for Plugin A as Plugin B and C are optional and can't be added to the usual `$require` property. However there may be conditional migrations in Plugin A that depend on the base tables being present from either Plugin B or C.

`setRequiredPlugins()` should return either a string or array in the same way as `$require`. See below for usage example.

```php
public function setRequiredPlugins()
{
    $requires = [];
    if (PluginManager::instance()->hasPlugin('RainLab.Blog')) {
        $requires[] = 'RainLab.Blog';
    }
		
    return $requires;
}
```