### PR TITLE
Cache page number in List widget

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -263,6 +263,9 @@ class Lists extends WidgetBase
 
         if ($this->showPagination) {
             $this->vars['pageCurrent'] = $this->records->currentPage();
+            // Store the currently visited page number in the session so the same
+            // data can be displayed when the user returns to this list.
+            $this->putSession('lastVisitedPage', $this->vars['pageCurrent']);
             if ($this->showPageNumbers) {
                 $this->vars['recordTotal'] = $this->records->total();
                 $this->vars['pageLast'] = $this->records->lastPage();
@@ -540,8 +543,13 @@ class Lists extends WidgetBase
             $records = $model->getNested();
         }
         elseif ($this->showPagination) {
-            $method = $this->showPageNumbers ? 'paginate' : 'simplePaginate';
-            $records = $model->{$method}($this->recordsPerPage, $this->currentPageNumber);
+            $method            = $this->showPageNumbers ? 'paginate' : 'simplePaginate';
+            $currentPageNumber = $this->currentPageNumber;
+            if (!$currentPageNumber && empty($this->searchTerm)) {
+                // Restore the last visited page from the session if available.
+                $currentPageNumber = $this->getSession('lastVisitedPage');
+            }
+            $records = $model->{$method}($this->recordsPerPage, $currentPageNumber);
         }
         else {
             $records = $model->get();


### PR DESCRIPTION
I am proposing a minor optimization to the way the list widget works when displaying multiple pages. This PR is one solution to this problem. I am open to discuss any other methods to solve this problem.

Let's say I am on page 5 of 10 in my list view and I clilck on a record. If I make the desired modifications and click on `Save` or `Cancel` I am redirected back to the list but I am now on page 1 and not on page 5.

My solution is to save the last visited page number into a session variable (like it is done with the search query and visible columns) and load it when the List widget creates the pagination.