### PR TITLE
German Translation for Row in import_export

### DIFF
--- a/modules/backend/lang/de/lang.php
+++ b/modules/backend/lang/de/lang.php
@@ -425,6 +425,7 @@ return [
     'import_export' => [
         'upload_csv_file' => '1. CSV-Datei hochladen',
         'import_file' => 'Datei importieren',
+        'row' => 'Zeile :row',
         'first_row_contains_titles' => 'Erste Zeile enthält Spaltentitel',
         'first_row_contains_titles_desc' => 'Aktiviert lassen, falls erste Zeile Spaltentitel enthält.',
         'match_columns' => '2. Spalten der Datei den Datenbankfeldern zuordnen',


### PR DESCRIPTION
The Translation for Row in the _import_result_form.htm was missing (Issue #3566).
Was fixed with the commit ce3c923c6fe039ed5929070a0be140c8366b105a.
This is the german translation for Row.