### PR TITLE
Account for NestedTree Trait setting

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -486,7 +486,7 @@ class Lists extends WidgetBase
         /*
          * Apply sorting
          */
-        if ($sortColumn = $this->getSortColumn()) {
+        if ($sortColumn = $this->getSortColumn() && !$this->showTree) {
             if (($column = array_get($this->allColumns, $sortColumn)) && $column->valueFrom) {
                 $sortColumn = $this->isColumnPivot($column)
                     ? 'pivot_' . $column->valueFrom

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -486,7 +486,7 @@ class Lists extends WidgetBase
         /*
          * Apply sorting
          */
-        if ($sortColumn = $this->getSortColumn() && !$this->showTree) {
+        if (($sortColumn = $this->getSortColumn()) && !$this->showTree) {
             if (($column = array_get($this->allColumns, $sortColumn)) && $column->valueFrom) {
                 $sortColumn = $this->isColumnPivot($column)
                     ? 'pivot_' . $column->valueFrom


### PR DESCRIPTION
See https://github.com/rainlab/blog-plugin/issues/338. The Lists Widget did not account for the NestedTree (showTree) setting which would result in Lists being rendered using sortOrders and not "Tree" orders.