### PR TITLE
Add functionality to use a model method to provide the availableColors for the color-picker widget

### DIFF
--- a/modules/backend/formwidgets/ColorPicker.php
+++ b/modules/backend/formwidgets/ColorPicker.php
@@ -95,10 +95,9 @@ class ColorPicker extends FormWidgetBase
     {
         if (is_array($this->availableColors)) {
             return $this->availableColors;
-        }
-        elseif (is_string($this->availableColors) && !empty($this->availableColors)) {
+        } elseif (is_string($this->availableColors) && !empty($this->availableColors)) {
             if ($this->model->methodExists($this->availableColors)) {
-                return $this->model->{$this->availableColors}(
+                return $this->availableColors = $this->model->{$this->availableColors}(
                     $this->formField->fieldName,
                     $this->formField->value,
                     $this->formField->config

--- a/modules/backend/formwidgets/ColorPicker.php
+++ b/modules/backend/formwidgets/ColorPicker.php
@@ -84,7 +84,6 @@ class ColorPicker extends FormWidgetBase
         $this->vars['allowEmpty'] = $this->allowEmpty;
         $this->vars['showAlpha'] = $this->showAlpha;
         $this->vars['isCustomColor'] = !in_array($value, $this->vars['availableColors']);
-
     }
 
     /**
@@ -98,18 +97,19 @@ class ColorPicker extends FormWidgetBase
             return $this->availableColors;
         }
         elseif (is_string($this->availableColors) && !empty($this->availableColors)) {
-            if (!$this->model->methodExists($this->availableColors)) {
+            if ($this->model->methodExists($this->availableColors)) {
+                return $this->model->{$this->availableColors}(
+                    $this->formField->fieldName,
+                    $this->formField->value,
+                    $this->formField->config
+                );
+            } else {
                 throw new ApplicationException(Lang::get('backend::lang.field.colors_method_not_exists', [
                     'model'  => get_class($this->model),
                     'method' => $this->availableColors,
                     'field'  => $this->formField->fieldName
                 ]));
             }
-            return $this->model->{$this->availableColors}(
-                $this->formField->fieldName,
-                $this->formField->value,
-                $this->formField->config
-            );
         }
     }
 

--- a/modules/backend/formwidgets/ColorPicker.php
+++ b/modules/backend/formwidgets/ColorPicker.php
@@ -97,50 +97,20 @@ class ColorPicker extends FormWidgetBase
         if (is_array($this->availableColors)) {
             return $this->availableColors;
         }
-        else {
-            $availableColors = isset($this->availableColors) ? $this->availableColors : null;
-            $availableColors = $this->getColorsFromModel($this->formField, $availableColors);
-            return $availableColors;
-        }
-    }
-
-
-    /**
-     * Looks at the model for defined colors.
-     *
-     * @param $field
-     * @param $fieldAvailableColors
-     * @return array
-     */
-    protected function getColorsFromModel($field, $fieldAvailableColors)
-    {
-        if (is_string($fieldAvailableColors)) {
-            if (!$this->objectMethodExists($this->model, $fieldAvailableColors)) {
+        elseif (is_string($this->availableColors) && !empty($this->availableColors)) {
+            if (!$this->model->methodExists($this->availableColors)) {
                 throw new ApplicationException(Lang::get('backend::lang.field.colors_method_not_exists', [
                     'model'  => get_class($this->model),
-                    'method' => $fieldAvailableColors,
-                    'field'  => $field->fieldName
+                    'method' => $this->availableColors,
+                    'field'  => $this->formField->fieldName
                 ]));
             }
-            $fieldAvailableColors = $this->model->$fieldAvailableColors($field->value, $field->fieldName, $field->config);
+            return $this->model->{$this->availableColors}(
+                $this->formField->fieldName,
+                $this->formField->value,
+                $this->formField->config
+            );
         }
-        return $fieldAvailableColors;
-    }
-
-    /**
-     * Internal helper for method existence checks.
-     *
-     * @param  object $object
-     * @param  string $method
-     * @return boolean
-     */
-    protected function objectMethodExists($object, $method)
-    {
-        if (method_exists($object, 'methodExists')) {
-            return $object->methodExists($method);
-        }
-
-        return method_exists($object, $method);
     }
 
     /**

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -8,7 +8,7 @@ return [
     'field' => [
         'invalid_type' => 'Invalid field type used :type.',
         'options_method_invalid_model' => "The attribute ':field' does not resolve to a valid model. Try specifying the options method for model class :model explicitly.",
-        'options_method_not_exists' => "The model class :model must define a method :method() returning options for the ':field' form field."
+        'options_method_not_exists' => "The model class :model must define a method :method() returning options for the ':field' form field.",
         'colors_method_not_exists' => "The model class :model must define a method :method() returning html color HEX codes for the ':field' form field."
     ],
     'widget' => [

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -9,6 +9,7 @@ return [
         'invalid_type' => 'Invalid field type used :type.',
         'options_method_invalid_model' => "The attribute ':field' does not resolve to a valid model. Try specifying the options method for model class :model explicitly.",
         'options_method_not_exists' => "The model class :model must define a method :method() returning options for the ':field' form field."
+        'colors_method_not_exists' => "The model class :model must define a method :method() returning html color HEX codes for the ':field' form field."
     ],
     'widget' => [
         'not_registered' => "A widget class name ':name' has not been registered",

--- a/modules/backend/lang/nl/lang.php
+++ b/modules/backend/lang/nl/lang.php
@@ -8,6 +8,7 @@ return [
         'invalid_type' => 'Ongeldig type veld: :type.',
         'options_method_invalid_model' => "Het attribuut ':field' levert geen geldig model op. Probeer de opties methode expliciet te specifieren voor modelklasse :model.",
         'options_method_not_exists' => 'De modelklasse :model moet de methode :method() definiëren met daarin opties voor het veld ":field".',
+        'colors_method_not_exists' => 'De modelklasse :model moet de methode :method() definiëren met daarin html HEX kleurcodes voor het veld ":field".',
     ],
     'widget' => [
         'not_registered' => "Een widget met klassenaam ':name' is niet geregistreerd",


### PR DESCRIPTION
This PR adds the functionality to use a custom model method to determine the availableColors (the colors used by the widget) of the color-picker form widget. It uses the same concept as the [dropdown documentation](https://github.com/octobercms/docs/blob/master/backend-forms.md#dropdown)'s fourth method to provide options.

The behaviour of the colorpicker availableColors now is:
- When omitted or left empty, it uses the default colors (stays the same)
- When providing an array of colors, it the colors from this array (stays the same)
- When providing a string function name, it looks at the model and uses that custom model function. 

Example usage:
In your plugin `plugins/example/example/models/example/fields.yaml` set availableColors to your custom method
```
icon_color:
    type: colorpicker
    availableColors: getBrandColors
```
Then in your `plugins/example/example/models/Example.php` define a the method which returns an array containing hex color codes
```
public function getBrandColors($fieldName, $value, $formData){
    return [BrandSetting::get('primary_color'), BrandSetting::get('secondary_color')];
}
```
