### PR TITLE
Don't block backend connection when a plugin migration trigger exception

### DIFF
--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -85,8 +85,13 @@ class Auth extends Controller
             'password' => post('password')
         ], $remember);
 
-        // Load version updates
-        UpdateManager::instance()->update();
+        try {
+            // Load version updates
+            UpdateManager::instance()->update();
+        }
+        catch (Exception $ex) {
+            Flash::error($ex->getMessage());
+        }
 
         // Log the sign in event
         AccessLog::add($user);


### PR DESCRIPTION
Without this commit if a plugin migration fail nobody can connect to the backend