### PR TITLE
Optimize theme recognition

### DIFF
--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -148,6 +148,7 @@ class Theme
     public static function getActiveThemeCode()
     {
         $activeTheme = Config::get('cms.activeTheme');
+        $themes = static::all();
         $havingMoreThemes = count($themes) > 1;
         $themeHasChanged = !empty($themes[0]) && $themes[0]->dirName !== $activeTheme;
         $checkDatabase = $havingMoreThemes || $themeHasChanged;

--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -148,8 +148,11 @@ class Theme
     public static function getActiveThemeCode()
     {
         $activeTheme = Config::get('cms.activeTheme');
+        $havingMoreThemes = count($themes) > 1;
+        $themeHasChanged = !empty($themes[0]) && $themes[0]->dirName !== $activeTheme;
+        $checkDatabase = $havingMoreThemes || $themeHasChanged;
 
-        if (App::hasDatabase()) {
+        if ($checkDatabase && App::hasDatabase()) {
             try {
                 try {
                     $dbResult = Cache::remember(self::ACTIVE_KEY, 1440, function () {


### PR DESCRIPTION
**Problem**: When we have only one theme, CMS ask backend for the active theme, which makes one SQL query.

**Goal**: Without that query, we could have a webpage without any SQL queries :-)

**Cases**:

- a user has one theme which is same as the theme in `cms.activeTheme` config - no need to check DB
- a user has one theme, but it is not the same as `cms.activeTheme` config (maybe downloaded another theme and deleted the previous one) - ok, let's check DB
- a user has more themes - ok, let's check DB

**Before**:

<img width="1138" alt="snimek obrazovky 2017-11-03 v 12 45 51" src="https://user-images.githubusercontent.com/374917/32372652-1358e492-c096-11e7-8d82-84264adc4559.png">

**After**:

<img width="1138" alt="snimek obrazovky 2017-11-03 v 12 46 03" src="https://user-images.githubusercontent.com/374917/32372659-191f7e72-c096-11e7-9aa8-bd827fbbc299.png">
