### PR TITLE
Allow simple pagination option on ListControllers

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -141,6 +141,7 @@ class ListController extends ControllerBehavior
             'recordUrl',
             'recordOnClick',
             'recordsPerPage',
+            'showPageNumbers',
             'noRecordsMessage',
             'defaultSort',
             'showSorting',
@@ -456,7 +457,7 @@ class ListController extends ControllerBehavior
     public function listExtendColumns($host)
     {
     }
-    
+
     /**
      * Called after the filter scopes are defined.
      * @param \Backend\Widgets\Filter $host The hosting filter widget
@@ -559,7 +560,7 @@ class ListController extends ControllerBehavior
             call_user_func_array($callback, [$widget, $widget->model]);
         });
     }
-    
+
      /**
      * Static helper for extending filter scopes.
      * @param  callable $callback

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -97,6 +97,11 @@ class Lists extends WidgetBase
     public $showPagination = 'auto';
 
     /**
+     * @var bool Display page numbers when pagination is enabled
+     */
+    public $showPageNumbers = true;
+
+    /**
      * @var string Specify a custom view path to override partials used by the list.
      */
     public $customViewPath;
@@ -190,6 +195,7 @@ class Lists extends WidgetBase
             'recordUrl',
             'recordOnClick',
             'noRecordsMessage',
+            'showPageNumbers',
             'recordsPerPage',
             'showSorting',
             'defaultSort',
@@ -248,6 +254,7 @@ class Lists extends WidgetBase
         $this->vars['showCheckboxes'] = $this->showCheckboxes;
         $this->vars['showSetup'] = $this->showSetup;
         $this->vars['showPagination'] = $this->showPagination;
+        $this->vars['showPageNumbers'] = $this->showPageNumbers;
         $this->vars['showSorting'] = $this->showSorting;
         $this->vars['sortColumn'] = $this->getSortColumn();
         $this->vars['sortDirection'] = $this->sortDirection;
@@ -255,11 +262,15 @@ class Lists extends WidgetBase
         $this->vars['treeLevel'] = 0;
 
         if ($this->showPagination) {
-            $this->vars['recordTotal'] = $this->records->total();
             $this->vars['pageCurrent'] = $this->records->currentPage();
-            $this->vars['pageLast'] = $this->records->lastPage();
-            $this->vars['pageFrom'] = $this->records->firstItem();
-            $this->vars['pageTo'] = $this->records->lastItem();
+            if ($this->showPageNumbers) {
+                $this->vars['recordTotal'] = $this->records->total();
+                $this->vars['pageLast'] = $this->records->lastPage();
+                $this->vars['pageFrom'] = $this->records->firstItem();
+                $this->vars['pageTo'] = $this->records->lastItem();
+            } else {
+                $this->vars['hasMorePages'] = $this->records->hasMorePages();
+            }
         }
         else {
             $this->vars['recordTotal'] = $this->records->count();
@@ -518,7 +529,10 @@ class Lists extends WidgetBase
             $records = $model->getNested();
         }
         elseif ($this->showPagination) {
-            $records = $model->paginate($this->recordsPerPage, $this->currentPageNumber);
+            $paginationMethod = $this->showPageNumbers
+                ? 'paginate'
+                : 'simplePaginate';
+            $records = $model->{$paginationMethod}($this->recordsPerPage, $this->currentPageNumber);
         }
         else {
             $records = $model->get();

--- a/modules/backend/widgets/lists/partials/_list.htm
+++ b/modules/backend/widgets/lists/partials/_list.htm
@@ -18,7 +18,11 @@
     <?php if ($showPagination): ?>
         <div class="list-footer">
             <div class="list-pagination">
+                <?php if ($showPageNumbers): ?>
                 <?= $this->makePartial('list_pagination') ?>
+                <?php else: ?>
+                <?= $this->makePartial('list_pagination_simple') ?>
+                <?php endif ?>
             </div>
         </div>
     <?php endif ?>

--- a/modules/backend/widgets/lists/partials/_list_pagination_simple.htm
+++ b/modules/backend/widgets/lists/partials/_list_pagination_simple.htm
@@ -1,0 +1,49 @@
+<div class="loading-indicator-container size-small pull-right">
+    <div class="control-pagination">
+        <?php if ($pageCurrent > 1): ?>
+            <a
+                href="javascript:;"
+                class="page-first"
+                data-request="<?= $this->getEventHandler('onPaginate') ?>"
+                data-request-data="page: 1"
+                data-load-indicator="<?= e(trans('backend::lang.list.loading')) ?>"
+                title="<?= e(trans('backend::lang.list.first_page')) ?>"></a>
+        <?php else: ?>
+            <span
+                class="page-first"
+                title="<?= e(trans('backend::lang.list.first_page')) ?>"></span>
+        <?php endif ?>
+        <?php if ($pageCurrent > 1): ?>
+            <a
+                href="javascript:;"
+                class="page-back"
+                data-request="<?= $this->getEventHandler('onPaginate') ?>"
+                data-request-data="page: <?= $pageCurrent-1 ?>"
+                data-load-indicator="<?= e(trans('backend::lang.list.loading')) ?>"
+                title="<?= e(trans('backend::lang.list.prev_page')) ?>"></a>
+        <?php else: ?>
+            <span
+                class="page-back"
+                title="<?= e(trans('backend::lang.list.prev_page')) ?>"></span>
+        <?php endif ?>
+        <select
+            disabled
+            name="page"
+            class="form-control input-sm custom-select select-no-search">
+                <option value="<?= $pageCurrent ?>" selected><?= $pageCurrent ?></option>
+        </select>
+        <?php if ($hasMorePages): ?>
+            <a
+                href="javascript:;"
+                class="page-next"
+                data-request-data="page: <?= $pageCurrent+1 ?>"
+                data-request="<?= $this->getEventHandler('onPaginate') ?>"
+                data-load-indicator="<?= e(trans('backend::lang.list.loading')) ?>"
+                title="<?= e(trans('backend::lang.list.next_page')) ?>"></a>
+        <?php else: ?>
+            <span
+                class="page-next"
+                title="<?= e(trans('backend::lang.list.next_page')) ?>"></span>
+        <?php endif ?>
+    </div>
+</div>


### PR DESCRIPTION
In response from #2788 this adds additional `showPageNumbers` option on Lists widget (consequently on list_config.yaml) to deal with tables with millions of records. This improves performance in general and also prevent HTML render stalled by populating page dropdown `<option></option>` in pagination partial.

If this is okay, then we should also proceed with making changes to the list_config.yaml stub in October/Rain repo, and also the documentation repo to introduce this additional feature.