### PR TITLE
Add temp folder path into config

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -255,6 +255,7 @@ return [
     */
 
     'storage' => [
+        'temp' => '/storage/temp',
 
         'uploads' => [
             'disk'   => 'local',

--- a/modules/cms/widgets/MediaManager.php
+++ b/modules/cms/widgets/MediaManager.php
@@ -870,7 +870,7 @@ class MediaManager extends WidgetBase
 
     protected function getThumbnailImageUrl($imagePath)
     {
-        return Url::to('/storage/temp'.$imagePath);
+        return Url::to(Config::get('cms.storage.temp', '/storage/temp').$imagePath);
     }
 
     protected function thumbnailExists($thumbnailParams, $itemPath, $lastModified)


### PR DESCRIPTION
The temp folder is not configurable currently, but I think this should be a feature of October's CMS configuration as the media, uploads, sessions, cache, and theme directories are already configurable.

**Scenario**
When configuring the media directory path to a different location, or onto a shared mount, this can place `storage/app/media` and `storage/app/uploads` in a separate path from `storage/temp`. This causes issues when cropping or resizing a media file to not be available in the shared mount.

```
/var/www/storage/app --> /var/share/storage/app
    /var/www/storage/app/media   --> /var/share/storage/app/media
    /var/www/storage/app/uploads --> /var/share/storage/app/uploads
```

If we could just configure the temp directory path, even say to be `storage/app/temp` then we could mount a single shared directory at `storage/app`.

```
/var/www/storage/app --> /var/share/storage/app
    /var/www/storage/app/media   --> /var/share/storage/app/media
    /var/www/storage/app/uploads --> /var/share/storage/app/uploads
    /var/www/storage/app/temp    --> /var/share/storage/app/temp
```

I also did some research and figured out that the config will not work unless we overwrite the `temp_path` function as so:
```
     app()->instance('path.temp', $this->tempPath());

    public function tempPath()
    {
        return base_path().config('cms.storage.temp');
    }
```
This could also be added in private plugins, and not use the `temp_path()` function.