### PR TITLE
Proof of concept: replace eval with JSON5.parse

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -209,6 +209,7 @@ class RelationController extends ControllerBehavior
     {
         parent::__construct($controller);
 
+        $this->addJs('//unpkg.com/json5@^1.0.0', 'core');
         $this->addJs('js/october.relation.js', 'core');
         $this->addCss('css/relation.css', 'core');
 

--- a/modules/backend/behaviors/relationcontroller/assets/js/october.relation.js
+++ b/modules/backend/behaviors/relationcontroller/assets/js/october.relation.js
@@ -78,7 +78,7 @@
             if (typeof value == 'object') return value
 
             try {
-                return JSON.parse(JSON.stringify(eval("({" + value + "})")))
+                return JSON5.parse("{" + value + "}");
             }
             catch (e) {
                 throw new Error('Error parsing the '+name+' attribute value. '+e)

--- a/modules/backend/layouts/_head.htm
+++ b/modules/backend/layouts/_head.htm
@@ -18,6 +18,7 @@
 <link href="<?= Url::asset('modules/system/assets/ui/storm.css') ?>?v<?= $coreBuild ?>" rel="stylesheet">
 <link href="<?= Backend::skinAsset('assets/css/october.css') ?>?v<?= $coreBuild ?>" rel="stylesheet">
 <script src="<?= Backend::skinAsset('assets/js/vendor/jquery.min.js') ?>?v<?= $coreBuild ?>"></script>
+<script src="https://unpkg.com/json5@^1.0.0"></script>
 <script src="<?= Url::asset('modules/system/assets/js/framework.js') ?>?v<?= $coreBuild ?>"></script>
 <script src="<?= Url::asset('modules/system/assets/ui/storm-min.js') ?>?v<?= $coreBuild ?>"></script>
 <script src="<?= Backend::skinAsset('assets/js/october-min.js') ?>?v<?= $coreBuild ?>"></script>

--- a/modules/backend/layouts/auth.htm
+++ b/modules/backend/layouts/auth.htm
@@ -12,6 +12,7 @@
         <link href="<?= Url::asset('modules/system/assets/ui/storm.css') ?>" rel="stylesheet">
         <link href="<?= Url::to('modules/backend/assets/css/october.css') ?>" rel="stylesheet">
         <script src="<?= Url::to('modules/backend/assets/js/vendor/jquery.min.js') ?>"></script>
+        <script src="https://unpkg.com/json5@^1.0.0"></script>
         <script src="<?= Url::to('modules/system/assets/js/framework.js') ?>"></script>
         <script src="<?= Url::asset('modules/system/assets/ui/storm-min.js') ?>"></script>
         <script src="<?= Url::to('modules/backend/assets/js/october-min.js') ?>"></script>

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -159,6 +159,7 @@ class Form extends WidgetBase
      */
     protected function loadAssets()
     {
+        $this->addJs('//unpkg.com/json5@^1.0.0', 'core');
         $this->addJs('js/october.form.js', 'core');
     }
 

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -264,7 +264,7 @@
         if (typeof value == 'object') return value
 
         try {
-            return JSON.parse(JSON.stringify(eval("({" + value + "})")))
+            return JSON5.parse("{" + value + "}");
         }
         catch (e) {
             throw new Error('Error parsing the '+name+' attribute value. '+e)

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -453,7 +453,7 @@ if (window.jQuery.request !== undefined) {
         if (typeof value == 'object') return value
 
         try {
-            return JSON.parse(JSON.stringify(eval("({" + value + "})")))
+            return JSON5.parse("{" + value + "}");
         }
         catch (e) {
             throw new Error('Error parsing the '+name+' attribute value. '+e)

--- a/modules/system/assets/ui/js/autocomplete.js
+++ b/modules/system/assets/ui/js/autocomplete.js
@@ -378,7 +378,7 @@
         if (typeof value == 'object') return value
 
         try {
-            return JSON.parse(JSON.stringify(eval("({" + value + "})")))
+            return JSON5.parse("{" + value + "}");
         }
         catch (e) {
             throw new Error('Error parsing the '+name+' attribute value. '+e)

--- a/modules/system/assets/ui/js/chart.line.js
+++ b/modules/system/assets/ui/js/chart.line.js
@@ -80,7 +80,7 @@
 
         var parsedOptions = {}
         try {
-            parsedOptions = JSON.parse(JSON.stringify(eval("({" + options.chartOptions + "})")));
+            parsedOptions = JSON5.parse("{" + options.chartOptions + "}");
         } catch (e) {
             throw new Error('Error parsing the data-chart-options attribute value. '+e);
         }

--- a/modules/system/assets/ui/js/popup.js
+++ b/modules/system/assets/ui/js/popup.js
@@ -386,7 +386,7 @@
         if (typeof value == 'object') return value
 
         try {
-            return JSON.parse(JSON.stringify(eval("({" + value + "})")))
+            return JSON5.parse("{" + value + "}");
         }
         catch (e) {
             throw new Error('Error parsing the '+name+' attribute value. '+e)


### PR DESCRIPTION
This PR replaces most usages of `eval` with `JSON5.parse`. This is only a proof of concept and shouldn't be merged. Ideally, the JSON5 library should be bundled with October and not pulled from `unpkg`.

I suggest we keep the discussion in #3608 for simplicity.