### PR TITLE
Alter `reserved` column to nullable when rolling back migration

### DIFF
--- a/modules/system/database/migrations/2017_10_01_000022_Db_Jobs_FailedJobs_Update.php
+++ b/modules/system/database/migrations/2017_10_01_000022_Db_Jobs_FailedJobs_Update.php
@@ -30,7 +30,7 @@ class DbJobsFailedJobsUpdate extends Migration
     public function down()
     {
         Schema::table($this->getTableName(), function (Blueprint $table) {
-            $table->tinyInteger('reserved')->unsigned();
+            $table->tinyInteger('reserved')->unsigned()->nullable();
             $table->dropIndex('jobs_queue_reserved_at_index');
         });
 


### PR DESCRIPTION
We should add column `reserved` to nullable to prevent this error,
```General error: 1 Cannot add a NOT NULL column with default value NULL (SQL: alter table "jobs" add column "reserved" integer not null)```