### PR TITLE
Update ImportModel.php

### DIFF
--- a/modules/backend/models/ImportModel.php
+++ b/modules/backend/models/ImportModel.php
@@ -141,13 +141,9 @@ abstract class ImportModel extends Model
             ));
         }
 
-        $result = [];
-        $contents = $reader->fetch();
-        foreach ($contents as $row) {
-            $result[] = $this->processImportRow($row, $matches);
-        }
-
-        return $result;
+        return $reader->fetch(function ($row) use ($matches) {
+            return $this->processImportRow($row, $matches);
+        });
     }
 
     /**


### PR DESCRIPTION
This PR ca be a backwards incompatible change in some cases, but substantially improves memory usage. Instead of loading all array upfront while importing it uses `fetch` (https://csv.thephpleague.com/8.0/reading/ ) callback feature that applies `processImportRow` function to each row one by one instead of loading the entire array into one variable. I experience some issues while trying to import 250k+ records set and this is the way for me to reduce the memory footprint drastically. 

This change will break the user code if the implementation relied on the fact that `processImportData` returned an array - now it's an `iterator` instance (it can be mitigated by adding `iterator_to_array` call in the userspace implementation). Typical usage should stay the same, as `foreach ($results as $result) {...}` still works, but the memory usage is much lower and it helps a lot with large datasets.