### PR TITLE
Added PluginManager::unregisterAll()

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -163,6 +163,16 @@ class PluginManager
     }
 
     /**
+     * Unregisters all plugins: the negative of registerAll().
+     * @return void
+     */
+    public function unregisterAll()
+    {
+        $this->registered = false;
+        $this->plugins = [];
+    }
+
+    /**
      * Registers a single plugin object.
      * @param PluginBase $plugin
      * @param string $pluginId

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -122,7 +122,7 @@ class PluginManagerTest extends TestCase
         $this->assertArrayHasKey('\database\tester', $result);
         $this->assertArrayHasKey('\testvendor\test', $result);
     }
-    
+
     public function testGetVendorAndPluginNames()
     {
         $manager = PluginManager::instance();
@@ -147,6 +147,16 @@ class PluginManagerTest extends TestCase
         $this->assertEquals('October Test Plugin', $pluginDetails['name']);
         $this->assertEquals('Test plugin used by unit tests.', $pluginDetails['description']);
         $this->assertEquals('Alexey Bobkov, Samuel Georges', $pluginDetails['author']);
+    }
+
+    public function testUnregisterall()
+    {
+        $manager = PluginManager::instance();
+        $result = $manager->getPlugins();
+        $this->assertCount(5, $result);
+
+        $manager->unregisterAll();
+        $this->assertEmpty($manager->getPlugins());
     }
 
 }


### PR DESCRIPTION
### Preface
This PR follows up on issue #2592. 
To recap: in the testing environment, if you're testing plugins working together, you need to do 

```php
PluginManager::instance()->registerAll(true);
PluginManager::instance()->bootAll(true);
```

to make sure everything is setup in the same way your frontend would be using them.

### One last issue
We noticed however, that the `app` instance bound to `$this->app` in a plugin gets corrupted, sort of.

For instance, usually `$app['translator']` is set, and this is true for the first test. Every subsequent test however, throws an exception from deep within Laravel's ServiceProvider stating `ReflectionException: Class translator does not exist`. 

Adding the following to my plugin's `boot()` method shows `true` for the first test, and `false` for every subsequent test:

```php
public function boot()
{
    dump(isset($this->app['translator']));
}
```

### Solution
This lead me to think something got destroyed in `tearDown` but not reset in `setUp` again. Eventually I ended up in `PluginTestCase::runPluginRefreshCommand()`.   
If I removed the `if` statement below the comment

```php
        /*
         * First time seeing this plugin, load it up
         */
```

my tests would run correctly, because it would run `loadPlugin()` regardless of wether it was the first time or not.

This is why I offer an `unregisterAll()` method that can be called from within my `tearDown()` function, making sure plugins are registered and booted from scratch for every test.

This would look something like this:

```php
    public function setUp()
    {
        parent::setUp();

        $pluginManager = PluginManager::instance();
        $pluginManager->registerAll(true);
        $pluginManager->bootAll(true);
    }

    public function tearDown()
    {
        parent::tearDown();

        $pluginManager = PluginManager::instance();
        $pluginManager->unregisterAll();
    }
```

It feels right for `tearDown` to do the exact opposite of `setUp` and clean up after it.

This fixes my problem, but I can imagine I might miss some intricacies regarding the PluginManager, so let me know if I should elaborate either my implementation or the accompanying unit test.

I can create a repo to reproduce the problem if you want.