### PR TITLE
Twig environment "strict_variables"

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -346,5 +346,20 @@ return [
     */
 
     'forceBytecodeInvalidation' => true,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Twig Strict Variables
+    |--------------------------------------------------------------------------
+    |
+    | If strict_variables is disabled, Twig will silently ignore invalid 
+    | variables (variables and or attributes/methods that do not exist) and
+    | replace them with a null value. When enabled, Twig throws an exception
+    | instead. If set to null, it is enabled when debug mode (app.debug) is
+    | enabled.
+    |
+    */
+    
+    'enableTwigStrictVariables' => false,
 
 ];

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -488,6 +488,7 @@ class Controller
 
         $useCache = !Config::get('cms.twigNoCache');
         $isDebugMode = Config::get('app.debug', false);
+        $strictVariables = (Config::get('cms.enableTwigStrictVariables', null) !== null) ?: $isDebugMode;
         $forceBytecode = Config::get('cms.forceBytecodeInvalidation', false);
 
         $options = [

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -488,7 +488,8 @@ class Controller
 
         $useCache = !Config::get('cms.twigNoCache');
         $isDebugMode = Config::get('app.debug', false);
-        if (($strictVariables = Config::get('cms.enableTwigStrictVariables', null)) === null) {
+        $strictVariables = Config::get('cms.enableTwigStrictVariables', false);
+        if ($strictVariables === null) {
             $strictVariables = $isDebugMode;
         }
         $forceBytecode = Config::get('cms.forceBytecodeInvalidation', false);

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -494,7 +494,7 @@ class Controller
         $options = [
             'auto_reload' => true,
             'debug' => $isDebugMode,
-            'strict_variables' => $isDebugMode,
+            'strict_variables' => $strictVariables,
         ];
 
         if ($useCache) {

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -488,7 +488,9 @@ class Controller
 
         $useCache = !Config::get('cms.twigNoCache');
         $isDebugMode = Config::get('app.debug', false);
-        $strictVariables = (Config::get('cms.enableTwigStrictVariables', null) !== null) ?: $isDebugMode;
+        if (($strictVariables = Config::get('cms.enableTwigStrictVariables', null)) === null) {
+            $strictVariables = $isDebugMode;
+        }
         $forceBytecode = Config::get('cms.forceBytecodeInvalidation', false);
 
         $options = [

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -489,9 +489,7 @@ class Controller
         $useCache = !Config::get('cms.twigNoCache');
         $isDebugMode = Config::get('app.debug', false);
         $strictVariables = Config::get('cms.enableTwigStrictVariables', false);
-        if ($strictVariables === null) {
-            $strictVariables = $isDebugMode;
-        }
+        $strictVariables = is_null($strictVariables) ? $isDebugMode : $strictVariables;
         $forceBytecode = Config::get('cms.forceBytecodeInvalidation', false);
 
         $options = [

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -493,6 +493,7 @@ class Controller
         $options = [
             'auto_reload' => true,
             'debug' => $isDebugMode,
+            'strict_variables' => $isDebugMode,
         ];
 
         if ($useCache) {


### PR DESCRIPTION
https://twig.symfony.com/doc/2.x/api.html#environment-options

`strict_variables` will ensure a cleaner approach in themes' development.