### PR TITLE
Fix for RichEditor root page links being returned with empty hrefs.

### DIFF
--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -223,6 +223,13 @@ class RichEditor extends FormWidgetBase
                     $linkUrl = substr($linkUrl, strlen($baseUrl));
                 }
 
+                /*
+                 * Root page fallback.
+                 */
+                if (strlen($linkUrl) === 0) {
+                    $linkUrl = '/';
+                }
+
                 $linkName = str_repeat('&nbsp;', $level * 4);
                 $linkName .= is_array($link) ? array_get($link, 'title', '') : $link;
                 $result[] = ['name' => $linkName, 'url' => $linkUrl];


### PR DESCRIPTION
Fixes second bullet point issue from https://github.com/octobercms/october/issues/3064#issuecomment-326008148.

Introduced special handling for root pages, where root page is classified as such due to it's href being "/".