### PR TITLE
Fix for missing _group field when saving data from a nested group repeater

### DIFF
--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -40,6 +40,9 @@
         <?php foreach ($widget->getFields() as $field): ?>
             <?= $widget->renderField($field) ?>
         <?php endforeach ?>
+        <?php if ($useGroups): ?>
+            <input type="hidden" name="<?= $widget->arrayName ?>[_group]" value="<?= $groupCode ?>" />
+        <?php endif ?>
     </div>
 
     <input type="hidden" name="<?= $indexInputName ?>[]" value="<?= $indexValue ?>" />


### PR DESCRIPTION
**Repro and details (screenshots, expected, actual, etc)**: daftspunk/oc-test-plugin#50
**Closes**: #3067

This fixes a bug where the `_group` field isn't saved with nested group repeater forms. This causes problems for subsequent renders of the backend form with the nested group repeater.