### PR TITLE
Passing parameters as an array

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -431,7 +431,7 @@ class Form extends WidgetBase
             $this->fields = [];
         }
 
-        $this->allTabs->outside = new FormTabs(FormTabs::SECTION_OUTSIDE, $this->config);
+        $this->allTabs->outside = new FormTabs(FormTabs::SECTION_OUTSIDE, (array)$this->config);
         $this->addFields($this->fields);
 
         /*

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -431,7 +431,7 @@ class Form extends WidgetBase
             $this->fields = [];
         }
 
-        $this->allTabs->outside = new FormTabs(FormTabs::SECTION_OUTSIDE, (array)$this->config);
+        $this->allTabs->outside = new FormTabs(FormTabs::SECTION_OUTSIDE, (array) $this->config);
         $this->addFields($this->fields);
 
         /*


### PR DESCRIPTION
Now it will work:
```yaml
cssClass: row
fields:
    price_section:
        label: Cost of goods
        type: section
        span: storm
        cssClass: col-xs-12
```

Just like this:
```yaml
tabs:
    cssClass: row
    fields:
        price_section:
            label: Cost of goods
            type: section
            span: storm
            cssClass: col-xs-12
```

I have previously received an error: Cannot use object of type stdClass as array
https://github.com/octobercms/october/blob/master/modules/backend/classes/FormTabs.php#L94