### PR TITLE
Add Same-Site Cookie configuration option

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -159,6 +159,10 @@ return [
     | take place, and can be used to mitigate CSRF attacks. By default, we
     | do not enable this as other CSRF protection services are in place.
     |
+    | In the strict mode, the cookie is not sent with any cross-site usage
+    | even if the user follows a link to another website. Lax cookies are
+    | only sent with a top-level get request.
+    |
     | Supported: "lax", "strict"
     |
     */

--- a/config/session.php
+++ b/config/session.php
@@ -150,4 +150,19 @@ return [
 
     'secure' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Same-Site Cookies
+    |--------------------------------------------------------------------------
+    |
+    | This option determines how your cookies behave when cross-site requests
+    | take place, and can be used to mitigate CSRF attacks. By default, we
+    | do not enable this as other CSRF protection services are in place.
+    |
+    | Supported: "lax", "strict"
+    |
+    */
+
+    'same_site' => null,
+
 ];


### PR DESCRIPTION
Adds the Same-Site configuration option for cookies. Laravel already has this configuration option in 5.5, see https://github.com/laravel/laravel/blob/5.5/config/session.php#L195.

More information about Same-Site cookies https://www.owasp.org/index.php/SameSite.