### PR TITLE
Fix call to a member function when BackendUser is null

### DIFF
--- a/modules/backend/controllers/Users.php
+++ b/modules/backend/controllers/Users.php
@@ -50,11 +50,13 @@ class Users extends Controller
     public function __construct()
     {
         $this->user = BackendAuth::getUser();
-        if (!$this->user->isSuperUser()) {
-            // Prevent non-superusers from even seeing the is_superuser filter
-            $this->listConfig = $this->makeConfig($this->listConfig);
-            $this->listConfig->filter = $this->makeConfig($this->listConfig->filter);
-            unset($this->listConfig->filter->scopes['is_superuser']);
+        if ($this->user) {
+            if (!$this->user->isSuperUser()) {
+                // Prevent non-superusers from even seeing the is_superuser filter
+                $this->listConfig = $this->makeConfig($this->listConfig);
+                $this->listConfig->filter = $this->makeConfig($this->listConfig->filter);
+                unset($this->listConfig->filter->scopes['is_superuser']);
+            }
         }
 
         parent::__construct();


### PR DESCRIPTION
Hi. If I am not an authorized user in the backend and try to access the page
/backend/backend/users/update
an error will appear:

Call to a member function isSuperUser() on null
/modules/backend/controllers/Users.php line 53