### PR TITLE
Remove duplicate attribute class

### DIFF
--- a/plugins/october/demo/components/todo/list.htm
+++ b/plugins/october/demo/components/todo/list.htm
@@ -7,7 +7,6 @@
         <button type="button" 
             class="close pull-right" 
             aria-hidden="true" 
-            class="" 
             onclick="$(this).closest('li').remove()">&times;</button>
     </li>
 {% endfor %}


### PR DESCRIPTION
Removes the duplicate attribute "class" from the "list.htm" in the demo plugin (todo component).