### PR TITLE
Arifnyet switch/checkbox   default value #2329

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -566,8 +566,8 @@ class Filter extends WidgetBase
         /*
          * Set scope value
          */
-        if($scopeType=='checkbox' || $scopeType=='switch'){
-            $scope->value = isset($config['value']) ? $config['value'] : $this->getScopeValue($scope);
+        if($scopeType==='checkbox' || $scopeType==='switch'){
+            $scope->value = isset($config['default']) ? $config['default'] : $this->getScopeValue($scope);
         } else{
             $scope->value = $this->getScopeValue($scope);
         }

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -564,12 +564,11 @@ class Filter extends WidgetBase
         $scope->displayAs($scopeType, $config);
 
         /*
-         * Set scope value
+         * Set scope value if session/cookies is not set then retrieve default value for switch/checkbox
          */
-        if($scopeType==='checkbox' || $scopeType==='switch'){
-            $scope->value = isset($config['default']) ? $config['default'] : $this->getScopeValue($scope);
-        } else{
-            $scope->value = $this->getScopeValue($scope);
+        $scope->value = $this->getScopeValue($scope);
+        if(!$scope->value && isset($config['default']) && ($scopeType==="checkbox" || $scopeType==="switch")){
+            $scope->value = $config['default'];
         }
 
         return $scope;

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -567,7 +567,7 @@ class Filter extends WidgetBase
          * Set scope value if session/cookies is not set then retrieve default value for switch/checkbox
          */
         $scope->value = $this->getScopeValue($scope);
-        if(!$scope->value && isset($config['default']) && ($scopeType==="checkbox" || $scopeType==="switch")){
+        if(!isset($scope->value) && isset($config['default']) && ($scopeType==="checkbox" || $scopeType==="switch")){
             $scope->value = $config['default'];
         }
 

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -564,13 +564,10 @@ class Filter extends WidgetBase
         $scope->displayAs($scopeType, $config);
 
         /*
-         * Set scope value if session/cookies is not set then retrieve default value for switch/checkbox
+         * Set scope value
          */
-        $scope->value = $this->getScopeValue($scope);
-        if(!isset($scope->value) && isset($config['default']) && ($scopeType==="checkbox" || $scopeType==="switch")){
-            $scope->value = $config['default'];
-        }
-
+        $scope->value = $this->getScopeValue($scope, @$config['default']);
+        
         return $scope;
     }
 

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -566,7 +566,11 @@ class Filter extends WidgetBase
         /*
          * Set scope value
          */
-        $scope->value = $this->getScopeValue($scope);
+        if($scopeType=='checkbox' || $scopeType=='switch'){
+            $scope->value = isset($config['value']) ? $config['value'] : $this->getScopeValue($scope);
+        } else{
+            $scope->value = $this->getScopeValue($scope);
+        }
 
         return $scope;
     }

--- a/modules/backend/widgets/filter/partials/_scope_checkbox.htm
+++ b/modules/backend/widgets/filter/partials/_scope_checkbox.htm
@@ -2,6 +2,6 @@
 <div
     class="filter-scope checkbox custom-checkbox"
     data-scope-name="<?= $scope->scopeName ?>">
-    <input type="checkbox" id="<?= $scope->getId() ?>" <?= $scope->value ? 'checked' : '' ?> />
+    <input type="checkbox" id="<?= $scope->getId() ?>" <?= $scope->value==1 ? 'checked' : '' ?> />
     <label for="<?= $scope->getId() ?>"><?= e(trans($scope->label)) ?></label>
 </div>

--- a/modules/backend/widgets/filter/partials/_scope_checkbox.htm
+++ b/modules/backend/widgets/filter/partials/_scope_checkbox.htm
@@ -2,6 +2,6 @@
 <div
     class="filter-scope checkbox custom-checkbox"
     data-scope-name="<?= $scope->scopeName ?>">
-    <input type="checkbox" id="<?= $scope->getId() ?>" <?= $scope->value==1 ? 'checked' : '' ?> />
+    <input type="checkbox" id="<?= $scope->getId() ?>" <?= $scope->value ? 'checked' : '' ?> />
     <label for="<?= $scope->getId() ?>"><?= e(trans($scope->label)) ?></label>
 </div>


### PR DESCRIPTION
@LukeTowers 
this pr should be compatible.. 
for checkbox and switch type
it will only use the default value set by the user if the user session is not yet set... ie after login and viewing the list for the first time... the default state/value for the switch/checkbox is according to the inputted default value...
however after the user make changes to it... ie uncheck it or change it state... it will remain the same until the user change it back or clear his/her session/cookies.. 
i hope this is the intended behavior 
usage as follows

```php
'ShowTrashed' => [
    'label' => 'Hide Trashed',
    'type' => 'switch',
    'default' => '2',
    'conditions' => ['deleted_at IS NOT NULL', 'deleted_at IS NULL']
],
``` 
```php
'ShowTrashed' => [
    'label' => 'Hide Trashed',
    'type' => 'checkbox',
    'default' => '1',
    'conditions' => ['deleted_at IS NOT NULL', 'deleted_at IS NULL']
],
```
switch 0: off 1: inter 2: on
checkbox 0: uncheck 1: checked