### PR TITLE
Attribute values for < and > and " should be written als &lt; &gt; and &quot;

### DIFF
--- a/modules/cms/widgets/mediamanager/partials/_upload-progress.htm
+++ b/modules/cms/widgets/mediamanager/partials/_upload-progress.htm
@@ -3,7 +3,7 @@
         <div class="upload-progress">
             <h5 
                 data-label="file-number-and-progress"
-                data-message-template="<?= e(trans('cms::lang.media.uploading_file_num')) ?> <span>:percents</span>"
+                data-message-template="<?= e(trans('cms::lang.media.uploading_file_num')) ?> &lt;span&gt;:percents&lt;/span&gt;"
                 data-success-template="<?= e(trans('cms::lang.media.uploading_complete')) ?>"
                 data-error-template="<?= e(trans('cms::lang.media.uploading_error')) ?>"
             ></h5>


### PR DESCRIPTION
Attribute values for < and > and " should be written als &lt; &gt; and &quot;

This way you can be sure that   

  A) browsers don't execute rogue html/throw parsing exceptions when they behave stupid, and  
  B) IDE's won't throw invalid html warnings.  

