### PR TITLE
Checking if the side menu exist

### DIFF
--- a/modules/backend/assets/js/october.sidepaneltab.js
+++ b/modules/backend/assets/js/october.sidepaneltab.js
@@ -164,6 +164,10 @@
     }
 
     SidePanelTab.prototype.updateActiveTab = function() {
+        if (this.$sideNav.length === 0) {
+            return;
+        }
+        
         if (!this.panelVisible && ($(window).width() < this.options.breakpoint || !this.panelFixed())) {
             $.oc.sideNav.unsetActiveItem()
         }


### PR DESCRIPTION
I'm trying create plugin with sidebar list, like as CMS page. But in my case - I do no need side menu (pages, layouts, partials, etc.). When I'm tring make some changes on page (refresh, click on sidebar records) - an error appears in the console:

```
october-min.js?v434:996 Uncaught TypeError: Cannot read property 'setActiveItem' of undefined
    at SidePanelTab.updateActiveTab (october-min.js?v434:996)
    at SidePanelTab.hideSidePanel (october-min.js?v434:991)
    at HTMLDivElement.<anonymous> (october-min.js?v434:963)
    at HTMLDivElement.handle (jquery.min.js?v434:3)
    at HTMLDivElement.dispatch (jquery.min.js?v434:3)
    at HTMLDivElement.r.handle (jquery.min.js?v434:3)
```