### PR TITLE
Fix for #3332: storage.uploads.disk in config/cms.php not effective

### DIFF
--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -60,8 +60,8 @@ class File extends FileBase
     }
 
     /**
-     * Returns true if the storage engine is local.
-     * @return bool True if storage.uploads.disk in config/cms.php is "local".
+     * Returns true if storage.uploads.disk in config/cms.php is "local".
+     * @return bool
      */
     protected function isLocalStorage()
     {

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -2,6 +2,8 @@
 
 use Url;
 use Config;
+use File as FileHelper;
+use Storage;
 use October\Rain\Database\Attach\File as FileBase;
 
 /**
@@ -55,5 +57,24 @@ class File extends FileBase
         else {
             return $uploadsFolder . '/protected/';
         }
+    }
+
+    /**
+     * Returns true if the storage engine is local.
+     * @return bool True if storage.uploads.disk in config/cms.php is "local".
+     */
+    protected function isLocalStorage()
+    {
+        return Config::get('cms.storage.uploads.disk') == 'local';
+    }
+
+    /**
+     * Copy the local file to Storage
+     * @return bool True on success, false on failure.
+     */
+    protected function copyLocalToStorage($localPath, $storagePath)
+    {
+        $disk = Storage::disk(Config::get('cms.storage.uploads.disk'));
+        return $disk->put($storagePath, FileHelper::get($localPath), ($this->isPublic()) ? 'public' : null);
     }
 }


### PR DESCRIPTION
This PR fixes issue #3332.

FileUpload widget uploads file to the disk specified by `default` in config/filesystem.php instead of `storage.uploads.disk` in config/cms.php, if we use `System\Models\File` following the instruction in [here](https://octobercms.com/docs/database/attachments#file-attachments).
Although we can still create another class extending `System\Models\File` or `October\Rain\Database\Attach\File` and use it as the model for attachOne/Many relation, `System\Models\File` seems to be the one that responsible to look at `storage.uploads.disk` in config/cms.php, because the existing methods are using `storage.uploads.*`.