### PR TITLE
#1795 - Bug: Disabled plugins showing up in main nav

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -431,7 +431,7 @@ class PluginManager
      *
      * @return string
      */
-    public function normalizeIdentifier(string $identifier): string
+    public function normalizeIdentifier($identifier)
     {
         foreach ($this->plugins as $id => $object) {
             if (strtolower($id) == strtolower($identifier)) {

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -6,9 +6,10 @@ use File;
 use Lang;
 use View;
 use Config;
+use ApplicationException;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
-use ApplicationException;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Plugin manager
@@ -425,10 +426,12 @@ class PluginManager
 
     /**
      * Takes a human plugin code (acme.blog) and makes it authentic (Acme.Blog)
-     * @param  string $id
+     *
+     * @param string $identifier
+     *
      * @return string
      */
-    public function normalizeIdentifier($identifier)
+    public function normalizeIdentifier(string $identifier): string
     {
         foreach ($this->plugins as $id => $object) {
             if (strtolower($id) == strtolower($identifier)) {
@@ -487,11 +490,12 @@ class PluginManager
             }
         }
 
+        $this->populateDisabledPluginsFromDb();
+
         if (File::exists($path)) {
             $disabled = json_decode(File::get($path), true) ?: [];
             $this->disabledPlugins = array_merge($this->disabledPlugins, $disabled);
-        }
-        else {
+        } else {
             $this->writeDisabled();
         }
     }
@@ -751,5 +755,19 @@ class PluginManager
         $manager = UpdateManager::instance();
         $manager->rollbackPlugin($id);
         $manager->updatePlugin($id);
+    }
+
+    /**
+     * Populates information about disabled plugins from DB
+     *
+     * @return void
+     */
+    private function populateDisabledPluginsFromDb(): void
+    {
+        $pluginsData = DB::select('select * from system_plugin_versions where is_disabled = ?', [1]);
+
+        foreach ($pluginsData as $plugin) {
+            $this->disabledPlugins[$plugin->code] = true;
+        }
     }
 }


### PR DESCRIPTION
The reason of underlying #1795 issue is that `disabled.json` is being removed on backend login (when UpdateManager is called) and therefore the information is lost.
To my mind `disabled.json` is not necessary at all, but anyway I left it as it was and fixed the issue by populating of missing data from DB. DatabaseServiceProvider is not booted there yet, that's why I had to use DB facade.