### PR TITLE
Fixes #2888. Set max url length to 8000

### DIFF
--- a/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
+++ b/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
@@ -3,8 +3,6 @@
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
-
-
 class DbSystemRequestLogs extends Migration
 {
     const MAX_URL_LENGTH = 8000; //https://tools.ietf.org/html/rfc7230#section-3.1.1

--- a/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
+++ b/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
@@ -3,6 +3,8 @@
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
+const MAX_URL_LENGTH = 8000; //https://tools.ietf.org/html/rfc7230#section-3.1.1
+
 class DbSystemRequestLogs extends Migration
 {
     public function up()
@@ -11,7 +13,7 @@ class DbSystemRequestLogs extends Migration
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('status_code')->nullable();
-            $table->string('url')->nullable();
+            $table->string('url', MAX_URL_LENGTH)->nullable();
             $table->text('referer')->nullable();
             $table->integer('count')->default(0);
             $table->timestamps();

--- a/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
+++ b/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
@@ -3,17 +3,19 @@
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
-const MAX_URL_LENGTH = 8000; //https://tools.ietf.org/html/rfc7230#section-3.1.1
+
 
 class DbSystemRequestLogs extends Migration
 {
+    const MAX_URL_LENGTH = 8000; //https://tools.ietf.org/html/rfc7230#section-3.1.1
+
     public function up()
     {
         Schema::create('system_request_logs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('status_code')->nullable();
-            $table->string('url', MAX_URL_LENGTH)->nullable();
+            $table->string('url', static::MAX_URL_LENGTH)->nullable();
             $table->text('referer')->nullable();
             $table->integer('count')->default(0);
             $table->timestamps();

--- a/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
+++ b/modules/system/database/migrations/2014_10_01_000012_Db_System_Request_Logs.php
@@ -5,15 +5,13 @@ use October\Rain\Database\Updates\Migration;
 
 class DbSystemRequestLogs extends Migration
 {
-    const MAX_URL_LENGTH = 8000; //https://tools.ietf.org/html/rfc7230#section-3.1.1
-
     public function up()
     {
         Schema::create('system_request_logs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->integer('status_code')->nullable();
-            $table->string('url', static::MAX_URL_LENGTH)->nullable();
+            $table->string('url')->nullable();
             $table->text('referer')->nullable();
             $table->integer('count')->default(0);
             $table->timestamps();

--- a/modules/system/database/migrations/2017_10_30_000024_Db_System_Request_Logs_Update.php
+++ b/modules/system/database/migrations/2017_10_30_000024_Db_System_Request_Logs_Update.php
@@ -1,0 +1,21 @@
+<?php
+
+use October\Rain\Database\Schema\Blueprint;
+use October\Rain\Database\Updates\Migration;
+
+class DbSystemRequestLogsUpdate extends Migration
+{
+    const MAX_URL_LENGTH = 8000; //https://tools.ietf.org/html/rfc7230#section-3.1.1
+
+    public function up()
+    {
+        Schema::table('system_request_logs', function (Blueprint $table) {
+            $table->string('url', static::MAX_URL_LENGTH)->change();
+        });
+    }
+
+    public function down()
+    {
+        //this migration should not be downgraded.
+    }
+}

--- a/modules/system/models/RequestLog.php
+++ b/modules/system/models/RequestLog.php
@@ -42,7 +42,7 @@ class RequestLog extends Model
         }
 
         $record = static::firstOrNew([
-            'url' => substr(Request::fullUrl(), 0, 255),
+            'url' => mb_substr(Request::fullUrl(), 0, 8000),
             'status_code' => $statusCode,
         ]);
 


### PR DESCRIPTION
It seems to be a better to set  length to `8000`.
There is no strict spec for max url length, but there is [recommendation](https://tools.ietf.org/html/rfc7230#section-3.1.1) about length.

> Various ad hoc limitations on request-line length are found in
   practice.  It is RECOMMENDED that all HTTP senders and recipients
   support, at a minimum, request-line lengths of 8000 octets.

So url in utf-8 encoding can have from 2000 up to 8000 chars, because  [RFC3629](https://tools.ietf.org/html/rfc3629) says:

> In UTF-8, characters from the U+0000..U+10FFFF range (the UTF-16 accessible range) are encoded using sequences of 1 to 4 octets.

PS:
However, in any case, we can not guarantee that there will not be an attempt to write a longer string than we expect, so I have a question, do I still need to validate the data before saving? I can add this feature to this PR.
