### PR TITLE
Fix 'illegal string offset' warning

### DIFF
--- a/modules/backend/formwidgets/PermissionEditor.php
+++ b/modules/backend/formwidgets/PermissionEditor.php
@@ -96,7 +96,7 @@ class PermissionEditor extends FormWidgetBase
         $newPermissions = is_array($value) ? array_map('intval', $value) : [];
 
         if (!empty($newPermissions)) {
-            $existingPermissions = $this->model->permissions;
+            $existingPermissions = $this->model->permissions ?: [];
 
             $allowedPermissions = array_map(function ($permissionObject) {
                 return $permissionObject->code;


### PR DESCRIPTION
In case a new administrator is created by a non-superuser and no permission is set directly on creation, ``permissions`` is not initialized correctly. Thus, when the non-superuser tries to acceess ``$this->model->permissions`` it is not populated with an empty array as expected.

I have actually no clue why it does work for superusers however, as they should certainly experience the same issue, but this is not the case.