### PR TITLE
create october:key command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "scripts": {
         "post-create-project-cmd": [
-            "php artisan key:generate"
+            "php artisan october:key"
         ],
         "post-update-cmd": [
             "php artisan october:util set build"

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -221,6 +221,7 @@ class ServiceProvider extends ModuleServiceProvider
         /*
          * Register console commands
          */
+        $this->registerConsoleCommand('october.key', 'System\Console\OctoberKey');
         $this->registerConsoleCommand('october.up', 'System\Console\OctoberUp');
         $this->registerConsoleCommand('october.down', 'System\Console\OctoberDown');
         $this->registerConsoleCommand('october.update', 'System\Console\OctoberUpdate');

--- a/modules/system/console/OctoberKey.php
+++ b/modules/system/console/OctoberKey.php
@@ -1,0 +1,90 @@
+<?php namespace System\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Encryption\Encrypter;
+use October\Rain\Config\ConfigWriter;
+use File;
+use Config;
+use Str;
+
+class OctoberKey extends Command
+{
+    /**
+     * The console command name.
+     */
+    protected $name = 'october:key';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Set the october application key';
+
+    protected $configWriter;
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->configWriter = new ConfigWriter;
+    }
+
+
+    public function handle()
+    {
+
+        $key = $this->generateRandomKey();
+
+        $this->writeToConfig('app', ['key' => $key]);
+
+        $this->laravel['config']['app.key'] = $key;
+
+        $this->info("Application key [$key] set successfully.");
+    }
+
+    /**
+     * Generate a random key for the application.
+     *
+     * @return string
+     */
+    protected function generateRandomKey()
+    {
+        return 'base64:' . base64_encode(
+                Encrypter::generateKey($this->laravel['config']['app.cipher'])
+            );
+    }
+
+
+    protected function writeToConfig($file, $values)
+    {
+        $configFile = $this->getConfigFile($file);
+
+        foreach ($values as $key => $value) {
+            Config::set($file . '.' . $key, $value);
+        }
+
+        $this->configWriter->toFile($configFile, $values);
+    }
+
+
+    /**
+     * Get a config file and contents.
+     *
+     * @return array
+     */
+    protected function getConfigFile($name = 'app')
+    {
+        $env = $this->option('env') ? $this->option('env') . '/' : '';
+
+        $name .= '.php';
+
+        $contents = File::get($path = $this->laravel['path.config'] . "/{$env}{$name}");
+
+        return $path;
+
+    }
+
+}
+

--- a/modules/system/console/OctoberKey.php
+++ b/modules/system/console/OctoberKey.php
@@ -31,10 +31,8 @@ class OctoberKey extends Command
         $this->configWriter = new ConfigWriter;
     }
 
-
     public function handle()
     {
-
         $key = $this->generateRandomKey();
 
         $this->writeToConfig('app', ['key' => $key]);
@@ -56,7 +54,6 @@ class OctoberKey extends Command
             );
     }
 
-
     protected function writeToConfig($file, $values)
     {
         $configFile = $this->getConfigFile($file);
@@ -68,7 +65,6 @@ class OctoberKey extends Command
         $this->configWriter->toFile($configFile, $values);
     }
 
-
     /**
      * Get a config file and contents.
      *
@@ -77,14 +73,8 @@ class OctoberKey extends Command
     protected function getConfigFile($name = 'app')
     {
         $env = $this->option('env') ? $this->option('env') . '/' : '';
-
         $name .= '.php';
-
         $contents = File::get($path = $this->laravel['path.config'] . "/{$env}{$name}");
-
         return $path;
-
     }
-
 }
-


### PR DESCRIPTION
create october:key command for this issue #3321 , this #3328  PR should be closed.   

if the the key like `  'key' => env('APP_KEY', 'some key')`, this will not work.   

only work with  `'key' => 'some key'`  situation.  

But I still think the best solution is remove ` php artisan key:generate` from `post-create-project-cmd`.