### PR TITLE
Purge flash messages after using {% flash %} tag

### DIFF
--- a/modules/cms/twig/FlashNode.php
+++ b/modules/cms/twig/FlashNode.php
@@ -1,5 +1,6 @@
 <?php namespace Cms\Twig;
 
+use Flash;
 use Twig_Node;
 use Twig_Compiler;
 use Twig_Node_Expression;
@@ -15,6 +16,11 @@ class FlashNode extends Twig_Node
     public function __construct($name, Twig_Node $body, $lineno, $tag = 'flash')
     {
         parent::__construct(['body' => $body], ['name' => $name], $lineno, $tag);
+    }
+    
+    public function __destruct()
+    {
+        Flash::purge();
     }
 
     /**


### PR DESCRIPTION
Fixes the problem that causes flash messages to display twice.

I'm purging the session data in the destructor, since the function Flash::getMessages()
 is not doing it by itself. That caused the flash messages to display again after a page refresh.

If this problem can be resolved in another way, let me know and i'll make the necessary changes.

Fixes issue #2869 