### PR TITLE
Add extensibility to auth restore view (like signin view)

### DIFF
--- a/modules/backend/controllers/auth/restore.htm
+++ b/modules/backend/controllers/auth/restore.htm
@@ -27,3 +27,5 @@
         </p>
     </div>
 <?= Form::close() ?>
+
+<?= $this->fireViewEvent('backend.auth.extendRestoreView') ?>


### PR DESCRIPTION
In the backend login view, a view event is fired which is useful for adding some content to this page, for example. This pull request adds the same event type to the password recovery view.