### PR TITLE
Support form field commentHtml flag for section, checkbox, and switch types

### DIFF
--- a/modules/backend/widgets/form/partials/_field_checkbox.htm
+++ b/modules/backend/widgets/form/partials/_field_checkbox.htm
@@ -18,6 +18,6 @@
         <?= e(trans($field->label)) ?>
     </label>
     <?php if ($field->comment): ?>
-        <p class="help-block"><?= e(trans($field->comment)) ?></p>
+        <p class="help-block"><?= $field->commentHtml ? trans($field->comment) : e(trans($field->comment)) ?></p>
     <?php endif ?>
 </div>

--- a/modules/backend/widgets/form/partials/_field_section.htm
+++ b/modules/backend/widgets/form/partials/_field_section.htm
@@ -5,6 +5,6 @@
     <?php endif ?>
 
     <?php if ($field->comment): ?>
-        <p class="help-block"><?= e(trans($field->comment)) ?></p>
+        <p class="help-block"><?= $field->commentHtml ? trans($field->comment) : e(trans($field->comment)) ?></p>
     <?php endif ?>
 </div>

--- a/modules/backend/widgets/form/partials/_field_switch.htm
+++ b/modules/backend/widgets/form/partials/_field_switch.htm
@@ -2,7 +2,7 @@
 <div class="field-switch">
     <label><?= e(trans($field->label)) ?></label>
     <?php if ($field->comment): ?>
-        <p class="help-block"><?= e(trans($field->comment)) ?></p>
+        <p class="help-block"><?= $field->commentHtml ? trans($field->comment) : e(trans($field->comment)) ?></p>
     <?php endif ?>
 </div>
 


### PR DESCRIPTION
**Expected behavior:**

Setting a backend form field's `commentHtml` value to true allows direct HTML display in the field's comment.

**Actual behavior:**

The field types that don't run through the standard `_field.htm` partial-- `section`, `checkbox`, and `switch`-- ignore the setting and display escaped comments regardless. 

I can't see why that would be intentional, so this commit corrects that behavior.