### PR TITLE
Add option for Richeditor to upload files as attachmany relation

### DIFF
--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -44,15 +44,14 @@ class RichEditor extends FormWidgetBase
 
     /**
      * @var array Contains the options used for file upload
-     *
      * Supported options:
-     * - mode: mediaManager, relationUpload
-     * - relationName: (name of model relation to use for upload, must be of type attachMany and
-     * the model must inherit from October\Rain\Database\Attach\File)
+     * - mode: [relation | medialibrary]
+     * - relation: Name of relation (relation also needs to be an attachmany relationship where the
+     * attached model inherits from October\Rain\Database\Attach\File)
      */
     public $uploadOptions = [
-        'mode' => 'mediaManager',
-        'relationName' => '',
+        'mode' => 'medialibrary',
+        'relation' => '',
     ];
 
     //
@@ -129,17 +128,17 @@ class RichEditor extends FormWidgetBase
     protected function evalUploadOptions()
     {
         if($this->uploadOptions['mode']
-           && $this->uploadOptions['mode'] == 'relationUpload'
-           && $this->uploadOptions['relationName']
-           && !empty(trim($this->uploadOptions['relationName']))) {
-            if($this->model->getRelationType($this->uploadOptions['relationName']) == 'attachMany'
-               &&  $this->model->{$this->uploadOptions['relationName']}()->getRelated()
+           && $this->uploadOptions['mode'] == 'relation'
+           && $this->uploadOptions['relation']
+           && !empty(trim($this->uploadOptions['relation']))) {
+            if($this->model->getRelationType($this->uploadOptions['relation']) == 'attachMany'
+               &&  $this->model->{$this->uploadOptions['relation']}()->getRelated()
                instanceof \October\Rain\Database\Attach\File) {
-                return 'relationUpload';
+                return 'relation';
             }
         }
 
-        return 'mediaManager';
+        return 'medialibrary';
     }
 
     protected function checkUploadPostback()

--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -45,7 +45,7 @@ class RichEditor extends FormWidgetBase
     /**
      * @var array Contains the options used for file upload
      * Supported options:
-     * - mode: [relation | medialibrary]
+     * - mode: [relation | medialibrary] (method of storing uploaded images)
      * - relation: Name of relation (relation also needs to be an attachmany relationship where the
      * attached model inherits from October\Rain\Database\Attach\File)
      */

--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -141,6 +141,23 @@ class RichEditor extends FormWidgetBase
         return 'medialibrary';
     }
 
+    public function onLoadRelationUploadBrowseForm()
+    {
+        $this->vars['relationUploads'] = $this->getRelationUploads();
+        return $this->makePartial('relation_upload_browse_form');
+    }
+
+    protected function getRelationUploads()
+    {
+        $relationUploads = $this->model->{$this->uploadOptions['relation']}()
+                            ->withDeferred($this->sessionKey)->lists('file_name', 'disk_name');
+        $result = [];
+        foreach($relationUploads as $diskName => $fileName) {
+            $result[] = ['file_name' => $fileName, 'disk_name' => $diskName];
+        }
+        return $result;
+    }
+
     protected function checkUploadPostback()
     {
         if (!post('X_OCTOBER_RICHEDITOR_RELATION_UPLOAD')) {
@@ -155,7 +172,7 @@ class RichEditor extends FormWidgetBase
             if ($uploadedFile)
                 $uploadedFileName = $uploadedFile->getClientOriginalName();
 
-            $relationName = $this->uploadOptions['relationName'];
+            $relationName = $this->uploadOptions['relation'];
             $relationClass = get_class($this->model->{$relationName}()->getRelated());
             $validationRules = ['max:'.$relationClass::getMaxFilesize()];
             $validationRules[] = 'mimes:jpg,jpeg,bmp,png,gif';

--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -46,8 +46,9 @@ class RichEditor extends FormWidgetBase
      * @var array Contains the options used for file upload
      *
      * Supported options:
-     * - mode: mediaManager, modelRelation
-     * - relationName: (name of model relation to use for upload)
+     * - mode: mediaManager, relationUpload
+     * - relationName: (name of model relation to use for upload, must be of type attachMany and
+     * the model must inherit from October\Rain\Database\Attach\File)
      */
     public $uploadOptions = [
         'mode' => 'mediaManager',
@@ -127,14 +128,14 @@ class RichEditor extends FormWidgetBase
     */
     protected function evalUploadOptions()
     {
-        $mode = $this->uploadOptions['mode'];
-        $relationName = $this->uploadOptions['relationName'];
-        if($mode == 'modelRelation' && !empty($relationName)) {
-
-            if($this->model->attachMany[$relationName]
-                &&  $this->model->{$relationName}()->getRelated() instanceof
-                    \October\Rain\Database\Attach\File) {
-                return 'modelRelation';
+        if($this->uploadOptions['mode']
+           && $this->uploadOptions['mode'] == 'relationUpload'
+           && $this->uploadOptions['relationName']
+           && !empty(trim($this->uploadOptions['relationName']))) {
+            if($this->model->getRelationType($this->uploadOptions['relationName']) == 'attachMany'
+               &&  $this->model->{$this->uploadOptions['relationName']}()->getRelated()
+               instanceof \October\Rain\Database\Attach\File) {
+                return 'relationUpload';
             }
         }
 

--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -11,6 +11,8 @@ use Input;
 use Validator;
 use Response;
 use Exception;
+use ValidationException;
+use SystemException;
 
 /**
  * Rich Editor
@@ -41,7 +43,7 @@ class RichEditor extends FormWidgetBase
     public $readOnly = false;
 
     /**
-     * @var class name Contains the class name used for file upload
+     * @var array Contains the options used for file upload
      *
      * Supported options:
      * - mode: mediaManager, modelRelation

--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -143,7 +143,9 @@ class RichEditor extends FormWidgetBase
 
     public function onLoadRelationUploadBrowseForm()
     {
-        $this->vars['relationUploads'] = $this->getRelationUploads();
+        $relationUploads = $this->getRelationUploads();
+        $this->vars['relationUploadsCount'] = count($relationUploads);
+        $this->vars['relationUploads'] = $relationUploads;
         return $this->makePartial('relation_upload_browse_form');
     }
 

--- a/modules/backend/formwidgets/richeditor/assets/js/build.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/build.js
@@ -41,6 +41,7 @@
 =require plugins/mediamanager.js
 =require plugins/pagelinks.js
 =require plugins/figures.js
+=require.plugins/relationupload.js
 =require richeditor.js
 
 */

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/mediamanager.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/mediamanager.js
@@ -162,10 +162,18 @@
             editor.popups.hide('audio.insert')
         }
 
+        function _setOptions() {
+            editor.opts.imageUploadParams = editor.opts.fileUploadParams = {
+                X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD:1
+            }
+        }
+
         /**
          * Init.
          */
         function _init () {
+            _setOptions();
+
             editor.events.on('destroy', _destroy, true)
 
             editor.events.on('video.linkError', _insertVideoFallback)

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
@@ -16,6 +16,23 @@
                 _session_key: $('input[name="_session_key"]').val(),
             }
         }
+
+        function onInsertImage() {
+            console.log('browse upload image');
+        }
+
+        function onInsertVideo() {
+            console.log('browse upload video');
+        }
+
+        function onInsertAudio() {
+            console.log('browse upload audio');
+        }
+
+        function onInsertFile() {
+            console.log('browse upload file');
+        }
+
         /**
          * Init.
          */
@@ -25,7 +42,79 @@
 
         return {
             _init: _init,
+            insertImage: onInsertImage,
+            insertVideo: onInsertVideo,
+            insertAudio: onInsertAudio,
+            insertFile: onInsertFile,
         }
     }
+
+    $.FE.DEFAULTS.imageInsertButtons.push('relationUploadImageManager');
+
+    $.FE.RegisterCommand('relationUploadImageManager', {
+        title: 'Browse',
+        undo: false,
+        focus: false,
+        callback: function () {
+            this.relationUpload.insertImage();
+        },
+        plugin: 'relationUpload'
+    })
+
+    // Add the font size icon.
+    $.FE.DefineIcon('relationUploadImageManager', {
+        NAME: 'folder'
+    });
+
+    $.FE.DEFAULTS.videoInsertButtons.push('relationUploadVideoManager');
+
+    $.FE.RegisterCommand('relationUploadVideoManager', {
+        title: 'Browse',
+        undo: false,
+        focus: false,
+        callback: function () {
+            this.relationUpload.insertVideo();
+        },
+        plugin: 'relationUpload'
+    })
+
+    // Add the font size icon.
+    $.FE.DefineIcon('relationUploadVideoManager', {
+        NAME: 'folder'
+    });
+
+    $.FE.DEFAULTS.audioInsertButtons.push('relationUploadAudioManager');
+
+    $.FE.RegisterCommand('relationUploadAudioManager', {
+        title: 'Browse',
+        undo: false,
+        focus: false,
+        callback: function () {
+            this.relationUpload.insertAudio();
+        },
+        plugin: 'relationUpload'
+    })
+
+    // Add the font size icon.
+    $.FE.DefineIcon('relationUploadAudioManager', {
+        NAME: 'folder'
+    });
+
+    $.FE.DEFAULTS.fileInsertButtons.push('relationUploadFileManager');
+
+    $.FE.RegisterCommand('relationUploadFileManager', {
+        title: 'Browse',
+        undo: false,
+        focus: false,
+        callback: function () {
+            this.relationUpload.insertFile();
+        },
+        plugin: 'relationUpload'
+    })
+
+    // Add the font size icon.
+    $.FE.DefineIcon('relationUploadFileManager', {
+        NAME: 'folder'
+    });
 
 })(jQuery);

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
@@ -87,28 +87,32 @@ function richeditorRelationUploadSelect($form) {
         function onInsertImage() {
             richeditorRelationUploadPlugin = this;
             editor.$el.popup({
-                handler: editor.opts.relationUploadBrowseHandler
+                handler: editor.opts.relationUploadBrowseHandler,
+                size: 'adaptive'
             })
         }
 
         function onInsertVideo() {
             richeditorRelationUploadPlugin = this;
             editor.$el.popup({
-                handler: editor.opts.relationUploadBrowseHandler
+                handler: editor.opts.relationUploadBrowseHandler,
+                size: 'adaptive'
             })
         }
 
         function onInsertAudio() {
             richeditorRelationUploadPlugin = this;
             editor.$el.popup({
-                handler: editor.opts.relationUploadBrowseHandler
+                handler: editor.opts.relationUploadBrowseHandler,
+                size: 'adaptive'
             })
         }
 
         function onInsertFile() {
             richeditorRelationUploadPlugin = this;
             editor.$el.popup({
-                handler: editor.opts.relationUploadBrowseHandler
+                handler: editor.opts.relationUploadBrowseHandler,
+                size: 'adaptive'
             })
         }
 

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
@@ -1,3 +1,8 @@
+var richeditorRelationUploadPlugin;
+
+function richeditorRelationUploadSelect($form) {
+    richeditorRelationUploadPlugin.insertFromBrowse($form);
+}
 (function ($) {
     // Add an option for your plugin.
     // $.FroalaEditor.DEFAULTS = $.extend($.FroalaEditor.DEFAULTS, {
@@ -5,6 +10,68 @@
     // });
 
     $.FroalaEditor.PLUGINS.relationUpload = function (editor) {
+
+        function insertFromBrowse($form) {
+            var $selected = $("input[name^='relations'][type='checkbox']:checked, input[name^='relations'][type='hidden']:enabled", $form);
+
+            if(!$selected.length) {
+                return;
+            }
+
+            var selectedArray = [];
+            $($selected).each(function(index) {
+                var name = ($(this).attr('name'));
+                console.log(name);
+                name = name.replace(/]/g, "");
+                var nameArr = name.split("[");
+                var inputIndex = nameArr[1];
+                var inputType = nameArr[2];
+                if(inputType == "id") {
+                    selectedArray.splice(inputIndex, 0, {})
+                    selectedArray[inputIndex].id = $(this).val();
+                }
+                else if(inputType == "file_name") {
+                    selectedArray[inputIndex].file_name = $(this).val();
+                }
+                else if(inputType == "disk_name") {
+                    selectedArray[inputIndex].disk_name = $(this).val();
+                }
+                else if(inputType == "path") {
+                    selectedArray[inputIndex].path = $(this).val();
+                }
+                else if(inputType == "file_type") {
+                    selectedArray[inputIndex].file_type = $(this).val();
+                }
+            });
+
+            var i = 0;
+            for(i = 0; i < selectedArray.length; i++){
+                if(selectedArray[i].file_type == "image") {
+                    var $currentImage = editor.image.get();
+                    editor.image.insert(selectedArray[i]['path'], false, {}, $currentImage)
+                }
+                else if(selectedArray[i].file_type == "video") {
+                    var $richEditorNode = editor.$el.closest('[data-control="richeditor"]');
+                    $richEditorNode.richEditor('insertVideo', selectedArray[i].path, selectedArray[i].file_name);
+                }
+                else if(selectedArray[i].file_type == "audio") {
+                    var $richEditorNode = editor.$el.closest('[data-control="richeditor"]');
+                    $richEditorNode.richEditor('insertAudio', selectedArray[i].path, selectedArray[i].file_name);
+                }
+                else {
+                    // Focus in the editor.
+                    editor.events.focus(true);
+                    editor.selection.restore();
+
+                    // Insert the link.
+                    editor.html.insert('<a href="' + selectedArray[i].path + '" id="fr-inserted-file" class="fr-file">' + selectedArray[i].file_name + '</a>');
+
+                    // Get the file.
+                    var $file = editor.$el.find('#fr-inserted-file');
+                    $file.removeAttr('id');
+                }
+            }
+        }
 
         function _setOptions() {
             editor.opts.requestHeaders = {
@@ -18,24 +85,28 @@
         }
 
         function onInsertImage() {
+            richeditorRelationUploadPlugin = this;
             editor.$el.popup({
                 handler: editor.opts.relationUploadBrowseHandler
             })
         }
 
         function onInsertVideo() {
+            richeditorRelationUploadPlugin = this;
             editor.$el.popup({
                 handler: editor.opts.relationUploadBrowseHandler
             })
         }
 
         function onInsertAudio() {
+            richeditorRelationUploadPlugin = this;
             editor.$el.popup({
                 handler: editor.opts.relationUploadBrowseHandler
             })
         }
 
         function onInsertFile() {
+            richeditorRelationUploadPlugin = this;
             editor.$el.popup({
                 handler: editor.opts.relationUploadBrowseHandler
             })
@@ -50,6 +121,7 @@
 
         return {
             _init: _init,
+            insertFromBrowse: insertFromBrowse,
             insertImage: onInsertImage,
             insertVideo: onInsertVideo,
             insertAudio: onInsertAudio,

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
@@ -18,19 +18,27 @@
         }
 
         function onInsertImage() {
-            console.log('browse upload image');
+            editor.$el.popup({
+                handler: editor.opts.relationUploadBrowseHandler
+            })
         }
 
         function onInsertVideo() {
-            console.log('browse upload video');
+            editor.$el.popup({
+                handler: editor.opts.relationUploadBrowseHandler
+            })
         }
 
         function onInsertAudio() {
-            console.log('browse upload audio');
+            editor.$el.popup({
+                handler: editor.opts.relationUploadBrowseHandler
+            })
         }
 
         function onInsertFile() {
-            console.log('browse upload file');
+            editor.$el.popup({
+                handler: editor.opts.relationUploadBrowseHandler
+            })
         }
 
         /**

--- a/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/plugins/relationupload.js
@@ -1,0 +1,31 @@
+(function ($) {
+    // Add an option for your plugin.
+    // $.FroalaEditor.DEFAULTS = $.extend($.FroalaEditor.DEFAULTS, {
+    //
+    // });
+
+    $.FroalaEditor.PLUGINS.relationUpload = function (editor) {
+
+        function _setOptions() {
+            editor.opts.requestHeaders = {
+                'X-CSRF-TOKEN': $('input[name="_token"]').val(),
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+            editor.opts.imageUploadParams = editor.opts.fileUploadParams = {
+                X_OCTOBER_RICHEDITOR_RELATION_UPLOAD: 1,
+                _session_key: $('input[name="_session_key"]').val(),
+            }
+        }
+        /**
+         * Init.
+         */
+        function _init () {
+            _setOptions();
+        }
+
+        return {
+            _init: _init,
+        }
+    }
+
+})(jQuery);

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -157,13 +157,13 @@
         // File upload
         froalaOptions.imageUploadURL = froalaOptions.fileUploadURL = window.location
         froalaOptions.imageUploadParam = froalaOptions.fileUploadParam = 'file_data'
-        if(this.options.uploadMode == 'mediaManager') {
+        if(this.options.uploadMode == 'medialibrary') {
             var relationUploadIndex = froalaOptions.pluginsEnabled.indexOf("relationUpload");
             if (relationUploadIndex > -1) {
                 froalaOptions.pluginsEnabled.splice(relationUploadIndex, 1);
             }
         }
-        else if(this.options.uploadMode == 'relationUpload') {
+        else if(this.options.uploadMode == 'relation') {
             var mediaManagerIndex = froalaOptions.pluginsEnabled.indexOf("mediaManager");
             if (mediaManagerIndex > -1) {
                 froalaOptions.pluginsEnabled.splice(mediaManagerIndex, 1);

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -83,7 +83,7 @@
                 'paragraphStyle', 'fullscreen', 'codeView', 'paragraphFormat', 'align', 'lists',
                 'file', 'image', 'link', 'table','video', 'audio', 'quote', 'fontSize', 'fontFamily',
                 'emoticons', 'colors', 'url', 'lineBreaker', 'entities', 'draggable', 'codeBeautifier',
-                'mediaManager', 'pageLinks', 'figures',
+                'mediaManager', 'pageLinks', 'figures', 'relationUpload',
             ],
         }
 
@@ -158,22 +158,15 @@
         froalaOptions.imageUploadURL = froalaOptions.fileUploadURL = window.location
         froalaOptions.imageUploadParam = froalaOptions.fileUploadParam = 'file_data'
         if(this.options.uploadMode == 'mediaManager') {
-            froalaOptions.imageUploadParams = froalaOptions.fileUploadParams = {
-                X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD:1
+            var relationUploadIndex = froalaOptions.pluginsEnabled.indexOf("relationUpload");
+            if (relationUploadIndex > -1) {
+                froalaOptions.pluginsEnabled.splice(relationUploadIndex, 1);
             }
         }
-        else if(this.options.uploadMode == 'modelRelation') {
+        else if(this.options.uploadMode == 'relationUpload') {
             var mediaManagerIndex = froalaOptions.pluginsEnabled.indexOf("mediaManager");
             if (mediaManagerIndex > -1) {
                 froalaOptions.pluginsEnabled.splice(mediaManagerIndex, 1);
-            }
-            froalaOptions.requestHeaders = {
-                'X-CSRF-TOKEN': $('input[name="_token"]').val(),
-                'X-Requested-With': 'XMLHttpRequest'
-            }
-            froalaOptions.imageUploadParams = froalaOptions.fileUploadParams = {
-                X_OCTOBER_RICHEDITOR_RELATION_UPLOAD: 1,
-                _session_key: $('input[name="_session_key"]').val(),
             }
         }
 

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -85,6 +85,7 @@
                 'emoticons', 'colors', 'url', 'lineBreaker', 'entities', 'draggable', 'codeBeautifier',
                 'mediaManager', 'pageLinks', 'figures', 'relationUpload',
             ],
+            relationUploadBrowseHandler: this.options.relationUploadHandler
         }
 
         if (this.options.toolbarButtons) {

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -78,7 +78,13 @@
             fullPage: this.options.fullpage,
             pageLinksHandler: this.options.linksHandler,
             aceEditorVendorPath: this.options.aceVendorPath,
-            toolbarSticky: false
+            toolbarSticky: false,
+            pluginsEnabled: [
+                'paragraphStyle', 'fullscreen', 'codeView', 'paragraphFormat', 'align', 'lists',
+                'file', 'image', 'link', 'table','video', 'audio', 'quote', 'fontSize', 'fontFamily',
+                'emoticons', 'colors', 'url', 'lineBreaker', 'entities', 'draggable', 'codeBeautifier',
+                'mediaManager', 'pageLinks', 'figures',
+            ],
         }
 
         if (this.options.toolbarButtons) {
@@ -157,6 +163,10 @@
             }
         }
         else if(this.options.uploadMode == 'modelRelation') {
+            var mediaManagerIndex = froalaOptions.pluginsEnabled.indexOf("mediaManager");
+            if (mediaManagerIndex > -1) {
+                froalaOptions.pluginsEnabled.splice(mediaManagerIndex, 1);
+            }
             froalaOptions.requestHeaders = {
                 'X-CSRF-TOKEN': $('input[name="_token"]').val(),
                 'X-Requested-With': 'XMLHttpRequest'

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -151,7 +151,21 @@
         // File upload
         froalaOptions.imageUploadURL = froalaOptions.fileUploadURL = window.location
         froalaOptions.imageUploadParam = froalaOptions.fileUploadParam = 'file_data'
-        froalaOptions.imageUploadParams = froalaOptions.fileUploadParams = { X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD: 1 }
+        if(this.options.uploadMode == 'mediaManager') {
+            froalaOptions.imageUploadParams = froalaOptions.fileUploadParams = {
+                X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD:1
+            }
+        }
+        else if(this.options.uploadMode == 'modelRelation') {
+            froalaOptions.requestHeaders = {
+                'X-CSRF-TOKEN': $('input[name="_token"]').val(),
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+            froalaOptions.imageUploadParams = froalaOptions.fileUploadParams = {
+                X_OCTOBER_RICHEDITOR_RELATION_UPLOAD: 1,
+                _session_key: $('input[name="_session_key"]').val(),
+            }
+        }
 
         var placeholder = this.$textarea.attr('placeholder')
         froalaOptions.placeholderText = placeholder ? placeholder : ''

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -85,7 +85,7 @@
                 'emoticons', 'colors', 'url', 'lineBreaker', 'entities', 'draggable', 'codeBeautifier',
                 'mediaManager', 'pageLinks', 'figures', 'relationUpload',
             ],
-            relationUploadBrowseHandler: this.options.relationUploadHandler
+            relationRecordsHandler: this.options.relationRecordsHandler
         }
 
         if (this.options.toolbarButtons) {

--- a/modules/backend/formwidgets/richeditor/partials/_relation_list.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_list.htm
@@ -1,0 +1,34 @@
+<div class="control-list">
+    <table class="table data">
+        <thead>
+            <tr>
+                <th class=""><a href="#"></a></th>
+                <th class=""><a href="#">File name</a></th>
+                <th class=""><a href="#">Disk name</a></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if(!$relationUploads || count($relationUploads) < 1): ?>
+                <tr class="no-data">
+                    <td colspan="100" class="nolink">
+                        <p class="no-data">
+                            There are no records in this view.
+                        </p>
+                    </td>
+                </tr>
+            <?php endif ?>
+            <?php for($i = 0; $i < $relationUploadsCount; $i++): ?>
+                <tr>
+                    <td class="list-checkbox nolink">
+                        <div class="checkbox custom-checkbox nolabel">
+                            <input id="relation_<?=$i?>" type="checkbox" name="relations[]" value="<?= array_get($relationUploads[$i], 'disk_name') ?>"/>
+                            <label for="relation_<?=$i?>">Check</label>
+                        </div>
+                    </td>
+                    <td><?= array_get($relationUploads[$i], 'file_name') ?></td>
+                    <td><?= array_get($relationUploads[$i], 'disk_name') ?></td>
+                </tr>
+            <?php endfor ?>
+        </tbody>
+    </table>
+</div>

--- a/modules/backend/formwidgets/richeditor/partials/_relation_list.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_list.htm
@@ -4,7 +4,7 @@
             <tr>
                 <th class=""><a href="#"></a></th>
                 <th class=""><a href="#">File name</a></th>
-                <th class=""><a href="#">Disk name</a></th>
+                <th class=""><a href="#">Path</a></th>
             </tr>
         </thead>
         <tbody>
@@ -21,12 +21,21 @@
                 <tr>
                     <td class="list-checkbox nolink">
                         <div class="checkbox custom-checkbox nolabel">
-                            <input id="relation_<?=$i?>" type="checkbox" name="relations[]" value="<?= array_get($relationUploads[$i], 'disk_name') ?>"/>
+                            <input id="relation_<?=$i?>" type="checkbox" name="relations[<?=$i?>][id]" value="<?= array_get($relationUploads[$i], 'id') ?>"/>
                             <label for="relation_<?=$i?>">Check</label>
+
+                            <input type="hidden" name="relations[<?=$i?>][file_name]" value="<?= array_get($relationUploads[$i], 'file_name') ?>"
+                            data-trigger-action="enable" data-trigger="#relation_<?=$i?>" data-trigger-condition="checked"/>
+                            <input type="hidden" name="relations[<?=$i?>][disk_name]" value="<?= array_get($relationUploads[$i], 'disk_name') ?>"
+                            data-trigger-action="enable" data-trigger="#relation_<?=$i?>" data-trigger-condition="checked"/>
+                            <input type="hidden" name="relations[<?=$i?>][path]" value="<?= array_get($relationUploads[$i], 'path') ?>"
+                            data-trigger-action="enable" data-trigger="#relation_<?=$i?>" data-trigger-condition="checked"/>
+                            <input type="hidden" name="relations[<?=$i?>][file_type]" value="<?= array_get($relationUploads[$i], 'file_type') ?>"
+                            data-trigger-action="enable" data-trigger="#relation_<?=$i?>" data-trigger-condition="checked"/>
                         </div>
                     </td>
                     <td><?= array_get($relationUploads[$i], 'file_name') ?></td>
-                    <td><?= array_get($relationUploads[$i], 'disk_name') ?></td>
+                    <td><?= array_get($relationUploads[$i], 'path') ?></td>
                 </tr>
             <?php endfor ?>
         </tbody>

--- a/modules/backend/formwidgets/richeditor/partials/_relation_list.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_list.htm
@@ -35,7 +35,7 @@
                         </div>
                     </td>
                     <td><?= array_get($relationUploads[$i], 'file_name') ?></td>
-                    <td><?= array_get($relationUploads[$i], 'path') ?></td>
+                    <td class="column-break-word"><?= array_get($relationUploads[$i], 'path') ?></td>
                 </tr>
             <?php endfor ?>
         </tbody>

--- a/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
@@ -1,0 +1,33 @@
+<?= Form::open(['id' => 'relationUploadBrowseForm']) ?>
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="popup">&times;</button>
+        <h4 class="modal-title"><?= e(trans('Relation browse')) ?></h4>
+    </div>
+    <div class="modal-body">
+
+        <div class="form-group">
+            <select name="pagelink" class="form-control custom-select" id="pageLink">
+                <?php foreach ($relationUploads as $relationUpload): ?>
+                    <option value="<?= array_get($link, 'url') ?>"><?= array_get($relationUpload, 'file_name') ?></option>
+                <?php endforeach ?>
+            </select>
+        </div>
+
+    </div>
+
+    <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-primary"
+            data-dismiss="popup"
+            onclick="relationUploadBrowseSelectItem($('#relationUploadBrowseForm'))">
+            <?= e(trans('backend::lang.form.select')) ?>
+        </button>
+        <button
+            type="button"
+            class="btn btn-default"
+            data-dismiss="popup">
+            <?= e(trans('backend::lang.form.cancel')) ?>
+        </button>
+    </div>
+<?= Form::close() ?>

--- a/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
@@ -1,18 +1,46 @@
 <?= Form::open(['id' => 'relationUploadBrowseForm']) ?>
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="popup">&times;</button>
-        <h4 class="modal-title"><?= e(trans('Relation browse')) ?></h4>
+        <h4 class="modal-title"><?= e(trans('Uploaded relational files')) ?></h4>
     </div>
+
     <div class="modal-body">
-
         <div class="form-group">
-            <select name="relationupload" class="form-control custom-select" id="relationUpload">
-                <?php foreach ($relationUploads as $relationUpload): ?>
-                    <option value="<?= array_get($relationUpload, 'disk_name') ?>"><?= array_get($relationUpload, 'file_name') ?></option>
-                <?php endforeach ?>
-            </select>
+            <div class="control-list">
+                <table class="table data">
+                    <thead>
+                        <tr>
+                            <th class=""><a href="#"></a></th>
+                            <th class=""><a href="#">File name</a></th>
+                            <th class=""><a href="#">Disk name</a></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if(!$relationUploads || count($relationUploads) < 1): ?>
+                            <tr class="no-data">
+                                <td colspan="100" class="nolink">
+                                    <p class="no-data">
+                                        There are no records in this view.
+                                    </p>
+                                </td>
+                            </tr>
+                        <?php endif ?>
+                        <?php for($i = 0; $i < $relationUploadsCount; $i++): ?>
+                            <tr>
+                                <td class="list-checkbox nolink">
+                                    <div class="checkbox custom-checkbox nolabel">
+                                        <input id="relation_<?=$i?>" type="checkbox" name="relation[]"/>
+                                        <label for="relation_<?=$i?>">Check</label>
+                                    </div>
+                                </td>
+                                <td><?= array_get($relationUploads[$i], 'file_name') ?></td>
+                                <td><?= array_get($relationUploads[$i], 'disk_name') ?></td>
+                            </tr>
+                        <?php endfor ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
-
     </div>
 
     <div class="modal-footer">

--- a/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
@@ -5,50 +5,23 @@
     </div>
 
     <div class="modal-body">
-        <div class="form-group">
-            <div class="control-list">
-                <table class="table data">
-                    <thead>
-                        <tr>
-                            <th class=""><a href="#"></a></th>
-                            <th class=""><a href="#">File name</a></th>
-                            <th class=""><a href="#">Disk name</a></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if(!$relationUploads || count($relationUploads) < 1): ?>
-                            <tr class="no-data">
-                                <td colspan="100" class="nolink">
-                                    <p class="no-data">
-                                        There are no records in this view.
-                                    </p>
-                                </td>
-                            </tr>
-                        <?php endif ?>
-                        <?php for($i = 0; $i < $relationUploadsCount; $i++): ?>
-                            <tr>
-                                <td class="list-checkbox nolink">
-                                    <div class="checkbox custom-checkbox nolabel">
-                                        <input id="relation_<?=$i?>" type="checkbox" name="relation[]"/>
-                                        <label for="relation_<?=$i?>">Check</label>
-                                    </div>
-                                </td>
-                                <td><?= array_get($relationUploads[$i], 'file_name') ?></td>
-                                <td><?= array_get($relationUploads[$i], 'disk_name') ?></td>
-                            </tr>
-                        <?php endfor ?>
-                    </tbody>
-                </table>
-            </div>
+        <div class="form-group" id="relation-list">
+            <?= $this->makePartial('relation_list') ?>
         </div>
     </div>
 
     <div class="modal-footer">
         <button
             type="button"
+            class="btn btn-danger"
+            data-request="<?= $this->getEventHandler('onDeleteRelationUpload') ?>">
+            <?= e(trans('backend::lang.form.delete')) ?>
+        </button>
+        <button
+            type="button"
             class="btn btn-primary"
             data-dismiss="popup"
-            onclick="relationUploadBrowseSelectItem($('#relationUploadBrowseForm'))">
+            onclick="relationUploadBrowseSelect($('#relationUploadBrowseForm'))">
             <?= e(trans('backend::lang.form.select')) ?>
         </button>
         <button

--- a/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
@@ -1,4 +1,4 @@
-<?= Form::open(['id' => 'relationUploadBrowseForm']) ?>
+<?= Form::open(['id' => 'relationRecordsForm']) ?>
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="popup">&times;</button>
         <h4 class="modal-title"><?= e(trans('Uploaded relational files')) ?></h4>
@@ -14,14 +14,17 @@
         <button
             type="button"
             class="btn btn-danger"
-            data-request="<?= $this->getEventHandler('onDeleteRelationUpload') ?>">
+            data-request="<?= $this->getEventHandler('onDeleteRelationRecord') ?>"
+            data-request-confirm="<?= e(trans('backend::lang.relation.delete_confirm')) ?>"
+            onclick="richeditorRelationUploadSetSelectedRecords($('#relationRecordsForm'))"
+            data-request-success="richeditorRelationUploadRemove()">
             <?= e(trans('backend::lang.form.delete')) ?>
         </button>
         <button
             type="button"
             class="btn btn-primary"
             data-dismiss="popup"
-            onclick="richeditorRelationUploadSelect($('#relationUploadBrowseForm'))">
+            onclick="richeditorRelationUploadSetSelectedRecords($('#relationRecordsForm'));richeditorRelationUploadInsert();">
             <?= e(trans('backend::lang.form.select')) ?>
         </button>
         <button

--- a/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
@@ -21,7 +21,7 @@
             type="button"
             class="btn btn-primary"
             data-dismiss="popup"
-            onclick="relationUploadBrowseSelect($('#relationUploadBrowseForm'))">
+            onclick="richeditorRelationUploadSelect($('#relationUploadBrowseForm'))">
             <?= e(trans('backend::lang.form.select')) ?>
         </button>
         <button

--- a/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_relation_upload_browse_form.htm
@@ -6,9 +6,9 @@
     <div class="modal-body">
 
         <div class="form-group">
-            <select name="pagelink" class="form-control custom-select" id="pageLink">
+            <select name="relationupload" class="form-control custom-select" id="relationUpload">
                 <?php foreach ($relationUploads as $relationUpload): ?>
-                    <option value="<?= array_get($link, 'url') ?>"><?= array_get($relationUpload, 'file_name') ?></option>
+                    <option value="<?= array_get($relationUpload, 'disk_name') ?>"><?= array_get($relationUpload, 'file_name') ?></option>
                 <?php endforeach ?>
             </select>
         </div>

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -22,7 +22,8 @@
         data-links-handler="<?= $this->getEventHandler('onLoadPageLinksForm') ?>"
         data-ace-vendor-path="<?= Url::asset('/modules/backend/formwidgets/codeeditor/assets/vendor/ace') ?>"
         placeholder="<?= e(trans($field->placeholder)) ?>"
-        data-control="richeditor">
+        data-control="richeditor"
+        data-upload-mode="<?= $uploadMode ?>">
         <textarea name="<?= $name ?>" id="<?= $this->getId('textarea') ?>"><?= e($value) ?></textarea>
         <div class="height-indicator"></div>
     </div>

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -24,7 +24,7 @@
         placeholder="<?= e(trans($field->placeholder)) ?>"
         data-control="richeditor"
         data-upload-mode="<?= $uploadMode ?>"
-        data-relation-upload-handler="<?= $this->getEventHandler('onLoadRelationUploadBrowseForm') ?>">
+        data-relation-records-handler="<?= $this->getEventHandler('onLoadRelationRecords') ?>">
         <textarea name="<?= $name ?>" id="<?= $this->getId('textarea') ?>"><?= e($value) ?></textarea>
         <div class="height-indicator"></div>
     </div>

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -24,6 +24,7 @@
         placeholder="<?= e(trans($field->placeholder)) ?>"
         data-control="richeditor"
         data-upload-mode="<?= $uploadMode ?>">
+        data-relation-upload-handler="<?= $this->getEventHandler('onLoadPageLinksForm') ?>"
         <textarea name="<?= $name ?>" id="<?= $this->getId('textarea') ?>"><?= e($value) ?></textarea>
         <div class="height-indicator"></div>
     </div>

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -23,8 +23,8 @@
         data-ace-vendor-path="<?= Url::asset('/modules/backend/formwidgets/codeeditor/assets/vendor/ace') ?>"
         placeholder="<?= e(trans($field->placeholder)) ?>"
         data-control="richeditor"
-        data-upload-mode="<?= $uploadMode ?>">
-        data-relation-upload-handler="<?= $this->getEventHandler('onLoadPageLinksForm') ?>"
+        data-upload-mode="<?= $uploadMode ?>"
+        data-relation-upload-handler="<?= $this->getEventHandler('onLoadRelationUploadBrowseForm') ?>">
         <textarea name="<?= $name ?>" id="<?= $this->getId('textarea') ?>"><?= e($value) ?></textarea>
         <div class="height-indicator"></div>
     </div>


### PR DESCRIPTION
This will add the option for users to define a relation for files uploaded through the richeditor.

Implemented:
- Users can upload files as relation through the richeditor
- Users can delete uploaded relational files through the browse popup
- Users can select(insert) attached files through the browse popup

Known issues:
- Width of row in popup makes table too wide