### PR TITLE
Placeholder for TagList

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -47,6 +47,11 @@ class TagList extends FormWidgetBase
      */
     public $useKey = false;
 
+    /**
+     * @var string Placeholder for empty TagList widget
+     */
+    public $placeholder = '';
+
     //
     // Object properties
     //
@@ -68,6 +73,7 @@ class TagList extends FormWidgetBase
             'mode',
             'nameFrom',
             'useKey',
+            'placeholder'
         ]);
     }
 
@@ -86,6 +92,7 @@ class TagList extends FormWidgetBase
      */
     public function prepareVars()
     {
+        $this->vars['placeholder'] = $this->placeholder;
         $this->vars['useKey'] = $this->useKey;
         $this->vars['field'] = $this->formField;
         $this->vars['fieldOptions'] = $this->getFieldOptions();

--- a/modules/backend/formwidgets/taglist/partials/_taglist.htm
+++ b/modules/backend/formwidgets/taglist/partials/_taglist.htm
@@ -7,8 +7,8 @@
     id="<?= $field->getId() ?>"
     name="<?= $field->getName() ?>[]"
     class="form-control custom-select <?= !count($fieldOptions) ? 'select-no-dropdown' : '' ?> select-hide-selected"
-    data-token-separators="<?= $customSeparators ?? ''; ?>"
-    data-placeholder="<?= !empty($placeholder) ? e(trans($placeholder)) : ''; ?>"
+    <?php if (!empty($customSeparators)): ?>data-token-separators="<?= $customSeparators ?>"<?php endif ?>
+    <?php if (!empty($placeholder)): ?>data-placeholder="<?= e(trans($placeholder)) ?>"<?php endif ?>
     multiple
     <?= $field->getAttributes() ?>>
     <?php foreach ($availableOptions as $key => $option): ?>

--- a/modules/backend/formwidgets/taglist/partials/_taglist.htm
+++ b/modules/backend/formwidgets/taglist/partials/_taglist.htm
@@ -7,8 +7,9 @@
     id="<?= $field->getId() ?>"
     name="<?= $field->getName() ?>[]"
     class="form-control custom-select <?= !count($fieldOptions) ? 'select-no-dropdown' : '' ?> select-hide-selected"
-    <?php if ($customSeparators): ?>data-token-separators="<?= $customSeparators ?>"<?php endif ?>
-    multiple
+    data-token-separators="<?= $customSeparators ?? ''; ?>"
+    data-placeholder="<?= $placeholder ?? ''; ?>"
+    multipletouch
     <?= $field->getAttributes() ?>>
     <?php foreach ($availableOptions as $key => $option): ?>
         <?php if (!strlen($option)) continue ?>

--- a/modules/backend/formwidgets/taglist/partials/_taglist.htm
+++ b/modules/backend/formwidgets/taglist/partials/_taglist.htm
@@ -9,7 +9,7 @@
     class="form-control custom-select <?= !count($fieldOptions) ? 'select-no-dropdown' : '' ?> select-hide-selected"
     data-token-separators="<?= $customSeparators ?? ''; ?>"
     data-placeholder="<?= $placeholder ?? ''; ?>"
-    multipletouch
+    multiple
     <?= $field->getAttributes() ?>>
     <?php foreach ($availableOptions as $key => $option): ?>
         <?php if (!strlen($option)) continue ?>

--- a/modules/backend/formwidgets/taglist/partials/_taglist.htm
+++ b/modules/backend/formwidgets/taglist/partials/_taglist.htm
@@ -8,7 +8,7 @@
     name="<?= $field->getName() ?>[]"
     class="form-control custom-select <?= !count($fieldOptions) ? 'select-no-dropdown' : '' ?> select-hide-selected"
     data-token-separators="<?= $customSeparators ?? ''; ?>"
-    data-placeholder="<?= $placeholder ?? ''; ?>"
+    data-placeholder="<?= !empty($placeholder) ? e(trans($placeholder)) : ''; ?>"
     multiple
     <?= $field->getAttributes() ?>>
     <?php foreach ($availableOptions as $key => $option): ?>

--- a/modules/system/assets/ui/less/select.less
+++ b/modules/system/assets/ui/less/select.less
@@ -320,14 +320,14 @@
         // Make Multi Select2's choices match default button styles.
         //
         .select2-selection__choice {
-            color: @input-color;
+            color: @color-select-text;
             background: @color-select-choice-bg;
             border: 1px solid @color-select-choice-border;
             border-radius: 4px;
             cursor: default;
             float: left;
-            margin: (@padding-base-vertical - 1) 0 0 @padding-base-horizontal/2;
-            padding: 0 @padding-base-vertical;
+            margin: (@padding-base-vertical - 2) 0 0 @padding-base-horizontal/2;
+            padding: 0 (@padding-base-vertical - 2);
         }
 
         //
@@ -349,7 +349,9 @@
             cursor: pointer;
             display: inline-block;
             font-weight: bold;
-            margin-right: @padding-base-vertical / 2;
+            font-size: 1.2em;
+            float: right;
+            margin: -2px 0 1px 8px;
 
             &:hover {
                 color: #333;
@@ -396,8 +398,8 @@
             .select2-selection__choice {
                 font-size: @font-size-small;
                 line-height: @line-height-small;
-                margin: (@padding-small-vertical - 1) 0 0 @padding-small-horizontal/2;
-                padding: 0 @padding-small-vertical;
+                margin: (@padding-small-vertical - 2) 0 0 @padding-small-horizontal/2;
+                padding: 0 (@padding-small-vertical - 2);
             }
 
             .select2-search--inline .select2-search__field {

--- a/modules/system/assets/ui/less/select.variables.less
+++ b/modules/system/assets/ui/less/select.variables.less
@@ -12,8 +12,9 @@
 @color-select-active-bg:              #4da7e8;
 @color-select-header:                 @gray-light;
 @color-select-link-disabled:          @gray-light;
-@color-select-choice-bg: #fff;
-@color-select-choice-border: #ccc;
+@color-select-choice-bg:              #fff;
+@color-select-choice-border:          #ccc;
+@color-select-text:                   #515c5d;
 
 @select-box-shadow: 0 3px 6px rgba(0,0,0,.075);
 @select-box-shadow-above: 0 -3px 6px rgba(0,0,0,.075);


### PR DESCRIPTION
I've noticed that placeholder option is missing for TagList, so I've added it within this PR.

```
                    ...
                    'type'  => 'taglist',
                    'placeholder' => 'Add items...',
                ]
```

![taglist_placeholder](https://user-images.githubusercontent.com/3897579/37487534-d5a8abc6-28a2-11e8-9edc-bab074a19761.png)

Also small adjustments were made to a default style of select items.

Before:
![taglist_before](https://user-images.githubusercontent.com/3897579/37487585-fb06b11a-28a2-11e8-803a-590e9a92b459.png)

After:
![taglist_after](https://user-images.githubusercontent.com/3897579/37487586-fb255462-28a2-11e8-81b7-8616c5c901eb.png)

Alignments were fixed, removal cross is slightly bigger, text color was changed. 