### PR TITLE
Fix Security issue in media manager

### DIFF
--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -119,7 +119,7 @@ class MediaManager extends WidgetBase
     public function onGoToFolder()
     {
         $path = Input::get('path');
-
+        
         if (Input::get('clearCache')) {
             MediaLibrary::instance()->resetCache();
         }
@@ -335,6 +335,14 @@ class MediaManager extends WidgetBase
         }
 
         $originalPath = Input::get('originalPath');
+        
+        $check = explode('/', $originalPath);
+        $regexPath = $check[count($check)-1];
+
+        if($originalPath != '/' && !$this->validateFileName($regexPath)) {
+            throw new ApplicationException(Lang::get('system::lang.media.invalid_path', compact('originalPath')));
+        }
+        
         $originalPath = MediaLibrary::validatePath($originalPath);
         $newPath = dirname($originalPath).'/'.$newName;
         $type = Input::get('type');
@@ -386,6 +394,14 @@ class MediaManager extends WidgetBase
         }
 
         $path = Input::get('path');
+        
+        $check = explode('/', $path);
+        $regexPath = $check[count($check)-1];
+
+        if($path != '/' && !$this->validateFileName($regexPath)) {
+            throw new ApplicationException(Lang::get('system::lang.media.invalid_path', compact('path')));
+        }
+        
         $path = MediaLibrary::validatePath($path);
 
         $newFolderPath = $path.'/'.$name;

--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -119,7 +119,7 @@ class MediaManager extends WidgetBase
     public function onGoToFolder()
     {
         $path = Input::get('path');
-        
+
         if (Input::get('clearCache')) {
             MediaLibrary::instance()->resetCache();
         }

--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -336,8 +336,8 @@ class MediaManager extends WidgetBase
 
         $originalPath = Input::get('originalPath');
         
-        $check = explode('/', $originalPath);
-        $regexPath = $check[count($check)-1];
+        $segments = explode('/', $originalPath);
+        $regexPath = $segments[count($segments)-1];
 
         if($originalPath != '/' && !$this->validateFileName($regexPath)) {
             throw new ApplicationException(Lang::get('system::lang.media.invalid_path', compact('originalPath')));
@@ -395,8 +395,8 @@ class MediaManager extends WidgetBase
 
         $path = Input::get('path');
         
-        $check = explode('/', $path);
-        $regexPath = $check[count($check)-1];
+        $segments = explode('/', $path);
+        $regexPath = $segments[count($segments)-1];
 
         if($path != '/' && !$this->validateFileName($regexPath)) {
             throw new ApplicationException(Lang::get('system::lang.media.invalid_path', compact('path')));


### PR DESCRIPTION
Currently there is a way to manipulate folder names using the request headers for the medafinder folder path. Since `MediaLibrary::validatePath()` does not validate folder names but rather only validates the existence of a folder as a parent directory or subdirectory. Using that manipulation, if the folder does not exist as a parent directory or subdirectory, the folder will be created using the path query.

We can utilize `$this->validateFileName()` to verify if the name of the folder path name being used for the folder name is valid during the folder creation function and the name applying function for the path query.