### PR TITLE
Updated to log when name is changed

### DIFF
--- a/modules/cms/models/ThemeLog.php
+++ b/modules/cms/models/ThemeLog.php
@@ -73,7 +73,7 @@ class ThemeLog extends Model
         $newContent = $template->toCompiled();
         $oldContent = $template->getOriginal('content');
 
-        if ($newContent === $oldContent && !$isDelete) {
+        if ($newContent === $oldContent && $templateName === $oldTemplateName && !$isDelete) {
             traceLog($newContent, $oldContent);
             traceLog('Content not dirty for: '. $template->getObjectTypeDirName().'/'.$template->fileName);
             return;


### PR DESCRIPTION
Enhancement that logs when a CMS object has been renamed but the content is unchanged