### PR TITLE
Make media URLs in accordance with the Link Policy

### DIFF
--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -6,6 +6,7 @@ use Cache;
 use Config;
 use Storage;
 use Request;
+use Url;
 use October\Rain\Filesystem\Definitions as FileDefinitions;
 use ApplicationException;
 use SystemException;
@@ -491,7 +492,7 @@ class MediaLibrary
     {
         $path = $this->validatePath($path);
 
-        return $this->storagePath.$path;
+        return URL::to($this->storagePath.$path);
     }
 
     /**

--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -492,7 +492,9 @@ class MediaLibrary
     {
         $path = $this->validatePath($path);
 
-        return URL::to($this->storagePath.$path);
+        $fullPath = $this->storagePath.implode("/", array_map("rawurlencode", explode("/", $path)));
+
+        return Url::to($fullPath);
     }
 
     /**


### PR DESCRIPTION
Since the Link Policy controls how URLs are generated "throughout the application", I thought it should also apply to media URLs. While I was at it, I made sure that it always returns valid URLs (before it kept spaces etc).

Here's an example:

Assume these settings:
`LINK_POLICY=force`
`APP_URL=http://example.dev`

And this path saved in the database from the media finder: 
`/tester/Volvo/V60 D6 TE/thumb.jpg`

Before my PR the result was the following while using the |media filter: 
`/storage/app/media/tester/Volvo/V60 D6 TE/thumb.jpg`

This does not comply with the link policy (should include protocol and domain), and also contains spaces and is therefore an invalid URL.

This would be the result with my PR:
`http://example.dev/storage/app/media/tester/Volvo/V60%20D6%20TE/thumb.jpg`

When using S3 etc the `cms.storage.media.path` config variable should be a valid URL and the Url::to() method will return the path directly, so you should not have to worry that protocol and domain is added to already fully valid URLs. Below is an excerpt from the UrlGenerator::to() method:

````php
// First we will check if the URL is already a valid URL. If it is we will not
// try to generate a new one but will simply return the URL as is, which is
// convenient since developers do not always have to check if it's valid.
if ($this->isValidUrl($path)) {
    return $path;
}
````

However it might be more efficient to move the Url::to() call to where the MediaManager->storagePath variable is set in the MediaManager init() function? Then it would only be called once and not every time. That would also produce URLs according to the link policy while using the Markdown editor and probably some other places, which I guess is a good thing but would make it harder to migrate content (but not harder than if you're using S3 etc).

This PR is a remake of #3057 because I messed that one up using my master branch that I need for other purposes.