### PR TITLE
Make field error focus work for media upload

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -242,7 +242,7 @@ if (window.jQuery.request !== undefined) {
                 $.each(fields, function focusErrorField(fieldName, fieldMessages) {
                     fieldName = fieldName.replace(/\.(\w+)/g, '[$1]')
 
-                    var fieldElement = $form.find('[name="'+fieldName+'"], [name="'+fieldName+'[]"], [name$="['+fieldName+']"], [name$="['+fieldName+'][]"]').filter(':enabled').first()
+                    var fieldElement = $form.find('[name="'+fieldName+'"], [name="'+fieldName+'[]"], [name$="['+fieldName+']"], [name$="['+fieldName+'][]"], [data-field-name="'+fieldName+'"]').filter(':not([disabled])').first()
                     if (fieldElement.length > 0) {
 
                         var _event = jQuery.Event('ajaxInvalidField')


### PR DESCRIPTION
Currently, the frontend validation does not detect `mediafinder` fields for focussing to the first error element. This annoyingly focusses the next tab with an error on a `text` (or other `name="..."` carrying) fields. The `mediafinder` needs to use `data-field-name`. This pull request fixes the focus after error bug.