### PR TITLE
Added MJS and Atom to Assets

### DIFF
--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -120,7 +120,7 @@ trait AssetMaker
                 $attributes = Html::attributes(array_merge(
                     [
                         'src'   => $this->getAssetEntryBuildPath($asset),
-                        'type'  => 'module',
+                        'type'  => 'module'
 
                     ],
                     array_except($asset['attributes'], $reserved)


### PR DESCRIPTION
Luke you did say create a Pull Request, this is totally up to the October Team if they want to add this PR. It adds Atom and Javascript Modules as Assets that can be inported into October's backend. I didn't add JSON as it seems quite hard and would need to be Parsed.

JS Modules Support is as follows:

Chrome: Shipped
Firefox: In development
Edge: In development
Safari: Shipped
Web Developers: Strongly positive

CanIuse says 74.65% and can be found here: https://caniuse.com/#feat=es6-module

Lastly relates to the issue found here: https://github.com/octobercms/october/issues/3646