### PR TITLE
Add form option for mediafinder for default cropping of images

### DIFF
--- a/modules/backend/assets/js/october-min.js
+++ b/modules/backend/assets/js/october-min.js
@@ -480,7 +480,7 @@ MediaManagerPopup.prototype.registerHandlers=function(){this.$popupRootElement.o
 this.$popupRootElement.one('shown.oc.popup',this.proxy(this.onPopupShown))}
 MediaManagerPopup.prototype.unregisterHandlers=function(){this.$popupElement.off('popupcommand',this.proxy(this.onPopupCommand))
 this.$popupRootElement.off('popupcommand',this.proxy(this.onPopupCommand))}
-MediaManagerPopup.prototype.show=function(){var data={bottomToolbar:this.options.bottomToolbar?1:0,cropAndInsertButton:this.options.cropAndInsertButton?1:0}
+MediaManagerPopup.prototype.show=function(){var data={bottomToolbar:this.options.bottomToolbar?1:0,cropAndInsertButton:this.options.cropAndInsertButton?1:0,cropwidth:this.options.cropwidth,cropheight:this.options.cropheight,cropmode:this.options.cropmode}
 this.$popupRootElement.popup({extraData:data,size:'adaptive',adaptiveHeight:true,handler:this.options.alias+'::onLoadPopup'})}
 MediaManagerPopup.prototype.hide=function(){if(this.$popupElement)
 this.$popupElement.trigger('close.oc.popup')}

--- a/modules/cms/formwidgets/MediaFinder.php
+++ b/modules/cms/formwidgets/MediaFinder.php
@@ -37,12 +37,17 @@ class MediaFinder extends FormWidgetBase
     /**
      * @var int Preview image width
      */
-    public $imageWidth = null;
+    public $cropwidth = '';
 
     /**
      * @var int Preview image height
      */
-    public $imageHeight = null;
+    public $cropheight = '';
+
+    /**
+     * @var string Preview image mod (normal, ratio or size)
+     */
+    public $cropmode = 'normal';
 
     //
     // Object properties
@@ -61,8 +66,9 @@ class MediaFinder extends FormWidgetBase
         $this->fillFromConfig([
             'mode',
             'prompt',
-            'imageWidth',
-            'imageHeight'
+            'cropheight',
+            'cropwidth',
+            'cropmode'
         ]);
 
         if ($this->formField->disabled) {
@@ -91,8 +97,9 @@ class MediaFinder extends FormWidgetBase
         $this->vars['field'] = $this->formField;
         $this->vars['prompt'] = str_replace('%s', '<i class="icon-folder"></i>', trans($this->prompt));
         $this->vars['mode'] = $this->mode;
-        $this->vars['imageWidth'] = $this->imageWidth;
-        $this->vars['imageHeight'] = $this->imageHeight;
+        $this->vars['cropwidth'] = $this->cropwidth;
+        $this->vars['cropheight'] = $this->cropheight;
+        $this->vars['cropmode'] = $this->cropmode;
     }
 
     /**

--- a/modules/cms/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/cms/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -88,6 +88,9 @@
 
         new $.oc.mediaManager.popup({
             alias: 'ocmediamanager',
+            cropwidth: self.options.cropwidth,
+            cropheight: self.options.cropheight,
+            cropmode: self.options.cropmode,
             cropAndInsertButton: true,
             onInsert: function(items) {
                 if (!items.length) {

--- a/modules/cms/formwidgets/mediafinder/partials/_image_single.htm
+++ b/modules/cms/formwidgets/mediafinder/partials/_image_single.htm
@@ -2,8 +2,9 @@
     id="<?= $this->getId() ?>"
     class="field-mediafinder style-image-single is-image <?= $value ? 'is-populated' : '' ?> <?= $this->previewMode ? 'is-preview' : '' ?>"
     data-control="mediafinder"
-    data-thumbnail-width="<?= $imageWidth ?: '0' ?>"
-    data-thumbnail-height="<?= $imageHeight ?: '0' ?>"
+    data-cropwidth="<?= $cropwidth ?: '' ?>"
+    data-cropheight="<?= $cropheight ?: '' ?>"
+    data-cropmode="<?= $cropmode ?: '' ?>"
 >
 
     <!-- Find Button -->

--- a/modules/cms/widgets/MediaManager.php
+++ b/modules/cms/widgets/MediaManager.php
@@ -487,8 +487,22 @@ class MediaManager extends WidgetBase
         $this->setSidebarVisible($visible);
     }
 
+    public function convertFormModeParamToConstant($mode) {
+        switch($mode) {
+            case 'normal': return MediaManager::SELECTION_MODE_NORMAL;
+            case 'size': return MediaManager::SELECTION_MODE_FIXED_SIZE;
+            case 'ratio': return MediaManager::SELECTION_MODE_FIXED_RATIO;
+            default: return null;
+        }
+    }
+
     public function onLoadPopup()
     {
+        $this->setSelectionParams(
+            $this->convertFormModeParamToConstant(Input::get('cropmode', 'normal')),
+            Input::get('cropwidth', ''),
+            Input::get('cropheight', '')
+        );
         $this->bottomToolbar = Input::get('bottomToolbar', $this->bottomToolbar);
 
         $this->cropAndInsertButton = Input::get('cropAndInsertButton', $this->cropAndInsertButton);

--- a/modules/cms/widgets/mediamanager/assets/js/mediamanager.popup.js
+++ b/modules/cms/widgets/mediamanager/assets/js/mediamanager.popup.js
@@ -54,7 +54,10 @@
     MediaManagerPopup.prototype.show = function() {
         var data = {
             bottomToolbar: this.options.bottomToolbar ? 1 : 0,
-            cropAndInsertButton: this.options.cropAndInsertButton ? 1 : 0
+            cropAndInsertButton: this.options.cropAndInsertButton ? 1 : 0,
+            cropwidth: this.options.cropwidth,
+            cropheight: this.options.cropheight,
+            cropmode: this.options.cropmode
         }
 
         this.$popupRootElement.popup({


### PR DESCRIPTION
You can easily crop images in the mediafinder form widget.
However, in some cass you require a predefined aspect ratio or even a fixed size for each image in the mediafinder field, for example for a slider. 
I added three properties to the mediafinder field: 'cropwidth', 'cropheight' and 'cropmode'. Copmode can have the values 'normal', 'size' and 'radio'.
If  you set these (or even just 1 or two of the three), the options will be loaded in the cropping popup.
That way, you ensure that you have always the same settings applied to every image with those properties.