### PR TITLE
Add getters for relation widgets

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1594,4 +1594,22 @@ class RelationController extends ControllerBehavior
 
         return $this->makeConfig($config);
     }
+
+    /**
+     * Returns the manage widget used by this behavior.
+     *
+     * @return \Backend\Classes\WidgetBase
+     */
+    public function relationGetManageWidget() {
+        return $this->manageWidget;
+    }
+
+    /**
+     * Returns the view widget used by this behavior.
+     *
+     * @return \Backend\Classes\WidgetBase
+     */
+    public function relationGetViewWidget() {
+        return $this->viewWidget;
+    }
 }


### PR DESCRIPTION
These are available for the ``FormController`` as well, so this is just consistent and usefull in some cases.