### PR TITLE
changing default (wrong) css names for table styles

### DIFF
--- a/modules/backend/models/EditorSetting.php
+++ b/modules/backend/models/EditorSetting.php
@@ -62,8 +62,8 @@ class EditorSetting extends Model
     ];
 
     protected $defaultHtmlStyleTable = [
-        'oc-table-dashed-borders' => 'Dashed Borders',
-        'oc-table-alternate-rows' => 'Alternate Rows',
+        'oc-dashed-borders' => 'Dashed Borders',
+        'oc-alternate-rows' => 'Alternate Rows',
     ];
 
     protected $defaultHtmlStyleTableCell = [


### PR DESCRIPTION
 oc-table-dashed-borders ->  oc-dashed-borders
 oc-table-alternate-borders ->  oc-alternate-borders