### PR TITLE
Trailing & in requestData if data is empty

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -105,9 +105,7 @@ if (window.jQuery.request !== undefined) {
             })
         }
         else {
-            requestData = $form.serialize()
-            if (requestData) requestData = requestData + '&'
-            if (!$.isEmptyObject(data)) requestData += $.param(data)
+            requestData = [$form.serialize(), $.param(data)].filter(Boolean).join('&')
         }
 
         /*


### PR DESCRIPTION
This fixes a small issue where the form is submitted an extra unnamed null field is present in the request due to a trailing & symbol in `requestData` when `data` is empty.