### PR TITLE
Fix ajax validation for array syntax

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -242,6 +242,9 @@ if (window.jQuery.request !== undefined) {
 
                 var isFirstInvalidField = true
                 $.each(fields, function focusErrorField(fieldName, fieldMessages) {
+
+                	fieldName = fieldName.replace(/\.(\w+)/g, '[$1]');
+
                     var fieldElement = $form.find('[name="'+fieldName+'"], [name="'+fieldName+'[]"], [name$="['+fieldName+']"], [name$="['+fieldName+'][]"]').filter(':enabled').first()
                     if (fieldElement.length > 0) {
 


### PR DESCRIPTION
allow array validation syntax if you have some fields like field.0.name etc. 

In my Project i use jQuery.repeater plugin to clone some form fields. The fields has structure like 
field[0][name], field[1][name]. After sending response to the server with ajax the validation Messages looks like field.0.name , filed.1.name etc. The validation messages are not displayed because framework.js look only for array syntax.
Model rules looks like this: 
'cats.*.content_cat_name' =>  'sometimes|required|max:255',