### PR TITLE
Silence errors coming from OpCache

### DIFF
--- a/modules/cms/classes/CodeParser.php
+++ b/modules/cms/classes/CodeParser.php
@@ -335,8 +335,8 @@ class CodeParser
          * Compile cached file into bytecode cache
          */
         if (Config::get('cms.forceBytecodeInvalidation', false)) {
-            if (function_exists('opcache_invalidate')) {
-                @opcache_invalidate($path, true);
+            if (function_exists('opcache_invalidate') && opcache_invalidate($path, true)) {
+                opcache_invalidate($path, true);
             }
             elseif (function_exists('apc_compile_file')) {
                 apc_compile_file($path);

--- a/modules/cms/classes/CodeParser.php
+++ b/modules/cms/classes/CodeParser.php
@@ -336,7 +336,7 @@ class CodeParser
          */
         if (Config::get('cms.forceBytecodeInvalidation', false)) {
             if (function_exists('opcache_invalidate')) {
-                opcache_invalidate($path, true);
+                @opcache_invalidate($path, true);
             }
             elseif (function_exists('apc_compile_file')) {
                 apc_compile_file($path);


### PR DESCRIPTION
I noticed an error being thrown by OpCache:

```
Zend OPcache API is restricted by "restrict_api" configuration directive
```

This PR temporarily silences it until a solution can be found.