### PR TITLE
Added a config flag for request cache. See octobercms/library pull 308.

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -78,4 +78,17 @@ return [
 
     'prefix' => 'october',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Disable Request Cache
+    |--------------------------------------------------------------------------
+    |
+    | The request cache remembers cache retrievals from your cache store
+    | in memory to speed up consecutive retrievals within the same request.
+    | It is recommended you leave this on both in production and development.
+    |
+    */
+
+    'disableRequestCache' => false,
+
 ];

--- a/config/cache.php
+++ b/config/cache.php
@@ -83,9 +83,9 @@ return [
     | Disable Request Cache
     |--------------------------------------------------------------------------
     |
-    | The request cache remembers cache retrievals from your cache store
+    | The request cache stores cache retrievals from the cache store
     | in memory to speed up consecutive retrievals within the same request.
-    | It is recommended you leave this on both in production and development.
+    | Set to true to disable this in-memory request cache.
     |
     */
 


### PR DESCRIPTION
This commit adds a config flag in `config/cache.php` to enable/disable the request cache being added in [this commit](https://github.com/octobercms/library/pull/308) to the core library, as discussed there with @LukeTowers 

Please let me know if you think something should be worded differently!