### PR TITLE
Modify the Markup Tags layout

### DIFF
--- a/modules/backend/models/editorsetting/fields.yaml
+++ b/modules/backend/models/editorsetting/fields.yaml
@@ -68,18 +68,18 @@ tabs:
                 class_name:
                     title: backend::lang.editor.class_name
 
-        html_allow_empty_tags:
-            label: backend::lang.editor.allowed_empty_tags
-            comment: backend::lang.editor.allowed_empty_tags_comment
-            tab: backend::lang.editor.markup_tags
-            type: textarea
-            span: auto
-
         html_allow_tags:
             label: backend::lang.editor.allowed_tags
             comment: backend::lang.editor.allowed_tags_comment
             tab: backend::lang.editor.markup_tags
             type: textarea
+
+        html_allow_empty_tags:
+            label: backend::lang.editor.allowed_empty_tags
+            comment: backend::lang.editor.allowed_empty_tags_comment
+            tab: backend::lang.editor.markup_tags
+            type: textarea
+            size: small
             span: auto
 
         html_no_wrap_tags:
@@ -87,6 +87,7 @@ tabs:
             comment: backend::lang.editor.no_wrap_comment
             tab: backend::lang.editor.markup_tags
             type: textarea
+            size: small
             span: auto
 
         html_remove_tags:
@@ -94,6 +95,7 @@ tabs:
             comment: backend::lang.editor.remove_tags_comment
             tab: backend::lang.editor.markup_tags
             type: textarea
+            size: small
             span: auto
 
         html_line_breaker_tags:
@@ -101,6 +103,7 @@ tabs:
             comment: backend::lang.editor.line_breaker_tags_comment
             tab: backend::lang.editor.markup_tags
             type: textarea
+            size: small
             span: auto
 
         html_toolbar_buttons:


### PR DESCRIPTION
Current layout on PC:
![before](https://user-images.githubusercontent.com/2959112/44258487-55a6bd00-a20f-11e8-93f4-d1760436ea4e.JPG)

New layout on PC:
![after](https://user-images.githubusercontent.com/2959112/44258502-62c3ac00-a20f-11e8-9e2b-ee5dd0a30c05.JPG)

New layout on Mobile:
![after-mobil](https://user-images.githubusercontent.com/2959112/44258519-6fe09b00-a20f-11e8-96ec-186f545f02ac.JPG)