### PR TITLE
error in count() structure fix

### DIFF
--- a/modules/cms/classes/CmsCompoundObject.php
+++ b/modules/cms/classes/CmsCompoundObject.php
@@ -301,7 +301,7 @@ class CmsCompoundObject extends CmsObject
         else {
             foreach ($this->settings['components'] as $name => $settings) {
                 $nameParts = explode(' ', $name);
-                if (count($nameParts > 1)) {
+                if (count($nameParts) > 1) {
                     $name = trim($nameParts[0]);
                 }
 

--- a/tests/unit/cms/classes/CmsCompoundObjectTest.php
+++ b/tests/unit/cms/classes/CmsCompoundObjectTest.php
@@ -29,9 +29,10 @@ class CmsCompoundObjectTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-
         Model::clearBootedModels();
         Model::flushEventListeners();
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Archive.php';
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Post.php';
     }
 
     public function testLoadFile()
@@ -92,6 +93,24 @@ class CmsCompoundObjectTest extends TestCase
         // Negative test
         $this->assertFalse($obj->hasComponent('yooHooBigSummerBlowOut'));
         $this->assertFalse($obj->hasComponent('October\Tester\Components\BigSummer'));
+    }
+
+    public function testGetComponentProperties()
+    {
+        $theme = Theme::load('test');
+
+        $obj = TestCmsCompoundObject::load($theme, 'components.htm');
+
+        $properties = $obj->getComponentProperties('October\Tester\Components\Post');
+        $emptyProperties = $obj->getComponentProperties('October\Tester\Components\Archive');
+        $notExistingProperties = $obj->getComponentProperties('This\Is\Not\Component');
+        $this->assertInternalType('array', $properties);
+        $this->assertArrayHasKey('show-featured', $properties);
+        $this->assertTrue((bool)$properties['show-featured']);
+        $this->assertEquals('true', $properties['show-featured']);
+        $this->assertCount(1, $properties);
+        $this->assertCount(0, $emptyProperties);
+        $this->assertCount(0, $notExistingProperties);
     }
 
     public function testCache()


### PR DESCRIPTION
I want to rant whoever wrote this so hard, but I will keep calm and will just say: if you do not write tests, at least **do not use notepad.exe to write your code**! Any proper IDE would give you red colors for this. 

I understand that it was giving warn in PHP instead of exception, but it's very very stupid and should be merged to master ASAP. Congrats tho, you made our whole team laugh hard. 

Regards,
James