### PR TITLE
Added support for `dependsOn` with relationships

### DIFF
--- a/modules/backend/behaviors/relationcontroller/assets/js/october.relation.js
+++ b/modules/backend/behaviors/relationcontroller/assets/js/october.relation.js
@@ -60,6 +60,15 @@
         }
 
         /*
+         * This function is called every time a record is created, added, removed
+         * or deleted using the relation widget. It triggers the change.oc.formwidget
+         * event to notify other elements on the page about the changed form state.
+         */
+        this.changed = function(relationId, event) {
+            $('[data-field-name="' + relationId + '"]').trigger('change.oc.formwidget', {event: event});
+        }
+
+        /*
          * This function transfers the supplied variables as hidden form inputs,
          * to any popup that is spawned within the supplied container. The spawned 
          * popup must contain a form element.

--- a/modules/backend/behaviors/relationcontroller/partials/_button_delete.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_delete.htm
@@ -3,6 +3,7 @@
         class="btn btn-sm btn-secondary oc-icon-trash-o"
         data-request="onRelationButtonDelete"
         data-request-confirm="<?= e(trans('backend::lang.relation.delete_confirm')) ?>"
+        data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'deleted')"
         data-stripe-load-indicator>
         <?= e(trans('backend::lang.relation.delete')) ?>
     </button>
@@ -15,6 +16,7 @@
         disabled="disabled"
         data-request="onRelationButtonDelete"
         data-request-confirm="<?= e(trans('backend::lang.relation.delete_confirm')) ?>"
+        data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'deleted')"
         data-trigger-action="enable"
         data-trigger="#<?= $this->relationGetId('view') ?> .control-list input[type=checkbox]"
         data-trigger-condition="checked"

--- a/modules/backend/behaviors/relationcontroller/partials/_button_remove.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_remove.htm
@@ -2,6 +2,7 @@
     <button
         class="btn btn-sm btn-secondary oc-icon-minus"
         data-request="onRelationButtonRemove"
+        data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'removed')"
         data-stripe-load-indicator>
         <?= e(trans('backend::lang.relation.remove')) ?>
     </button>
@@ -13,6 +14,7 @@
         })"
         disabled="disabled"
         data-request="onRelationButtonRemove"
+        data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'removed')"
         data-trigger-action="enable"
         data-trigger="#<?= $this->relationGetId('view') ?> .control-list input[type=checkbox]"
         data-trigger-condition="checked"

--- a/modules/backend/behaviors/relationcontroller/partials/_button_unlink.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_unlink.htm
@@ -2,6 +2,7 @@
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-unlink"
     data-request="onRelationButtonUnlink"
+    data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'removed')"
     data-request-confirm="<?= e(trans('backend::lang.relation.unlink_confirm')) ?>"
     data-stripe-load-indicator>
     <?= e(trans('backend::lang.relation.unlink')) ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_manage_form.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_form.htm
@@ -47,7 +47,13 @@
 
     <?php else: ?>
 
-        <?= Form::ajax('onRelationManageCreate', ['data-popup-load-indicator' => true, 'sessionKey' => $newSessionKey]) ?>
+        <?= Form::ajax('onRelationManageCreate', [
+            'data-popup-load-indicator' => true,
+            'data-request-success' => "
+                $.oc.relationBehavior.changed('" . e($this->vars['relationField']) . "', 'created')
+            ",
+            'sessionKey' => $newSessionKey
+        ]) ?>
 
             <!-- Passable fields -->
             <input type="hidden" name="_relation_field" value="<?= $relationField ?>" />

--- a/modules/backend/behaviors/relationcontroller/partials/_manage_form.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_form.htm
@@ -49,9 +49,7 @@
 
         <?= Form::ajax('onRelationManageCreate', [
             'data-popup-load-indicator' => true,
-            'data-request-success' => "
-                $.oc.relationBehavior.changed('" . e($this->vars['relationField']) . "', 'created')
-            ",
+            'data-request-success' => "$.oc.relationBehavior.changed('" . e($this->vars['relationField']) . "', 'created')",
             'sessionKey' => $newSessionKey
         ]) ?>
 

--- a/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
@@ -21,6 +21,9 @@
                     class="btn btn-primary"
                     data-request="onRelationManageAdd"
                     data-dismiss="popup"
+                    data-request-success="
+                        $.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'added')
+                    "
                     data-stripe-load-indicator>
                     <?= e(trans('backend::lang.relation.add_selected')) ?>
                 </button>

--- a/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
@@ -21,9 +21,7 @@
                     class="btn btn-primary"
                     data-request="onRelationManageAdd"
                     data-dismiss="popup"
-                    data-request-success="
-                        $.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'added')
-                    "
+                    data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'added')"
                     data-stripe-load-indicator>
                     <?= e(trans('backend::lang.relation.add_selected')) ?>
                 </button>


### PR DESCRIPTION
With this PR I propose to add a new `changed` function to the relation controller's JS. This new function is called everytime a new record is successfully added, created, removed or deleted.

The new `changed` function triggers the `change.oc.formwidget` event on the respective form field. This allows us to use a `dependsOn` option together with a relation controller as we would with any other form field.

The example below shows how to use this new feature to update the `credits` fields of a user everytime he is signed up for a course lesson.

![peek 2018-05-04 13-56](https://user-images.githubusercontent.com/8600029/39626731-8556227a-4fa3-11e8-975e-81655c3f6434.gif)

### Example usage

```yml
fields:
    credits:
        label: Credits
        span: auto
        type: number
        dependsOn: signups
    signups:
        span: full
        path: signups
        type: partial
```

```php
// ListController
public function __construct()
{
    // ...
    Event::listen('backend.form.beforeRefresh', function ($widget, $form) {
       $form->data['credits'] = $this->vars['formModel']->fresh()->credits;
    });
}
````