### PR TITLE
Update RelationController.php

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1203,7 +1203,9 @@ class RelationController extends ControllerBehavior
         elseif ($this->viewMode == 'single') {
             if ($this->relationType == 'belongsTo') {
                 $this->relationObject->dissociate();
-                $this->relationObject->getParent()->save();
+                if ($this->relationObject->getParent()->exists){
+                    $this->relationObject->getParent()->save();
+                }
             }
             elseif ($this->relationType == 'hasOne' || $this->relationType == 'morphOne') {
                 if ($obj = $relatedModel->find($recordId)) {


### PR DESCRIPTION
On unlinking a related model - now checks if the Parent of the related model exists before trying to save it, (as otherwise it will try and save a record before the user has finished filling out the backend form, and you get validation errors before the user has actually clicked save)