### PR TITLE
Adds i18n support for the form field default property

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -911,7 +911,7 @@ class Form extends WidgetBase
         }
 
         $defaultValue = !$this->model->exists
-            ? $field->getDefaultFromData($this->data)
+            ? trans($field->getDefaultFromData($this->data))
             : null;
 
         return $field->getValueFromData($this->data, $defaultValue);


### PR DESCRIPTION
Previously when creating a backend form with RainLab.Builder if you filled in the "Default" property using the i18n + (to get, for example, acme.plugin::lang.field.default) then that string would be output exactly on the form (i.e. <input value="acme.plugin::lang.field.default"...>) instead of being replaced with the actual value of that key from the lang file