### PR TITLE
fix issue #3064 froala selection text works

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
@@ -57,6 +57,17 @@ $.FroalaEditor.DEFAULTS.key = 'HHMDUGENKACTMXQL==';
         }
 
         function insertLink() {
+            editor.selection.restore();
+            range = editor.selection.ranges(0);
+            editor.events.on('link.beforeInsert', function(){
+                if (range) {
+                    var sel = editor.selection.get();
+                    editor.selection.clear();
+                    sel.addRange(range);
+                    range = null;
+                }
+            });
+            
             richeditorPageLinksPlugin = this
 
             editor.$el.popup({

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
@@ -61,7 +61,9 @@ $.FroalaEditor.DEFAULTS.key = 'HHMDUGENKACTMXQL==';
 
             editor.$el.popup({
                 handler: editor.opts.pageLinksHandler
-            })
+            }).on('shown.oc.popup', function(){
+                editor.selection.save();
+            });
         }
 
         /**

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/pagelinks.js
@@ -72,8 +72,6 @@ $.FroalaEditor.DEFAULTS.key = 'HHMDUGENKACTMXQL==';
 
             editor.$el.popup({
                 handler: editor.opts.pageLinksHandler
-            }).on('shown.oc.popup', function(){
-                editor.selection.save();
             });
         }
 


### PR DESCRIPTION
i checked https://github.com/octobercms/october/issues/3064 and https://github.com/octobercms/october/pull/3086, and use one half day to fix this.
i think i figure it out


![kapture 2017-11-10 at 15 32 36](https://user-images.githubusercontent.com/26053904/32647495-1ee2082c-c5b7-11e7-9124-4d657f27feba.gif)

after i click pageLink search btn, i found there is a selection in editor
 so i think editor save the selection before and it restore now( but i don't know why it restore after click and where it be saved),while I click any place, the selection lost focus 

i realized that it must be saved after popup show, before any operations

![kapture 2017-11-10 at 15 54 25](https://user-images.githubusercontent.com/26053904/32648139-1ed8ae00-c5ba-11e7-8e6e-54c488dd66fe.gif)

after click  insertLinkButton, i found the selection is disappeared, and i click insertButton the selection appear there with a new link, may be froala call `editor.selection.restore()` in insertButton ?



