### PR TITLE
Fix exception Class 'System\Twig\MediaLibrary' not found in build 426

### DIFF
--- a/modules/system/twig/Extension.php
+++ b/modules/system/twig/Extension.php
@@ -6,7 +6,7 @@ use Twig_TokenParser;
 use Twig_SimpleFilter;
 use Twig_SimpleFunction;
 use ApplicationException;
-use System\Classes\MediaLibary;
+use System\Classes\MediaLibrary;
 use System\Classes\MarkupManager;
 
 /**


### PR DESCRIPTION
Fix typo issue added on commit 08f9cd8