### PR TITLE
Resetting pagination on filter scope change

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -239,7 +239,7 @@ class ListController extends ControllerBehavior
              * Filter the list when the scopes are changed
              */
             $filterWidget->bindEvent('filter.update', function () use ($widget, $filterWidget) {
-                return $widget->onRefresh();
+                return $widget->onFilter();
             });
 
             /*

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -301,6 +301,15 @@ class Lists extends WidgetBase
     }
 
     /**
+     * Event handler for changing the filter
+     */
+    public function onFilter()
+    {
+        $this->currentPageNumber = 1;
+        return $this->onRefresh();
+    }
+
+    /**
      * Validate the supplied form model.
      * @return void
      */


### PR DESCRIPTION
See #3610 

Adjusting the pagination back to 1 when the filter scope updates. Previously a list controller could get stuck if the current page was greater than the total number of records returned after the filter.