### PR TITLE
Support for nested objects in FormData

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -99,10 +99,48 @@ if (window.jQuery.request !== undefined) {
 
                 delete data[inputName]
             }
+            
+            /*
+             * JavaScript Object to FormData, with support for nested objects, arrays and File objects.
+             * https://gist.github.com/ghinda/8442a57f22099bdb2e34
+             */
+            var objectToFormData = function(obj, form, namespace) {
 
-            $.each(data, function(key) {
+                var fd = form || new FormData();
+                var formKey;
+
+                for(var property in obj) {
+                    if(obj.hasOwnProperty(property)) {
+
+                        if(namespace) {
+                            formKey = namespace + '[' + property + ']';
+                        } else {
+                            formKey = property;
+                        }
+
+                        // if the property is an object, but not a File,
+                        // use recursivity.
+                        if(typeof obj[property] === 'object' && !(obj[property] instanceof File)) {
+
+                            objectToFormData(obj[property], fd, property);
+
+                        } else {
+
+                            // if it's a string or a File object
+                            fd.append(formKey, obj[property]);
+                        }
+
+                    }
+                }
+
+                return fd;
+            };
+            
+            requestData = objectToFormData(data, requestData);
+
+            /*$.each(data, function(key) {
                 requestData.append(key, this)
-            })
+            })*/
         }
         else {
             requestData = $form.serialize()


### PR DESCRIPTION
At now, FormData objects are sent as `[object Object]` string. With this change, nested objects are sent right as `{key: value}` object.