### PR TITLE
RichEditor Page Links, save and restore selections accordingly.

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
@@ -54,6 +54,9 @@ $.FroalaEditor.DEFAULTS.key = 'HHMDUGENKACTMXQL==';
                 $input = $(check_inputs[i]);
                 $input.prop('checked', $input.data('checked') == link[$input.attr('name')]);
             }
+
+            // Restore selection, so that the link gets inserted properly.
+            editor.selection.restore();
         }
 
         function insertLink() {
@@ -61,6 +64,9 @@ $.FroalaEditor.DEFAULTS.key = 'HHMDUGENKACTMXQL==';
 
             editor.$el.popup({
                 handler: editor.opts.pageLinksHandler
+            }).one('shown.oc.popup.pageLinks', function () {
+              // I still have no idea why selection is only restored after popup is actually shown.
+              editor.selection.save()
             })
         }
 


### PR DESCRIPTION
Fixes reported #3064, explicitly, fourth bullet point issue from https://github.com/octobercms/october/issues/3064#issuecomment-326008148

I had to add this extra event, because, before the popup is shown, editor seems to have lost it's track of selection.

Somehow (couldn't actually find out why) the selection is restored once the popup has been shown (not on "_show_", but explicitly "_shown_").  
I tracked it down visually and by accident, even by debugging I couldn't find the actual code where and why the selection gets restored back once the popup is shown. While debugging I did trace it down to [these lines](https://github.com/octobercms/october/blob/4074ad8cc9c20a3196f058e908d98c5efca9ad1b/modules/system/assets/js/framework.js#L304): before triggering the events no selection was active, after the events, selection is back on track. I did a search over the code to find any listeners to `ajaxUpdateComplete` but I could find any that would resemble anything about selections...

So yeah, after the popup was shown, I noticed how at that point clicking anywhere on the page (which includes the pageLinks select field) removed the selection from editor, and possibly focus too, though, Froala didn't emit blur event then<sup>1</sup>. The selection never got restored back after that.

My first attempt was to use "_show_" event, but it was fired before the selection got restored, so I attempted "_shown_" and voila, that's where I save the selection.

And then, knowing that while the popup is active the selection will be forgotten, I restore selection only after the actual link values are being set back on Froala's `links.popup`.

I'm not really happy about this fix, but I'm providing this PR so that we can continue to investigate this further, knowing that you guys might know what's going on there. Or, if we don't find out proper solution, then this could stay as a fix.

I chose `one` instead of `on`, because popup is cached internally and `on` did bind multiple events.

<sup>1</sup> I actually found the `blur` event quite unreliable through my debugging. There are plenty of times when `blur` isn't called even though Froala has lost focus. That, obviously, feeds back to focus not being fired when Froala gets the actual focus back, but that's a whole other issue. Maybe internally Froala remains focused at all times, but if that's so, then whole focus/blur system is totally unreliable. I really expect it to lose focus when I activate an actual input field... _Yeah, froala's blur event wasn't called even when I clicked the pageLinks select field._