### PR TITLE
adding align support to non sortable list columns

### DIFF
--- a/modules/backend/widgets/lists/partials/_list_head_row.htm
+++ b/modules/backend/widgets/lists/partials/_list_head_row.htm
@@ -31,7 +31,7 @@
         <?php else: ?>
             <th
                 <?php if ($column->width): ?>style="width: <?= $column->width ?>"<?php endif ?>
-                class="list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?>"
+                class="list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->getAlignClass() ?>"
                 >
                 <span><?= $this->getHeaderValue($column) ?></span>
             </th>


### PR DESCRIPTION
Problem: the `align` column definition attribute has no effect on list column headers where the column is not sortable.

Solution: add the missing `$column->getAlignClass()` call to the list header partial.