### PR TITLE
Replace URL parameters dynamically without needing a list in advance

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -464,7 +464,7 @@ class FormController extends ControllerBehavior
         }
 
         if ($model && $redirectUrl) {
-            $redirectUrl = RouterHelper::parseValues($model, array_keys($model->getAttributes()), $redirectUrl);
+            $redirectUrl = RouterHelper::replaceParameters($model, $redirectUrl);
         }
 
         return ($redirectUrl) ? Backend::redirect($redirectUrl) : null;

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -562,12 +562,7 @@ class Lists extends WidgetBase
             return null;
         }
 
-        $data = $record->toArray();
-        $data += [$record->getKeyName() => $record->getKey()];
-
-        $columns = array_keys($data);
-
-        $url = RouterHelper::parseValues($data, $columns, $this->recordUrl);
+        $url = RouterHelper::replaceParameters($record, $this->recordUrl);
         return Backend::url($url);
     }
 
@@ -582,8 +577,7 @@ class Lists extends WidgetBase
             return null;
         }
 
-        $columns = array_keys($record->getAttributes());
-        $recordOnClick = RouterHelper::parseValues($record, $columns, $this->recordOnClick);
+        $recordOnClick = RouterHelper::replaceParameters($record, $this->recordOnClick);
         return Html::attributes(['onclick' => $recordOnClick]);
     }
 


### PR DESCRIPTION
Fixes #3358. Depends on octobercms/library#297.

`Backend\Widgets\Lists::getRecordUrl` called `toArray` on models, allowing access to all attributes and relationships in the serialization, but requiring possibly a large amount of data to be loaded. This is specifically a replacement for that behavior to access only attributes for which there are parameters in the URL, but I figured as long as I was making changes, I may as well update the `FormController` redirect and `Lists::getRecordOnClick` to allow access to any model attributes, including those accessible via get mutators.