### PR TITLE
Added align property to list columns definition

### DIFF
--- a/modules/backend/classes/ListColumn.php
+++ b/modules/backend/classes/ListColumn.php
@@ -92,6 +92,11 @@ class ListColumn
     public $path;
 
     /**
+     * @var string Specifies the alignment of this column.
+     */
+    public $align;
+
+    /**
      * @var array Raw field configuration.
      */
     public $config;
@@ -163,6 +168,9 @@ class ListColumn
         if (isset($config['path'])) {
             $this->path = $config['path'];
         }
+        if (isset($config['align']) && \in_array($config['align'], ['left', 'right', 'center'])) {
+            $this->align = $config['align'];
+        }
 
         return $config;
     }
@@ -192,6 +200,15 @@ class ListColumn
         }
 
         return HtmlHelper::nameToId($id);
+    }
+
+    /**
+     * Returns the column specific aligment css class.
+     * @return string
+     */
+    public function getAlignClass()
+    {
+        return $this->align ? 'list-cell-align-' . $this->align : '';
     }
 
     /**

--- a/modules/backend/widgets/lists/partials/_list_body_row.htm
+++ b/modules/backend/widgets/lists/partials/_list_body_row.htm
@@ -18,7 +18,7 @@
 
     <?php $index = $url = 0; foreach ($columns as $key => $column): ?>
         <?php $index++; ?>
-        <td class="list-cell-index-<?= $index ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->clickable ? '' : 'nolink' ?> <?= $column->cssClass ?>">
+        <td class="list-cell-index-<?= $index ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->clickable ? '' : 'nolink' ?> <?= $column->getAlignClass() ?> <?= $column->cssClass ?>">
             <?php if ($column->clickable && !$url && ($url = $this->getRecordUrl($record))): ?>
                 <a <?= $this->getRecordOnClick($record) ?> href="<?= $url ?>">
                     <?= $this->getColumnValue($record, $column) ?>

--- a/modules/backend/widgets/lists/partials/_list_head_row.htm
+++ b/modules/backend/widgets/lists/partials/_list_head_row.htm
@@ -18,7 +18,7 @@
         <?php if ($showSorting && $column->sortable): ?>
             <th
                 <?php if ($column->width): ?>style="width: <?= $column->width ?>"<?php endif ?>
-                class="<?= $this->sortColumn==$column->columnName?'sort-'.$this->sortDirection.' active':'sort-desc' ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?>"
+                class="<?= $this->sortColumn==$column->columnName?'sort-'.$this->sortDirection.' active':'sort-desc' ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->getAlignClass() ?>"
                 >
                 <a
                     href="javascript:;"

--- a/modules/system/assets/ui/less/list.less
+++ b/modules/system/assets/ui/less/list.less
@@ -290,6 +290,21 @@ table.table.data {
         text-align: right;
     }
 
+    th.list-cell-align-left,
+    td.list-cell-align-left {
+        text-align: left;
+    }
+
+    th.list-cell-align-right,
+    td.list-cell-align-right {
+        text-align: right;
+    }
+
+    th.list-cell-align-center,
+    td.list-cell-align-center {
+        text-align: center;
+    }
+
     //
     // Labels
     //

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -2665,6 +2665,9 @@ table.table.data tfoot a{color:#666666;text-decoration:none}
 table.table.data tfoot td,table.table.data tfoot th{border-color:#d4d8da;padding:10px 15px}
 table.table.data th.list-cell-type-switch,table.table.data td.list-cell-type-switch{text-align:center}
 table.table.data th.list-cell-type-number,table.table.data td.list-cell-type-number{text-align:right}
+table.table.data th.list-cell-align-left,table.table.data td.list-cell-align-left{text-align:left}
+table.table.data th.list-cell-align-right,table.table.data td.list-cell-align-right{text-align:right}
+table.table.data th.list-cell-align-center,table.table.data td.list-cell-align-center{text-align:center}
 table.table.data .list-badge{display:inline-block;position:relative;top:0;margin:0 5px 0 0;padding:1px 0 0 0;font-size:10px;width:15px;height:15px;text-align:center;border-radius:3px;color:#fff}
 table.table.data .list-badge > i{position:relative;top:-1px}
 table.table.data .list-badge.badge-default{background:#999999}


### PR DESCRIPTION
By default all backend `text` columns are aligned left, columns with the type `number` are aligned right.

This is not always ideal: If I have an order total like `2'000.00 €` I want to format it as right aligned text. Defining a css class like `text-right` in the `cssClass` property allows me to format the rows but not the header. 

This PR adds an `align` property to the columns definition that accepts the values `left`, `right` and `center`. If specified a `list-cell-align-*` class is added to the rows and the header. This class will take precedence over the default `number` alignment if specified.

If this PR gets merged I will gladly update the docs accordingly.

Example config:

```yml
total:
    label: Order Total
    path: $/acme/plugin/models/order/_total_formatted.htm
    type: partial
    align: right
```