### PR TITLE
Refactoring tests

### DIFF
--- a/tests/unit/backend/traits/WidgetMakerTest.php
+++ b/tests/unit/backend/traits/WidgetMakerTest.php
@@ -41,7 +41,7 @@ class WidgetMakerTest extends TestCase
         $maker = $this->traitObject;
 
         $widget = $maker->makeWidget('Backend\Widgets\Search');
-        $this->assertTrue($widget instanceof \Backend\Widgets\Search);
+        $this->assertInstanceOf('Backend\Widgets\Search', $widget);
     }
 
     public function testMakeWidget()

--- a/tests/unit/cms/classes/RouterTest.php
+++ b/tests/unit/cms/classes/RouterTest.php
@@ -103,7 +103,7 @@ class RouterTest extends TestCase
         $parameters = $router->getParameters();
         $this->assertNotEmpty($page);
         $this->assertEquals('blog-post.htm', $page->getFileName());
-        $this->assertEquals(1, count($parameters));
+        $this->assertCount(1, $parameters);
         $this->assertArrayHasKey('url_title', $parameters);
         $this->assertEquals('my-post-title', $parameters['url_title']);
 
@@ -112,7 +112,7 @@ class RouterTest extends TestCase
         $parameters = $router->getParameters();
         $this->assertNotEmpty($page);
         $this->assertEquals('blog-post.htm', $page->getFileName());
-        $this->assertEquals(1, count($parameters));
+        $this->assertCount(1, $parameters);
         $this->assertArrayHasKey('url_title', $parameters);
         $this->assertEquals('my-post-title', $parameters['url_title']);
 
@@ -120,7 +120,7 @@ class RouterTest extends TestCase
         $parameters = $router->getParameters();
         $this->assertNotEmpty($page);
         $this->assertEquals('authors.htm', $page->getFileName());
-        $this->assertEquals(1, count($parameters));
+        $this->assertCount(1, $parameters);
         $this->assertArrayHasKey('author_id', $parameters);
         $this->assertEquals('no-author', $parameters['author_id']);
 
@@ -134,7 +134,7 @@ class RouterTest extends TestCase
         $parameters = $router->getParameters();
         $this->assertNotEmpty($page);
         $this->assertEquals('authors.htm', $page->getFileName());
-        $this->assertEquals(1, count($parameters));
+        $this->assertCount(1, $parameters);
         $this->assertArrayHasKey('author_id', $parameters);
         $this->assertEquals('44', $parameters['author_id']);
 
@@ -142,7 +142,7 @@ class RouterTest extends TestCase
         $parameters = $router->getParameters();
         $this->assertNotEmpty($page);
         $this->assertEquals('blog-archive.htm', $page->getFileName());
-        $this->assertEquals(1, count($parameters));
+        $this->assertCount(1, $parameters);
     }
 
     public function testFindPageFromSubdirectory()

--- a/tests/unit/cms/classes/ThemeTest.php
+++ b/tests/unit/cms/classes/ThemeTest.php
@@ -46,7 +46,7 @@ class ThemeTest extends TestCase
         $this->assertInternalType('array', $pages);
 
         $expectedPageNum = $this->countThemePages(base_path().'/tests/fixtures/themes/test/pages');
-        $this->assertEquals($expectedPageNum, count($pages));
+        $this->assertCount($expectedPageNum, $pages);
 
         $this->assertInstanceOf('\Cms\Classes\Page', $pages[0]);
         $this->assertNotEmpty($pages[0]->url);

--- a/tests/unit/system/classes/MarkupManagerTest.php
+++ b/tests/unit/system/classes/MarkupManagerTest.php
@@ -84,8 +84,8 @@ class MarkupManagerTest extends TestCase
         $this->assertTrue($result);
 
         $result = self::callProtectedMethod($manager, 'isWildCallable', [$callable, 'bar']);
-        $this->assertTrue(isset($result[0]));
-        $this->assertTrue(isset($result[1]));
+        $this->assertArrayHasKey(0, $result);
+        $this->assertArrayHasKey(1, $result);
         $this->assertEquals('Class', $result[0]);
         $this->assertEquals('foo_bar', $result[1]);
 
@@ -94,8 +94,8 @@ class MarkupManagerTest extends TestCase
         $this->assertTrue($result);
 
         $result = self::callProtectedMethod($manager, 'isWildCallable', [$callable, 'Class']);
-        $this->assertTrue(isset($result[0]));
-        $this->assertTrue(isset($result[1]));
+        $this->assertArrayHasKey(0, $result);
+        $this->assertArrayHasKey(1, $result);
         $this->assertEquals('MyClass', $result[0]);
         $this->assertEquals('method', $result[1]);
 
@@ -104,8 +104,8 @@ class MarkupManagerTest extends TestCase
         $this->assertTrue($result);
 
         $result = self::callProtectedMethod($manager, 'isWildCallable', [$callable, 'Food']);
-        $this->assertTrue(isset($result[0]));
-        $this->assertTrue(isset($result[1]));
+        $this->assertArrayHasKey(0, $result);
+        $this->assertArrayHasKey(1, $result);
         $this->assertEquals('MyFood', $result[0]);
         $this->assertEquals('myFood', $result[1]);
     }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertArrayHasKey` instead of `isset` function.