### PR TITLE
Fix incorrect usage of the count() function

### DIFF
--- a/modules/system/controllers/requestlogs/_referer_field.htm
+++ b/modules/system/controllers/requestlogs/_referer_field.htm
@@ -1,4 +1,4 @@
-<?php if (count($formModel->referer) > 0): ?>
+<?php if (is_array($formModel->referer)?count($formModel->referer):0 > 0): ?>
     <div class="form-control control-simplelist with-icons">
         <ul>
             <?php foreach ((array) $formModel->referer as $referer): ?>


### PR DESCRIPTION
Fixes the error: `ErrorException: count(): Parameter must be an array or an object that implements Countable in /var/www/superkorb/modules/system/controllers/requestlogs/_referer_field.htm:1`
In PHP 7.2 there was a change, which won't allow anymore to give null into the function. So we need to check it before, if the object is an array which is countable.

//  Edit: This error occurs, when you gonna view the request log and check for the referrers in a PHP 7.2 installation. 