### PR TITLE
Correct row numbers displayed in the import result form

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -210,6 +210,8 @@ class ImportExportController extends ControllerBehavior
         catch (Exception $ex) {
             $this->controller->handleError($ex);
         }
+        
+        $this->vars['sourceIndexOffset'] = $this->getImportSourceIndexOffset($importOptions['firstRowTitles']);
 
         return $this->importExportMakePartial('import_result_form');
     }
@@ -331,6 +333,17 @@ class ImportExportController extends ControllerBehavior
         }
 
         return $firstRow;
+    }
+    
+    /**
+     * Get the index offset to add to the reported row number in status messages
+     *
+     * @param bool $firstRowTitles Whether or not the first row contains column titles
+     * @return int $offset
+     */
+    protected function getImportSourceIndexOffset($firstRowTitles)
+    {
+        return $firstRowTitles ? 2 : 1;
     }
 
     protected function makeImportUploadFormWidget()

--- a/modules/backend/behaviors/importexportcontroller/partials/_import_result_form.htm
+++ b/modules/backend/behaviors/importexportcontroller/partials/_import_result_form.htm
@@ -61,7 +61,7 @@
                                     <ul>
                                         <?php foreach ($importResults->{$code} as $row => $message): ?>
                                             <li>
-                                                <strong>Row <?= $row ?></strong>
+                                                <strong>Row <?= $row + $sourceIndexOffset ?></strong>
                                                 - <?= e($message) ?>
                                             </li>
                                         <?php endforeach ?>


### PR DESCRIPTION
Row numbers displayed in the import results form currently have an incorrect row number because they are based off of the index of the zero-based array that contains the source file's data. This calculates an offset to apply to that index based on whether or not the first row of the source file contains the column titles.

@daftspunk this is ready for review.