### PR TITLE
Fix subject escaped twice in mail template

### DIFF
--- a/modules/system/views/mail/layout-default.htm
+++ b/modules/system/views/mail/layout-default.htm
@@ -18,7 +18,7 @@ name = "Default layout"
 
         <!-- Header -->
         {% partial 'header' body %}
-            {{ subject }}
+            {{ subject|raw }}
         {% endpartial %}
 
         <tr>


### PR DESCRIPTION
Before this PR, when sending a mail with the default template and setting the subject as `Nouvelle demande d'adhésion`, it get displayed like this:
```
Nouvelle demande d&#039;adhésion
```

This is because the raw html value is as:
```
Nouvelle demande d&amp;#039;adhésion
```

With this PR we avoid to escape twice the html entity, so it will rendered properly like that by the mail client:
```
Nouvelle demande d'adhésion
```