### PR TITLE
Trigger queue worker restart on settings model save

### DIFF
--- a/modules/system/behaviors/SettingsModel.php
+++ b/modules/system/behaviors/SettingsModel.php
@@ -1,6 +1,7 @@
 <?php namespace System\Behaviors;
 
 use App;
+use Artisan;
 use Cache;
 use System\Classes\ModelBehavior;
 use ApplicationException;
@@ -196,12 +197,14 @@ class SettingsModel extends ModelBehavior
     }
 
     /**
-     * After the model is saved, clear the cached query entry.
+     * After the model is saved, clear the cached query entry
+     * and restart queue workers so they have the latest settings
      * @return void
      */
     public function afterModelSave()
     {
         Cache::forget($this->getCacheKey());
+        Artisan::call('queue:restart');
     }
 
     /**


### PR DESCRIPTION
Most October installations likely don’t use queues, so it might only matter to a minority of users, but I think it makes sense for settings changes to trigger queue worker restarts. That way daemon queue workers automatically pick up any new settings.

It’s a simple change that I can easily implement for my own projects, but it seems like something that might belong in October core so that it just works out of the box if, say, mail is being queued for later sending and the mail settings have been changed in the backend since the worker daemon started.

So, I’ve changed the SettingsModel behavior to call the `queue:restart` console command after saving. This works, but on the one hand I don’t like that saving a model triggers a separate app boot to run a command just to update a cached timestamp. On the other hand, it’s not really _that_ bad, and settings models are generally not going to be updated in bulk, just one at a time from the settings controller. I don’t see where Laravel exposes that functionality anywhere else, so it’s either that or update the cache directly.

Thoughts?