### PR TITLE
Fix sorting icon

### DIFF
--- a/modules/cms/widgets/templatelist/partials/_toolbar.htm
+++ b/modules/cms/widgets/templatelist/partials/_toolbar.htm
@@ -13,7 +13,7 @@
                     <div class="dropdown">
                         <button
                             type="button"
-                            class="btn btn-default empty oc-icon-sort-alpha-desc"
+                            class="btn btn-default empty oc-icon-sort-alpha-asc"
                             data-toggle="dropdown"></button>
                         <ul
                             class="dropdown-menu offset-left"


### PR DESCRIPTION
The sort icon was descending (Z-A) while the sorting is ascending (A-Z). Modified the icon to be ascending.

Before: 
![before](https://user-images.githubusercontent.com/1123054/44288210-cd0c3900-a26f-11e8-968f-e07dae157229.PNG)

After:
![after](https://user-images.githubusercontent.com/1123054/44288219-d1d0ed00-a26f-11e8-96a0-060d5eed5c36.PNG)
