### PR TITLE
Add Cache-Control header for combine assets

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -245,6 +245,7 @@ class CombineAssets
         header_remove();
         $response = Response::make();
         $response->header('Content-Type', $mime);
+        $response->header('Cache-Control', 'private, max-age=604800');
         $response->setLastModified(new DateTime($lastModifiedTime));
         $response->setEtag($etag);
         $response->setPublic();


### PR DESCRIPTION
Hi! I'm working on site optimization. To check the optimization I use the services:
https://developers.google.com/speed/pagespeed/insights/
https://tools.pingdom.com/
https://gtmetrix.com/

All services offer me caching 'combine' file. After this fix - services say 'It's okay'