### PR TITLE
RichEditor Page Links, don't update Froala's link.popup text if it is already filled.

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
@@ -42,11 +42,16 @@ $.FroalaEditor.DEFAULTS.key = 'HHMDUGENKACTMXQL==';
             var i;
             for (i = 0; i < text_inputs.length; i++) {
                 $input = $(text_inputs[i]);
-                if (link[$input.attr('name')]) {
-                    $input.val(link[$input.attr('name')]);
-                }
-                else if ($input.attr('name') != 'text') {
-                    $input.val('');
+                var name = $input.attr('name');
+                var value = link[name];
+
+                if (name === 'text') {
+                    // Change link popup text, only if it is not already filled.
+                    if ($input.val().length === 0) {
+                        $input.val(value);
+                    }
+                } else {
+                    $input.val(value);
                 }
             }
 


### PR DESCRIPTION
Fixes third bullet point issue from https://github.com/octobercms/october/issues/3064#issuecomment-326008148.

I found the previous _if checks_ quite ambiguous, hence introduced a new one:

1. Change value of text field only if current value was not set, as to not override.
2. Change values of matching input fields to provided values. Seems to me, to be compliant with previous routine.