### PR TITLE
Override the Paginators defaultSimpleView

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -27,6 +27,7 @@ use System\Classes\CombineAssets;
 use Backend\Classes\WidgetManager;
 use October\Rain\Support\ModuleServiceProvider;
 use October\Rain\Router\Helper as RouterHelper;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Schema;
 
 class ServiceProvider extends ModuleServiceProvider
@@ -89,6 +90,8 @@ class ServiceProvider extends ModuleServiceProvider
         if (Config::get('database.connections.mysql.charset') === 'utf8mb4') {
             Schema::defaultStringLength(191);
         }
+
+        Paginator::defaultSimpleView('system::pagination.simple-default');
 
         /*
          * Boot plugins

--- a/modules/system/lang/el/lang.php
+++ b/modules/system/lang/el/lang.php
@@ -317,4 +317,8 @@ return [
         'invalid_path' => "Ορίστηκε μη έγκυρη διαδρομή αρχείου : ':path'.",
         'folder_size_items' => 'αντικείμενο(α)',
     ],
+    'pagination' => [
+        'previous' => 'Προηγούμενη',
+        'next' => 'Επόμενη',
+    ],
 ];

--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -442,4 +442,8 @@ return [
         'invalid_path' => "Invalid file path specified: ':path'.",
         'folder_size_items' => 'item(s)',
     ],
+    'pagination' => [
+        'previous' => 'Previous',
+        'next' => 'Next',
+    ],
 ];

--- a/modules/system/views/pagination/simple-default.blade.php
+++ b/modules/system/views/pagination/simple-default.blade.php
@@ -1,0 +1,20 @@
+@if ($paginator->hasPages())
+    <ul class="pagination">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <li class="disabled"><span>{!! Lang::get('system::lang.pagination.previous') !!}</span></li>
+        @else
+            <li><a href="{{ $paginator->previousPageUrl() }}"
+                   rel="prev">{!! Lang::get('system::lang.pagination.previous') !!}</a></li>
+        @endif
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">{!! Lang::get('system::lang.pagination.next') !!}</a>
+            </li>
+        @else
+            <li class="disabled"><span>{!! Lang::get('system::lang.pagination.next') !!}</span></li>
+        @endif
+    </ul>
+@endif
+


### PR DESCRIPTION
As discussed in https://github.com/octobercms/october/issues/3355#issuecomment-406879069, this pull request overrides the default Laravel view, used when calling the `render` method on a `simplePaginate`d result.