### PR TITLE
Fix S3 Media Library Item Url

### DIFF
--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -574,7 +574,7 @@ class MediaLibrary
             ? $this->getStorageDisk()->size($path)
             : $this->getFolderItemCount($path);
 
-        $publicUrl = $this->storagePath.$relativePath;
+        $publicUrl = $this->getPathUrl($relativePath);
 
         return new MediaLibraryItem($relativePath, $size, $lastModified, $itemType, $publicUrl);
     }


### PR DESCRIPTION
Fix for #3445 the Public Url of S3 Media items in the backend when the storage folder is set as a bucket Root folder. 
The File path was missing a slash between the bucket name & file path.