### PR TITLE
Catch Artisan::call exception

### DIFF
--- a/modules/system/behaviors/SettingsModel.php
+++ b/modules/system/behaviors/SettingsModel.php
@@ -3,6 +3,8 @@
 use App;
 use Artisan;
 use Cache;
+use Log;
+use Exception;
 use System\Classes\ModelBehavior;
 use ApplicationException;
 
@@ -204,7 +206,12 @@ class SettingsModel extends ModelBehavior
     public function afterModelSave()
     {
         Cache::forget($this->getCacheKey());
-        Artisan::call('queue:restart');
+
+        try {
+            Artisan::call('queue:restart');
+        } catch (Exception $e) {
+            Log::warning($e->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
This change will allow settings to be saved even when Exception is
thrown in Artisan::call (eg. when putenv() function is disabled).

Is related to #3339 and #3280.