### PR TITLE
Fix content item

### DIFF
--- a/modules/cms/classes/Content.php
+++ b/modules/cms/classes/Content.php
@@ -9,7 +9,7 @@ use Markdown;
  * @package october\cms
  * @author Alexey Bobkov, Samuel Georges
  */
-class Content extends CmsCompoundObject
+class Content extends CmsObject
 {
     /**
      * @var string The container name associated with the model, eg: pages.
@@ -59,13 +59,13 @@ class Content extends CmsCompoundObject
 
         switch ($extension) {
             case 'txt':
-                $result = htmlspecialchars($this->markup);
+                $result = htmlspecialchars($this->content);
                 break;
             case 'md':
-                $result = Markdown::parse($this->markup);
+                $result = Markdown::parse($this->content);
                 break;
             default:
-                $result = $this->markup;
+                $result = $this->content;
         }
 
         return $result;

--- a/modules/cms/classes/content/fields.yaml
+++ b/modules/cms/classes/content/fields.yaml
@@ -21,7 +21,7 @@ tabs:
 secondaryTabs:
     stretch: true
     fields:
-        markup:
+        content:
             tab: cms::lang.editor.content
             stretch: true
             type: codeeditor

--- a/tests/unit/cms/classes/ContentTest.php
+++ b/tests/unit/cms/classes/ContentTest.php
@@ -11,7 +11,7 @@ class ContentTest extends TestCase
         $theme = Theme::load('test');
         $content = Content::load($theme, 'markdown-content.md');
 
-        $this->assertEquals('Be brave, be **bold**, live *italic*', $content->markup);
+        $this->assertEquals('Be brave, be **bold**, live *italic*', $content->content);
         $this->assertEquals('<p>Be brave, be <strong>bold</strong>, live <em>italic</em></p>', $content->parsedMarkup);
     }
 
@@ -20,7 +20,7 @@ class ContentTest extends TestCase
         $theme = Theme::load('test');
         $content = Content::load($theme, 'text-content.txt');
 
-        $this->assertEquals('Pen is <mightier> than the sword, HTML is <richer> than the text', $content->markup);
+        $this->assertEquals('Pen is <mightier> than the sword, HTML is <richer> than the text', $content->content);
         $this->assertEquals('Pen is &lt;mightier&gt; than the sword, HTML is &lt;richer&gt; than the text', $content->parsedMarkup);
     }
 
@@ -29,7 +29,7 @@ class ContentTest extends TestCase
         $theme = Theme::load('test');
         $content = Content::load($theme, 'html-content.htm');
 
-        $this->assertEquals('<a href="#">Stephen Saucier</a> changed his profile picture &mdash; <small>7 hrs ago</small></div>', $content->markup);
+        $this->assertEquals('<a href="#">Stephen Saucier</a> changed his profile picture &mdash; <small>7 hrs ago</small></div>', $content->content);
         $this->assertEquals('<a href="#">Stephen Saucier</a> changed his profile picture &mdash; <small>7 hrs ago</small></div>', $content->parsedMarkup);
     }
 


### PR DESCRIPTION
Suggested fix for #3581. Content items don't need to be compound objects as far as I can see, so changed the base type from `CmsCompoundObject` to `CmsObject` and made relevant adjustments.