### PR TITLE
Fixes component default template overrides

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -823,6 +823,14 @@ class Controller
             }
 
             /*
+             * Check for default partial override
+             */
+            if ($partial === null) {
+                $overrideName = $componentObj->name . '/' . $partialName;
+                $partial = Partial::loadCached($this->theme, $overrideName);
+            }
+
+            /*
              * Check the component partial
              */
             if ($partial === null) {


### PR DESCRIPTION
Component default template overrides weren't working due to the different alias of the new instance of the component