### PR TITLE
warn users when uploading duplicate file names to the media manager

### DIFF
--- a/modules/cms/widgets/MediaManager.php
+++ b/modules/cms/widgets/MediaManager.php
@@ -1129,6 +1129,17 @@ class MediaManager extends WidgetBase
             $path = MediaLibrary::validatePath($path);
             $filePath = $path.'/'.$fileName;
 
+            if (MediaLibrary::instance()->exists($filePath)) {
+                if ($quickMode) {
+                    // If quickMode is true, auto rename file name
+                    $fileName = File::name($uploadedFile->getClientOriginalName()) . '-' . str_random(40) . '.' . $extension;
+                    $filePath = $path . '/' . $fileName;
+                } else {
+                    // Else throw exception
+                    throw new ApplicationException(Lang::get('cms::lang.cms_object.file_already_exists',['name' => $fileName]));
+                }
+            }
+
             /*
              * getRealPath() can be empty for some environments (IIS)
              */

--- a/modules/cms/widgets/MediaManager.php
+++ b/modules/cms/widgets/MediaManager.php
@@ -17,6 +17,8 @@ use Cms\Classes\MediaLibrary;
 use Cms\Classes\MediaLibraryItem;
 use October\Rain\Database\Attach\Resizer;
 use October\Rain\Filesystem\Definitions as FileDefinitions;
+use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Media Manager widget.
@@ -1132,11 +1134,15 @@ class MediaManager extends WidgetBase
             if (MediaLibrary::instance()->exists($filePath)) {
                 if ($quickMode) {
                     // If quickMode is true, auto rename file name
-                    $fileName = File::name($uploadedFile->getClientOriginalName()) . '-' . str_random(40) . '.' . $extension;
-                    $filePath = $path . '/' . $fileName;
+                    try{
+                        $fileName = Uuid::uuid1()->toString() . '.' . $extension;
+                        $filePath = $path . '/' . $fileName;
+                    }catch (UnsatisfiedDependencyException $e){
+                        throw new ApplicationException($e->getMessage());
+                    }
                 } else {
                     // Else throw exception
-                    throw new ApplicationException(Lang::get('cms::lang.cms_object.file_already_exists',['name' => $fileName]));
+                    throw new ApplicationException(Lang::get('cms::lang.cms_object.file_already_exists', ['name' => $fileName]));
                 }
             }
 


### PR DESCRIPTION
for issue #3124 
when uploading duplicate file names to the media manager, throw excepiton for hint. if quickMode enable, auto rename filename.  
