### PR TITLE
Improved availability of the backend inspector outside of dragscroll elements

### DIFF
--- a/modules/cms/assets/js/october.cmspage.js
+++ b/modules/cms/assets/js/october.cmspage.js
@@ -375,7 +375,12 @@
     }
 
     CmsPage.prototype.onInspectorShowing = function(ev, data) {
-        $(ev.currentTarget).closest('[data-control="toolbar"]').data('oc.dragScroll').goToElement(ev.currentTarget, data.callback)
+        var $dragScroll = $(ev.currentTarget).closest('[data-control="toolbar"]').data('oc.dragScroll')
+        if ($dragScroll) {
+            $dragScroll.goToElement(ev.currentTarget, data.callback)
+        } else {
+            data.callback();
+        }
 
         ev.stopPropagation()
     }


### PR DESCRIPTION
Update to the javascript cmsPage onInspectorShowing event handler to make it check whether the event target has a dragScroll attached to it (which it previously assumed it did). This allows the inspector to be used in other locations on the backend which are outside of a dragscroll without causing a javascript error.

I am currently developing a backend form which inserts inspector-able elements to the page dynamically and without this change a javascript error ("Uncaught TypeError: Cannot read property 'goToElement' of undefined") occurs when trying to open the inspector. The data.callback() needs to be called still though or the inspector doesn't open