### PR TITLE
Singularize placeholders for automatically generated titles

### DIFF
--- a/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
@@ -2,9 +2,11 @@
     <?= Form::open() ?>
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
-            <h4 class="modal-title"><?= e(trans($relationManageTitle, [
-                'name' => trans($relationLabel)
-            ])) ?></h4>
+            <h4 class="modal-title">
+                <?= e(trans($relationManageTitle, [
+                    'name' => trans(str_singular($relationLabel))
+                ])) ?>
+            </h4>
         </div>
 
         <div class="list-flush">

--- a/modules/backend/behaviors/relationcontroller/partials/_manage_pivot.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_pivot.htm
@@ -2,7 +2,11 @@
     <?= Form::open() ?>
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
-            <h4 class="modal-title"><?= e(trans($relationManageTitle, ['name'=>trans($relationLabel)])) ?></h4>
+            <h4 class="modal-title">
+                <?= e(trans($relationManageTitle, [
+                    'name' => trans(str_singular($relationLabel))
+                ])) ?>
+            </h4>
         </div>
         <?php if (!$relationSearchWidget): ?>
             <div class="modal-body">


### PR DESCRIPTION
Titles for manage-list and manage-pivot modals are automatically generated. In most cases model names are plural whilst titles expect singular nouns. Currently we end up with such titles by default:

![october_add_a_new_posts](https://user-images.githubusercontent.com/3897579/40324479-46908ab6-5d41-11e8-9e14-266c5deb76e9.png)

This PR is to fix such titles.

It would be also nice to title-case all titles, but title_case function does not behave correctly (for example, it title-cased articles for me).  