### PR TITLE
Overwrite SameName Image Upload Using MediaManager

### DIFF
--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -1101,7 +1101,7 @@ class MediaManager extends WidgetBase
              * Convert uppcare case file extensions to lower case
              */
             $extension = strtolower($uploadedFile->getClientOriginalExtension());
-            $fileName = File::name($fileName).'.'.$extension;
+            $fileName = File::name($fileName).time().'.'.$extension;
 
             /*
              * File name contains non-latin characters, attempt to slug the value


### PR DESCRIPTION
Right Now In OctoberCMS Images we upload using MediaManager, the same name Images are replaced every time when upload the image. To resolve that that issue I have modified the MediaManager.php file. Using that I have resolved my issue But the one other problem arise with this when composer runs file is reverted to original version. Above I have done a change to resolve that issue If it is right than I request you to please update your file to resolve it permanently.