### PR TITLE
fix form controller redirect with empty context option

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -489,7 +489,7 @@ class FormController extends ControllerBehavior
         // source for the default redirect being default[redirect]
         $redirects['default'] = $this->getConfig('defaultRedirect', '');
 
-        if (!isset($redirects[$context])) {
+        if (empty($redirects[$context])) {
             return $redirects['default'];
         }
 

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -482,7 +482,9 @@ class FormController extends ControllerBehavior
         $redirectContext = explode('-', $context, 2)[0];
         $redirectSource = ends_with($context, '-close') ? 'redirectClose' : 'redirect';
 
-        $redirects = [];
+        // Get the redirect for the provided context
+        $redirects = [$context => $this->getConfig("{$redirectContext}[{$redirectSource}]", '')];
+
         // Assign the default redirect afterwards to prevent the
         // source for the default redirect being default[redirect]
         $redirects['default'] = $this->getConfig('defaultRedirect', '');


### PR DESCRIPTION
When i delete a data in update page, it will not going to redirect, because  i did not specify delete context

so this commit is set `defualtRedirect` to defualt context  if there is no matched context