### PR TITLE
Check for plugin version table existence when loading disabled plugin data or registering schedules

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -209,6 +209,11 @@ class ServiceProvider extends ModuleServiceProvider
          * Allow plugins to use the scheduler
          */
         Event::listen('console.schedule', function ($schedule) {
+            // Plugins may access system functionality dependent on DB, so require system migrations to run first
+            if (App::hasDatabase() && !PluginManager::instance()->versionTableExists()) {
+                return;
+            }
+
             $plugins = PluginManager::instance()->getPlugins();
             foreach ($plugins as $plugin) {
                 if (method_exists($plugin, 'registerSchedule')) {

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -10,6 +10,7 @@ use Config;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use ApplicationException;
+use Schema;
 
 /**
  * Plugin manager
@@ -532,6 +533,10 @@ class PluginManager
             return;
         }
 
+        if (!$this->versionTableExists()) {
+            return;
+        }
+
         $disabled = Db::table('system_plugin_versions')->where('is_disabled', '1')->lists('code');
 
         foreach ($disabled as $code) {
@@ -560,6 +565,11 @@ class PluginManager
         }
 
         return true;
+    }
+
+    public function versionTableExists()
+    {
+        return Schema::hasTable('system_plugin_versions');
     }
 
     /**


### PR DESCRIPTION
@LukeTowers This is what I propose for #3691 and @munxar's issue brought up in #3208, which I have also run into. I decided that deferring plugin loading like I was describing in #3691 was fine but unnecessary. This is simple enough.

I don't think anyone would count on running plugin task scheduling without getting everything set up and at least running `october:up` on their database, but this would break that particular use case.