### PR TITLE
Fixes #3211: Old migration was repaired.

### DIFF
--- a/modules/system/database/migrations/2017_10_01_000022_Db_Jobs_FailedJobs_Update.php
+++ b/modules/system/database/migrations/2017_10_01_000022_Db_Jobs_FailedJobs_Update.php
@@ -30,7 +30,7 @@ class DbJobsFailedJobsUpdate extends Migration
     public function down()
     {
         Schema::table($this->getTableName(), function (Blueprint $table) {
-            $table->tinyInteger('reserved')->unsigned();
+            $table->tinyInteger('reserved')->unsigned()->nullable();
             $table->dropIndex('jobs_queue_reserved_at_index');
         });
 

--- a/modules/system/database/migrations/2017_10_01_000022_Db_Jobs_FailedJobs_Update.php
+++ b/modules/system/database/migrations/2017_10_01_000022_Db_Jobs_FailedJobs_Update.php
@@ -30,7 +30,7 @@ class DbJobsFailedJobsUpdate extends Migration
     public function down()
     {
         Schema::table($this->getTableName(), function (Blueprint $table) {
-            $table->tinyInteger('reserved')->unsigned()->nullable();
+            $table->tinyInteger('reserved')->unsigned()->default(0);
             $table->dropIndex('jobs_queue_reserved_at_index');
         });
 


### PR DESCRIPTION
It's impossible now to downgrade whole project, because when you add new field to existiing table with existing rows, it must be nullable or have default value. Just for this case `nullable` it's enough.
