### PR TITLE
Replace old selenium functional testing for the new Laravel Dusk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,15 @@
     "require-dev": {
         "fzaninotto/faker": "~1.4",
         "phpunit/phpunit": "~5.7",
-        "phpunit/phpunit-selenium": "~1.2"
+        "laravel/dusk": "^1.1"
     },
     "autoload-dev": {
         "classmap": [
             "tests/TestCase.php",
             "tests/UiTestCase.php",
-            "tests/PluginTestCase.php"
+            "tests/PluginTestCase.php",
+            "tests/CreatesApplication.php",
+            "tests/DuskTestCase.php"
         ]
     },
     "scripts": {

--- a/config/dusk/app.php
+++ b/config/dusk/app.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'providers' => array_merge(include(base_path('modules/system/providers.php')), [
+        'System\ServiceProvider',
+        \Laravel\Dusk\DuskServiceProvider::class
+    ])
+];

--- a/config/dusk/database.php
+++ b/config/dusk/database.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'default' => 'sqlite_testing',
+    'connections' => [
+        'sqlite_testing' => [
+            'driver' => 'sqlite',
+            'database' => storage_path('testing.sqlite'),
+        ]
+    ]
+];

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Browser;
+
+class HomePage extends Page
+{
+    /**
+     * Get the URL for the page.
+     *
+     * @return string
+     */
+    public function url()
+    {
+        return '/';
+    }
+
+    /**
+     * Assert that the browser is on the page.
+     *
+     * @param  Browser  $browser
+     * @return void
+     */
+    public function assert(Browser $browser)
+    {
+        //
+    }
+
+    /**
+     * Get the element shortcuts for the page.
+     *
+     * @return array
+     */
+    public function elements()
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/Browser/Pages/Page.php
+++ b/tests/Browser/Pages/Page.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Page as BasePage;
+
+abstract class Page extends BasePage
+{
+    /**
+     * Get the global element shortcuts for the site.
+     *
+     * @return array
+     */
+    public static function siteElements()
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/Browser/backend/AuthTest.php
+++ b/tests/Browser/backend/AuthTest.php
@@ -1,0 +1,54 @@
+<?php namespace Tests\Browser\Backend;
+
+use Laravel\Dusk\Browser;
+
+class AuthTest extends \UiTestCase
+{
+    /**
+     * @group auth
+     */
+    public function testSignInAndOut()
+    {
+        $this->signInToBackend();
+
+        $cssOpenLogoutLink = '#layout-mainmenu .mainmenu-account > a:first-child';
+        $cssLogoutLink = '#layout-mainmenu .mainmenu-accountmenu > ul > li:last-child > a';
+        $this->browse(function (Browser $browser) use ($cssLogoutLink, $cssOpenLogoutLink) {
+
+            $browser->assertTitle('Dashboard | OctoberCMS');
+
+            //Log out
+            $browser->element($cssOpenLogoutLink)->click();
+            $logoutLinkEl = $browser->element($cssLogoutLink);
+            $this->assertNotNull($logoutLinkEl);
+            $this->assertEquals('Sign out', $this->getTextFromElement($logoutLinkEl));
+            $logoutLinkEl->click();
+
+            $browser->waitFor(".login-button")
+                ->assertTitle('Administration Area');
+        });
+    }
+
+    /**
+     * @group auth
+     */
+    public function testPasswordReset()
+    {
+        $this->browse(function(Browser $browser){
+            $browser->visit('backend');
+
+            $browser->assertSee('Forgot your password?');
+            $browser->clickLink('Forgot your password?');
+            $browser->waitFor('.restore-button');
+            $browser->assertSeeIn('.restore-button','Restore');
+
+            $browser->assertSeeLink('Cancel');
+            $browser->type('login','admin');
+            $browser->press('Restore');
+
+            $browser->assertTitle('Administration Area');
+            $browser->waitFor('p.flash-message.success');
+            $browser->assertSeeIn('p.flash-message.success','Message sent to your email address with instructions.');
+        });
+    }
+}

--- a/tests/Browser/cms/TemplateTest.php
+++ b/tests/Browser/cms/TemplateTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Tests\Browser\Cms;
+
+use Laravel\Dusk\Browser;
+use Config;
+
+class TemplateTest extends \UiTestCase
+{
+
+    private $theme;
+
+    private $fakePath = '/xxx/functional/test/';
+
+    private $fakeName = 'xxx_functional_test';
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->theme = Config::get('cms.activeTheme');
+        $this->clean();
+    }
+
+    private function fixSidebar(Browser $browser)
+    {
+        $browser->waitUntil('document.getElementsByClassName("fix-button")[0].style.display="block";');
+    }
+
+    /**
+     * @group templates
+     */
+    public function testCmsPages()
+    {
+
+        $this->signInToBackend();
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit('backend/cms')
+                ->assertPathIs('/backend/cms');
+
+            $this->fixSidebar($browser);
+
+            $browser->click("form[data-template-type='page'] button[data-control='create-template']");
+            $browser->waitFor("input[name='settings[title]']");
+
+            //Populate page details
+            $browser->type('settings[title]', 'Functional Test Page');
+            $browser->type('settings[url]', "{$this->fakePath}page");
+            $browser->type('fileName', "{$this->fakeName}_page");
+
+            //Save the new page
+            $pageSelector = "li[data-tab-id='page-{$this->theme}-{$this->fakeName}_page.htm']";
+            $browser->click('a[data-request=onSave]');
+            $browser->waitFor("$pageSelector");
+
+            //Close the tab
+            $browser->waitUntilMissing('.flash-message', 7);
+            $browser->click("$pageSelector span.tab-close");
+
+            //Reopen the tab
+            $pageToOpenSelector = "div#TemplateList-pageList-template-list ul > li[data-item-path='{$this->fakeName}_page.htm'] a";
+            $browser->waitFor($pageToOpenSelector);
+            $browser->click($pageToOpenSelector);
+            $browser->waitFor("input[name='settings[title]']");
+
+            $browser->pause(100);
+
+            //Delete the page
+            $browser->click('button[data-request="onDelete"]');
+
+            $browser->whenAvailable('.sweet-alert', function ($sweetAlert) {
+                $sweetAlert->assertSee('Delete this page?');
+                $sweetAlert->pause(1000); //Wait for the correct DOM binding to the button
+                $sweetAlert->press('OK');
+            });
+
+            $browser->waitUntilMissing("input[name='settings[title]']");
+
+        });
+    }
+
+    /**
+     * @group templates
+     */
+
+    public function testCmsPartials()
+    {
+
+        $this->browse(function (Browser $browser) {
+
+            $browser->visit('backend/cms');
+
+            $browser->assertPathIs('/backend/cms');
+
+            $this->fixSidebar($browser);
+
+            //Click partials menu item
+
+            $browser->click('li[data-menu-item="partials"] > a');
+
+            //Create a new partial
+
+            $browser->click('form[data-template-type="partial"] button[data-control="create-template"]');
+            $browser->waitFor("input[name='fileName']");
+
+            //Populate partial details
+
+            $browser->type('fileName', "{$this->fakeName}_partial");
+            $browser->type('settings[description]', 'Test partial');
+
+            //Save the new partial
+
+            $partialSelector = "li[data-tab-id='partial-{$this->theme}-{$this->fakeName}_partial.htm']";
+            $browser->click('a[data-request="onSave"]');
+            $browser->waitFor($partialSelector);
+
+            //Close the tab
+
+            $browser->waitUntilMissing('.flash-message', 7);
+            $browser->click("$partialSelector span.tab-close");
+
+            //Reopen the tab
+            $partialToOpenSelector = "div#TemplateList-partialList-template-list ul > li[data-item-path='{$this->fakeName}_partial.htm'] a";
+            $browser->waitFor($partialToOpenSelector);
+            $browser->click($partialToOpenSelector);
+            $browser->waitFor("input[name='fileName']");
+
+            $browser->pause(100);
+
+            //Delete the page
+            $browser->click('button[data-request="onDelete"]');
+
+            $browser->whenAvailable('.sweet-alert', function ($sweetAlert) {
+                $sweetAlert->assertSee('Delete this partial?');
+                $sweetAlert->pause(1000); //Wait for the correct DOM binding to the button
+                $sweetAlert->press('OK');
+            });
+
+            $browser->waitUntilMissing("input[name='fileName']");
+
+        });
+    }
+
+    public function testCmsLayout()
+    {
+
+        $this->browse(function (Browser $browser) {
+
+            $browser->visit('backend/cms');
+
+            $browser->assertPathIs('/backend/cms');
+
+            $this->fixSidebar($browser);
+
+            //Click layouts menu item
+
+            $browser->click('li[data-menu-item="layouts"] > a');
+
+            //Create a new layout
+
+            $browser->click('form[data-template-type="layout"] button[data-control="create-template"]');
+            $browser->waitFor("input[name='fileName']");
+
+            //Populate layout details
+
+            $browser->type('fileName', "{$this->fakeName}_layout");
+            $browser->type('settings[description]', 'Test layout');
+
+            //Save the new layout
+
+            $partialSelector = "li[data-tab-id='layout-{$this->theme}-{$this->fakeName}_layout.htm']";
+            $browser->click('a[data-request="onSave"]');
+            $browser->waitFor($partialSelector);
+
+            //Close the tab
+
+            $browser->waitUntilMissing('.flash-message', 7);
+            $browser->click("$partialSelector span.tab-close");
+
+            //Reopen the tab
+            $partialToOpenSelector = "div#TemplateList-layoutList-template-list ul > li[data-item-path='{$this->fakeName}_layout.htm'] a";
+            $browser->waitFor($partialToOpenSelector);
+            $browser->click($partialToOpenSelector);
+            $browser->waitFor("input[name='fileName']");
+
+            $browser->pause(100);
+
+            //Delete the page
+            $browser->click('button[data-request="onDelete"]');
+
+            $browser->whenAvailable('.sweet-alert', function ($sweetAlert) {
+                $sweetAlert->assertSee('Delete this layout?');
+                $sweetAlert->pause(1000); //Wait for the correct DOM binding to the button
+                $sweetAlert->press('OK');
+            });
+
+            $browser->waitUntilMissing("input[name='fileName']");
+
+        });
+    }
+
+    public function testCmsContent()
+    {
+
+        $this->browse(function (Browser $browser) {
+
+            $browser->visit('backend/cms');
+
+            $browser->assertPathIs('/backend/cms');
+
+            $this->fixSidebar($browser);
+
+            //Click contents menu item
+
+            $browser->click('li[data-menu-item="content"] > a');
+
+            //Create a new content
+
+            $browser->click('form[data-template-type="content"] button[data-control="create-template"]');
+            $browser->waitFor("input[name='fileName']");
+
+            //Populate contents defails
+
+            $browser->type('fileName', "{$this->fakeName}_content.txt");
+
+            //Save the new content
+
+            $contentSelector = "li[data-tab-id='content-{$this->theme}-{$this->fakeName}_content.txt']";
+            $browser->click('a[data-request="onSave"]');
+            $browser->waitFor($contentSelector);
+
+            //Close the tab
+
+            $browser->waitUntilMissing('.flash-message', 7);
+            $browser->click("$contentSelector span.tab-close");
+
+            //Reopen the tab
+            $partialToOpenSelector = "div#TemplateList-contentList-template-list ul > li[data-item-path='{$this->fakeName}_content.txt'] a";
+            $browser->waitFor($partialToOpenSelector);
+            $browser->click($partialToOpenSelector);
+            $browser->waitFor("input[name='fileName']");
+
+            $browser->pause(100);
+
+            //Delete the page
+            $browser->click('button[data-request="onDelete"]');
+
+            $browser->whenAvailable('.sweet-alert', function ($sweetAlert) {
+                $sweetAlert->assertSee('Delete this content file?');
+                $sweetAlert->pause(1000); //Wait for the correct DOM binding to the button
+                $sweetAlert->press('OK');
+            });
+
+            $browser->waitUntilMissing("input[name='fileName']");
+
+        });
+
+    }
+
+    public function tearDown()
+    {
+        $this->clean();
+        parent::tearDown();
+    }
+
+    private function clean()
+    {
+        collect(['page', 'partial', 'layout'])->each(function ($dir) {
+            $file = themes_path("{$this->theme}/{$dir}s/{$this->fakeName}_{$dir}.htm");
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        });
+        $txt = themes_path("{$this->theme}/content/{$this->fakeName}_content.txt");
+        if (file_exists($txt)) {
+            unlink($txt);
+        }
+    }
+
+}

--- a/tests/Browser/console/.gitignore
+++ b/tests/Browser/console/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Browser/screenshots/.gitignore
+++ b/tests/Browser/screenshots/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php namespace Tests;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        /**
+         * Creates the application.
+         *
+         * @return \Illuminate\Foundation\Application
+         */
+        $app = require __DIR__ . '/../bootstrap/app.php';
+        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $app['cache']->setDefaultDriver('array');
+        $app->setLocale('en');
+        return $app;
+    }
+}

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests;
+
+use Laravel\Dusk\TestCase as BaseTestCase;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+
+abstract class DuskTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+
+    /**
+     * Prepare for Dusk test execution.
+     *
+     * @beforeClass
+     * @return void
+     */
+    public static function prepare()
+    {
+        static::startChromeDriver();
+    }
+
+    /**
+     * Create the RemoteWebDriver instance.
+     *
+     * @return \Facebook\WebDriver\Remote\RemoteWebDriver
+     */
+    protected function driver()
+    {
+        return RemoteWebDriver::create(
+            'http://localhost:9515', DesiredCapabilities::chrome()
+        );
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,37 +58,20 @@ The test class should extend the base class `PluginTestCase` and this is a speci
 
 Unit tests can be performed by running `phpunit` in the root directory or inside `/tests/unit`.
 
-### Functional tests
+### Functional tests with Laravel Dusk
 
-Functional tests can be performed by running `phpunit` in the `/tests/functional` directory. Ensure the following configuration is met:
+Functional tests can be performed by running `php artisan dusk` in the root of the project. Ensure the following configuration is met:
 
 - Active theme is `demo`
 - Language preference is `en`
+- A sqlite file located at 'storage/testing.sqlite'
 
-#### Selenium set up
+> You will need a real sqlite database to perform the functional testing because Laravel Dusk use a different process to execute the tests.
 
-1. Download latest Java SE from http://java.sun.com/ and install
-1. Download a distribution archive of [Selenium Server](http://seleniumhq.org/download/).
-1. Unzip the distribution archive and copy selenium-server-standalone-2.42.2.jar (check the version suffix) to /usr/local/bin, for instance.
-1. Start the Selenium Server server by running `java -jar /usr/local/bin/selenium-server-standalone-2.42.2.jar`.
+To be able to run the `dusk` artisan command it's necessary to register the Laravel Dusk Provider, a dusk configuration was added to the `config` directory so you only need to create an enviroment file `.env` with the following line.
 
-#### Selenium configuration
+```
+    APP_ENV=dusk
+```
 
-Create a new file `selenium.php` in the root directory, add the following content:
-
-    <?php
-
-    // Selenium server details
-    define('TEST_SELENIUM_HOST', '127.0.0.1');
-    define('TEST_SELENIUM_PORT', 4444);
-    define('TEST_SELENIUM_BROWSER', '*firefox');
-
-    // Back-end URL
-    define('TEST_SELENIUM_URL', 'http://localhost/backend/');
-
-    // Active Theme
-    define('TEST_SELENIUM_THEME', 'demo');
-
-    // Back-end credentials
-    define('TEST_SELENIUM_USER', 'admin');
-    define('TEST_SELENIUM_PASS', 'admin');
+For more information about Laravel Dusk please read the [Docs](https://laravel.com/docs/5.4/dusk).

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,22 +1,8 @@
 <?php
 
+use Tests\CreatesApplication;
+
 class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
-
-    /**
-     * Creates the application.
-     *
-     * @return \Illuminate\Foundation\Application
-     */
-    public function createApplication()
-    {
-        $app = require __DIR__.'/../bootstrap/app.php';
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
-
-        $app['cache']->setDefaultDriver('array');
-        $app->setLocale('en');
-
-        return $app;
-    }
-
+    use CreatesApplication;
 }


### PR DESCRIPTION
Hi OctoBros! 👊

I have updated the functional tests to meet the new Laravel dusk features and be able to test the CMS features and also provide to the users a powerful and easy way to test their plugins.

I added a `dusk` folder inside the config directory to be able to config the default service provider used by dusk and be able to easily integrate in any continuous integration platform.

I think this is a huge advantage to avoid the selenium nightmare, and provide to the users a super easy and natural functional testing.

The user only have to setup the enviroment to `APP_ENV=dusk` and done

![image](https://user-images.githubusercontent.com/4997549/29644032-ca54f596-8838-11e7-8515-cf35bed38cde.png)
