### PR TITLE
MediaLibrary test updates

### DIFF
--- a/tests/unit/system/classes/MediaLibraryTest.php
+++ b/tests/unit/system/classes/MediaLibraryTest.php
@@ -41,8 +41,9 @@ class MediaLibraryTest extends TestCase // @codingStandardsIgnoreLine
      */
     public function testInvalidPathsOnValidatePath($path)
     {
-        $this->setExpectedException('ApplicationException');
+        $this->expectException('ApplicationException');
         MediaLibrary::validatePath($path);
+
     }
 
     /**
@@ -50,6 +51,7 @@ class MediaLibraryTest extends TestCase // @codingStandardsIgnoreLine
      */
     public function testValidPathsOnValidatePath($path)
     {
-        MediaLibrary::validatePath($path);
+        $result = MediaLibrary::validatePath($path);
+        $this->assertInternalType('string', $result);
     }
 }


### PR DESCRIPTION
Updates for depreciated methods and empty tests. This is phpunit 7.0.1 runned on php7.2 before this patch:

https://gist.github.com/viamage/2ac3e80412bcbf15d0c2fdd2d2c41869

And this is after:

https://gist.github.com/viamage/3b27e4b31075f9969ff309ebbfaeaa6e

setExpectedException is depraciated since phpunit 5.x and can be safely replaced, the other is just additional assertion that removes the test from risky list and adds additional coverage for checking if result is indeed string (should be done with typehint, but if no typehint let there be test at least). 

Two remaining "risky" tests are from October/Rain library, not spammy so i'll leave them be for now. 