### PR TITLE
Fix mail.beforeAddContent listener to use the $plain argument as well

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -330,7 +330,8 @@ class ServiceProvider extends ModuleServiceProvider
          */
         Event::listen('mailer.beforeAddContent', function ($mailer, $message, $view, $data, $raw, $plain) {
             $method = $raw === null ? 'addContentToMailer' : 'addRawContentToMailer';
-            return !MailManager::instance()->$method($message, $raw ?: $view ?: $plain, $data, $view === null);
+            $plainOnly = $view === null; // When "plain-text only" email is sent, $view is null, this sets the flag appropriately
+            return !MailManager::instance()->$method($message, $raw ?: $view ?: $plain, $data, $plainOnly);
         });
     }
 

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -330,7 +330,7 @@ class ServiceProvider extends ModuleServiceProvider
          */
         Event::listen('mailer.beforeAddContent', function ($mailer, $message, $view, $data, $raw, $plain) {
             $method = $raw === null ? 'addContentToMailer' : 'addRawContentToMailer';
-            return !MailManager::instance()->$method($message, $raw ?: $view ?: $plain, $data);
+            return !MailManager::instance()->$method($message, $raw ?: $view ?: $plain, $data, $view === null);
         });
     }
 

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -328,9 +328,9 @@ class ServiceProvider extends ModuleServiceProvider
         /*
          * Override standard Mailer content with template
          */
-        Event::listen('mailer.beforeAddContent', function ($mailer, $message, $view, $data, $raw) {
+        Event::listen('mailer.beforeAddContent', function ($mailer, $message, $view, $data, $raw, $plain) {
             $method = $raw === null ? 'addContentToMailer' : 'addRawContentToMailer';
-            return !MailManager::instance()->$method($message, $raw ?: $view, $data);
+            return !MailManager::instance()->$method($message, $raw ?: $view ?: $plain, $data);
         });
     }
 

--- a/modules/system/classes/MailManager.php
+++ b/modules/system/classes/MailManager.php
@@ -58,6 +58,7 @@ class MailManager
 
     /**
      * Same as `addContentToMailer` except with raw content.
+     *
      * @return bool
      */
     public function addRawContentToMailer($message, $content, $data)
@@ -74,9 +75,14 @@ class MailManager
     /**
      * This function hijacks the `addContent` method of the `October\Rain\Mail\Mailer`
      * class, using the `mailer.beforeAddContent` event.
+     *
+     * @param \Illuminate\Mail\Message $message
+     * @param string $code
+     * @param array $data
+     * @param bool $plainOnly Add only plain text content to the message
      * @return bool
      */
-    public function addContentToMailer($message, $code, $data, $plainOnly)
+    public function addContentToMailer($message, $code, $data, $plainOnly = false)
     {
         if (isset($this->templateCache[$code])) {
             $template = $this->templateCache[$code];
@@ -96,9 +102,14 @@ class MailManager
 
     /**
      * Internal method used to share logic between `addRawContentToMailer` and `addContentToMailer`
+     *
+     * @param \Illuminate\Mail\Message $message
+     * @param string $template
+     * @param array $data
+     * @param bool $plainOnly Add only plain text content to the message
      * @return void
      */
-    protected function addContentToMailerInternal($message, $template, $data, $plainOnly)
+    protected function addContentToMailerInternal($message, $template, $data, $plainOnly = false)
     {
         /*
          * Start twig transaction
@@ -197,9 +208,8 @@ class MailManager
 
     /**
      * Render the Markdown template into text.
-     *
-     * @param  string  $view
-     * @param  array  $data
+     * @param $content
+     * @param array $data
      * @return string
      */
     public function renderText($content, $data = [])

--- a/modules/system/classes/MailManager.php
+++ b/modules/system/classes/MailManager.php
@@ -72,11 +72,11 @@ class MailManager
     }
 
     /**
-     * This function hijacks the `addContent` method of the `October\Rain\Mail\Mailer` 
+     * This function hijacks the `addContent` method of the `October\Rain\Mail\Mailer`
      * class, using the `mailer.beforeAddContent` event.
      * @return bool
      */
-    public function addContentToMailer($message, $code, $data)
+    public function addContentToMailer($message, $code, $data, $plainOnly)
     {
         if (isset($this->templateCache[$code])) {
             $template = $this->templateCache[$code];
@@ -89,7 +89,7 @@ class MailManager
             return false;
         }
 
-        $this->addContentToMailerInternal($message, $template, $data);
+        $this->addContentToMailerInternal($message, $template, $data, $plainOnly);
 
         return true;
     }
@@ -98,7 +98,7 @@ class MailManager
      * Internal method used to share logic between `addRawContentToMailer` and `addContentToMailer`
      * @return void
      */
-    protected function addContentToMailerInternal($message, $template, $data)
+    protected function addContentToMailerInternal($message, $template, $data, $plainOnly)
     {
         /*
          * Start twig transaction
@@ -126,12 +126,14 @@ class MailManager
             'subject' => $swiftMessage->getSubject()
         ];
 
-        /*
-         * HTML contents
-         */
-        $html = $this->renderTemplate($template, $data);
+        if (!$plainOnly) {
+            /*
+             * HTML contents
+             */
+            $html = $this->renderTemplate($template, $data);
 
-        $message->setBody($html, 'text/html');
+            $message->setBody($html, 'text/html');
+        }
 
         /*
          * Text contents


### PR DESCRIPTION
`System\Serviceprovider` adds a listener to `mail.beforeAddContent` but was not passing the `$plain` argument provided by the dispatched event.
See https://github.com/octobercms/library/blob/9d3c73e1d4e6cc562dea6b930bcb4e63d2b64d3b/src/Mail/Mailer.php#L335

This resulted in that when plain-text only emails are attempted with `[ 'text' => 'template.code' ]`, `template.code` became `null` in the handler and could not be found. As a consequence `lluminate/View/FileViewFinder` trying to find it on the filesystem where it did not exist, because mail templates/views/layouts may be stored in the database alone.

`InvalidArgumentException: View [template.code] not found.`