### PR TITLE
Fixing stale cache issue

### DIFF
--- a/modules/cms/classes/CodeParser.php
+++ b/modules/cms/classes/CodeParser.php
@@ -192,8 +192,10 @@ class CodeParser
 
         if (is_file($path)) {
             if ($className = $this->extractClassFromFile($path)) {
-                $data['className'] = $className;
-                return $data;
+                if (class_exists($className)) {
+                    $data['className'] = $className;
+                    return $data;
+                }
             }
 
             @unlink($path);


### PR DESCRIPTION
Occasionally with certain IIS setups, the file will contain an out-of-date class name.  This patch will verify the class name from the file before returning, and clear the cache if invalid.