### PR TITLE
Fix checkboxlist triggers for #2861

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -646,7 +646,7 @@ class Form extends WidgetBase
         $label = (isset($config['label'])) ? $config['label'] : null;
         list($fieldName, $fieldContext) = $this->getFieldName($name);
 
-        $field = new FormField($fieldName, $label);
+        $field = new FormField($fieldName, $label, $this);
         if ($fieldContext) {
             $field->context = $fieldContext;
         }

--- a/tests/unit/backend/widgets/FormTest.php
+++ b/tests/unit/backend/widgets/FormTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Backend\Widgets\Form;
+use Illuminate\Database\Eloquent\Model;
+
+class FormTestModel extends Model
+{
+    
+}
+
+class FormTest extends TestCase
+{
+    public function testCheckboxlistTrigger()
+    {
+        $form = new Form(null, [
+            'model' => new FormTestModel(),
+            'arrayName' => 'array',
+            'fields' => [
+                'trigger' => [
+                    'type' => 'checkboxlist',
+                    'options' => [
+                        '1' => 'Value One'
+                    ]
+                ],
+                'triggered' => [
+                    'type' => 'text',
+                    'trigger' => [
+                        'field' => 'trigger',
+                        'action' => 'show',
+                        'condition' => 'value[1]'
+                    ]
+                ]
+            ]
+        ]);
+        
+        $form->render();
+        
+        $attributes = $form->getField('triggered')->getAttributes('container', false);
+        $this->assertEquals('[name="array[trigger][]"]', array_get($attributes, 'data-trigger'));
+    }
+}


### PR DESCRIPTION
Reference: #2861 

@LukeTowers This works, but I'm open for feedback on any improvements.

The FormField class has of course to this point not had a reference to the parent form, but I didn't see any way to fix this bug without being able to grab the trigger field's object, since its field type impacts the selector the JS trigger API needs to use to watch for changes.

I don't know how often someone would set up a trigger on a field without that field being set up through a form, but I left in logic to still have a generic selector if the field has no parent form. That logic would of course still fail if the trigger field is a checkboxlist.