### PR TITLE
Adding method to return a list of MailTemplate objects

### DIFF
--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -60,6 +60,23 @@ class MailTemplate extends Model
     }
 
     /**
+     * Returns a list of all mail templates.
+     * @return array Returns an array of the MailTemplate objects.
+     */
+    public static function allTemplates()
+    {
+        $result = [];
+        $codes = array_keys(self::listAllTemplates());
+
+        foreach ($codes as $code) {
+
+            $result[] = self::findOrMakeTemplate($code);
+        }
+
+        return $result;
+    }
+
+    /**
      * Syncronise all file templates to the database.
      * @return void
      */

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -69,7 +69,6 @@ class MailTemplate extends Model
         $codes = array_keys(self::listAllTemplates());
 
         foreach ($codes as $code) {
-
             $result[] = self::findOrMakeTemplate($code);
         }
 


### PR DESCRIPTION
Adding method to return a list of MailTemplate objects (for `rainlab/translate-plugin` list translatable messages in the backend). See: https://github.com/rainlab/translate-plugin/issues/87