### PR TITLE
Configure APP_URL in testing environment

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
     </testsuites>
     <php>
         <env name="APP_ENV" value="testing" />
+        <env name="APP_URL" value="http://localhost" />
         <env name="CACHE_DRIVER" value="array" />
         <env name="SESSION_DRIVER" value="array" />
     </php>


### PR DESCRIPTION
This fixes #2939, where `ControllerTest::testThemeUrl` fails when the configured url is not `localhost`.