### PR TITLE
Use config variable for data cache key.

### DIFF
--- a/modules/cms/classes/CodeParser.php
+++ b/modules/cms/classes/CodeParser.php
@@ -32,7 +32,7 @@ class CodeParser
     /**
      * @var string Key for the parsed PHP file information cache.
      */
-    protected $dataCacheKey = 'cms-php-file-data';
+    protected $dataCacheKey = '';
 
     /**
      * Creates the class instance
@@ -40,8 +40,10 @@ class CodeParser
      */
     public function __construct(CmsCompoundObject $object)
     {
+
         $this->object = $object;
         $this->filePath = $object->getFilePath();
+        $this->dataCacheKey = Config::get('cache.codeParserDataCacheKey', 'cms-php-file-data');
     }
 
     /**


### PR DESCRIPTION
If we deploy octobercms on two servers (in the same path on both), and setup one cache storage for it (for example redis).
System will store information about cached "partials" in redis, and servers will rewrite this information because they are stored under the same key. System validate cache by compare "mtime", between "mtime" in redis and filesystem "mtime".
Often we have "mtime" from server1 in redis which compare with file mtime on server2, so system run rebuild cache very often.

And when we have big traffic we able to get error:
`prod.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Class 'Cms5a667baecf93e170794683_4ce1b5d369a0cfcf4b16d519cea731c1Class' not found in /var/www/html/modules/cms/classes/CodeParser.php:180`