### PR TITLE
Add support for more than one nested folder in the CMS file browser #3382

### DIFF
--- a/modules/cms/classes/Partial.php
+++ b/modules/cms/classes/Partial.php
@@ -9,6 +9,12 @@
 class Partial extends CmsCompoundObject
 {
     /**
+     * From david: I dont think this variable $maxNesting is still working
+     * TODO: Make sure that we use this variable to control the max nesting level which allows us to have different max nesting possiablities in the different cms type(pages, partials ...)
+     */
+    protected $maxNesting = null;
+
+    /**
      * @var string The container name associated with the model, eg: pages.
      */
     protected $dirName = 'partials';

--- a/modules/cms/widgets/TemplateList.php
+++ b/modules/cms/widgets/TemplateList.php
@@ -202,12 +202,20 @@ class TemplateList extends WidgetBase
             $filteredItems = $items;
         }
 
-        /*
-         * Group the items
-         */
+        return $this->groupItems($filteredItems);
+    }
+
+    protected function groupItems($filteredItems)
+    {
         $result = [];
         $foundGroups = [];
+        $folderStrcture = [];
+        $isMultiLayer = false;
         foreach ($filteredItems as $itemData) {
+            $folderStrcture = explode('/', $itemData->fileName);
+            if (sizeof($folderStrcture) > 2) {
+                $subGroup = $folderStrcture[1];
+            }
             $pos = strpos($itemData->fileName, '/');
 
             if ($pos !== false) {
@@ -217,11 +225,21 @@ class TemplateList extends WidgetBase
                         'title' => $group,
                         'items' => []
                     ];
-
                     $foundGroups[$group] = $newGroup;
                 }
-
                 $foundGroups[$group]->items[] = $itemData;
+
+                // if sub group exist
+                if (isset($subGroup)) {
+                    if (!array_key_exists($subGroup, $foundGroups[$group]->items)) {
+                        $newGroup = (object)[
+                            'title' => $subGroup,
+                            'items' => []
+                        ];
+                        $foundGroups[$group]->items[$subGroup] = $newGroup;
+                    }
+                    $foundGroups[$group]->items[$subGroup]->items[] = $itemData;
+                }
             }
             else {
                 $result[] = $itemData;


### PR DESCRIPTION
#3382  **Add support for more than one nested folder in the CMS file browser**
This is a quick implementation of supporting max two levels of subdirectories for ONLY partials.
TODO: Investigate a good UI/UX example to implement infinite levels of subdirectories without making backend as a mess

To October Team,

I suggest that we can support max two levels of subdirectories only in cms type: partial.
I have another solution that we implement the Partials' UI as the Assets' UI does, so which supports infinite nested folder.
Please advise me what to do next. 
Also, could you please explain that how the $maxNesting works, I have overridden the variable in modules/cms/classes/Partial.php but I still not be able to extract the items with two or more nested folder and files in the Template file without changing the vendor/october/rain/src/Halcyon/Datasource/FileDatasource.php which I think is not robust enough.

Cheers,
Siyu Qian