### PR TITLE
Add config flag for allowing insecure paths (#3619)

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -362,4 +362,23 @@ return [
     
     'enableTwigStrictVariables' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Base Directory Restriction
+    |--------------------------------------------------------------------------
+    |
+    | Restricts loading backend template and config files to within the base
+    | directory of the application.
+    |
+    | WARNING: This should always be enabled for security reasons. However, in
+    | some cases you may need to disable this; for instance when developing
+    | plugins that are stored elsewhere in the filesystem for organizational
+    | reasons and then symlinked into the application plugins/ directory.
+    |
+    | NEVER have this disabled in production.
+    |
+    */
+
+    'restrictBaseDir' => true,
+
 ];

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -7,6 +7,7 @@ use Event;
 use SystemException;
 use Backend\Classes\Controller;
 use stdClass;
+use Config;
 
 /**
  * Config Maker Trait
@@ -141,7 +142,9 @@ trait ConfigMaker
 
         $fileName = File::symbolizePath($fileName);
 
-        if (File::isLocalPath($fileName)) {
+        if (File::isLocalPath($fileName) ||
+            (!Config::get('cms.restrictBaseDir', true) && realpath($fileName) !== false)
+        ) {
             return $fileName;
         }
 

--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -8,6 +8,7 @@ use SystemException;
 use Exception;
 use Throwable;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Config;
 
 /**
  * View Maker Trait
@@ -194,7 +195,9 @@ trait ViewMaker
 
         $fileName = File::symbolizePath($fileName);
 
-        if (File::isLocalPath($fileName)) {
+        if (File::isLocalPath($fileName) ||
+            (!Config::get('cms.restrictBaseDir', true) && realpath($fileName) !== false)
+        ) {
             return $fileName;
         }
 
@@ -221,7 +224,10 @@ trait ViewMaker
      */
     public function makeFileContents($filePath, $extraParams = [])
     {
-        if (!strlen($filePath) || !File::isFile($filePath) || !File::isLocalPath($filePath)) {
+        if (!strlen($filePath) ||
+            !File::isFile($filePath) ||
+            (!File::isLocalPath($filePath) && Config::get('cms.restrictBaseDir', true))
+        ) {
             return '';
         }
 


### PR DESCRIPTION
In the testing that I was doing with a plugin that was symlinked, not all of these conditions needed to be modified in order for the plugin to "work" as it should. Which is another way of saying, I only verified the functionality of the one condition (the one in ViewMaker::makeFileContents()). Nevertheless, I assume there are situations similar to mine where these functions might receive paths that contain symlinks.