### PR TITLE
Check admin permissions before displaying global media buttons in Rich Editor

### DIFF
--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -1,7 +1,7 @@
 <?php namespace Backend\FormWidgets;
 
 use App;
-use Backend\Facades\BackendAuth;
+use BackendAuth;
 use File;
 use Event;
 use Lang;
@@ -88,7 +88,7 @@ class RichEditor extends FormWidgetBase
 
         $this->vars['globalToolbarButtons'] = EditorSetting::getConfigured('html_toolbar_buttons');
 
-        if (!BackendAuth::getUser()->hasPermission(['media.manage_media'])) {
+        if (!BackendAuth::getUser()->hasAccess('media.manage_media')) {
             $mediaButtonNames = ['insertImage', 'insertVideo', 'insertAudio', 'insertFile'];
 
             foreach($mediaButtonNames as $mediaButtonName)

--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -1,6 +1,7 @@
 <?php namespace Backend\FormWidgets;
 
 use App;
+use Backend\Facades\BackendAuth;
 use File;
 use Event;
 use Lang;
@@ -86,6 +87,16 @@ class RichEditor extends FormWidgetBase
         $this->vars['toolbarButtons'] = $this->evalToolbarButtons();
 
         $this->vars['globalToolbarButtons'] = EditorSetting::getConfigured('html_toolbar_buttons');
+
+        if (!BackendAuth::getUser()->hasPermission(['media.manage_media'])) {
+            $mediaButtonNames = ['insertImage', 'insertVideo', 'insertAudio', 'insertFile'];
+
+            foreach($mediaButtonNames as $mediaButtonName)
+            {
+                $this->vars['globalToolbarButtons'] = str_replace($mediaButtonName, "", $this->vars['globalToolbarButtons']);
+            }
+        }
+
         $this->vars['allowEmptyTags'] = EditorSetting::getConfigured('html_allow_empty_tags');
         $this->vars['allowTags'] = EditorSetting::getConfigured('html_allow_tags');
         $this->vars['noWrapTags'] = EditorSetting::getConfigured('html_no_wrap_tags');


### PR DESCRIPTION
**Fixes / Related:** 
https://github.com/rainlab/blog-plugin/issues/325

**Current behavior:**
If they're defined as toolbar buttons globally from the Editor Settings, an admin user will see media buttons regardless of their permissions. Using a media button to upload media without the permission to manage media will result in an exception.

**Fixed behavior:**
If they're defined as toolbar buttons globally from the Editor Settings, an admin user will only see media buttons if they have permission to do so. 