### PR TITLE
Extend opcache check if it is enabled

### DIFF
--- a/modules/cms/classes/CodeParser.php
+++ b/modules/cms/classes/CodeParser.php
@@ -338,7 +338,7 @@ class CodeParser
          * Compile cached file into bytecode cache
          */
         if (Config::get('cms.forceBytecodeInvalidation', false)) {
-            if (function_exists('opcache_invalidate')) {
+            if (function_exists('opcache_invalidate') && ini_get('opcache.enable')) {
                 opcache_invalidate($path, true);
             }
             elseif (function_exists('apc_compile_file')) {


### PR DESCRIPTION
When trying to deploy October on shared hosting (www.websupport.sk) I received following error when accessing the frontend pages - ErrorException:> Zend OPcache API is restricted by "restrict_api" configuration directive.
Backend was working normally. 
I propose the following change to check not only if the opcache_invalidate exists but also if opcache is enabled.
Same check is actually present in twig vendor files - but so far it is working without having the check there.