### PR TITLE
[Discussion] Left align number inputs in backend forms

### DIFF
--- a/modules/system/assets/ui/less/form.less
+++ b/modules/system/assets/ui/less/form.less
@@ -162,10 +162,6 @@
         padding-bottom: 5px;
     }
 
-    &.number-field {
-        > .form-control { text-align: right; }
-    }
-
     &.radio-align {
         padding-left: 28px;
         margin-top: -20px;

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -2504,7 +2504,6 @@ html.cssanimations .cursor-loading-indicator.hide{display:none}
 .form-group.span-right{float:right;width:48.5%;clear:right}
 .form-group.layout-relative{padding-bottom:0}
 .form-group.checkbox-field{padding-bottom:5px}
-.form-group.number-field > .form-control{text-align:right}
 .form-group.radio-align{padding-left:28px;margin-top:-20px}
 .form-group.checkbox-align{padding-left:28px;margin-top:-5px}
 .form-group.field-align-above{margin-top:-5px}


### PR DESCRIPTION
Currently `number` is the only backend form field type that is right aligned.

I see the reason why number inputs might be right aliged, but in my opinion this makes backend forms look inconsistent. It also makes it harder to see what fields contain data, especially on bigger screens where the form fields can become very wide.

![grafik](https://user-images.githubusercontent.com/8600029/39629086-48a5ab0e-4fab-11e8-9601-fc83e7c771f2.png)

I suggest to left align number inputs to get more consistency and better UX in backend forms.

![grafik](https://user-images.githubusercontent.com/8600029/39629154-820d31c8-4fab-11e8-9cf4-23105232be4f.png)
