### PR TITLE
If using database, don't call plugin task scheduling before initial system migration

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -17,6 +17,7 @@ use System\Classes\ErrorHandler;
 use System\Classes\MarkupManager;
 use System\Classes\PluginManager;
 use System\Classes\SettingsManager;
+use System\Classes\UpdateManager;
 use System\Twig\Engine as TwigEngine;
 use System\Twig\Loader as TwigLoader;
 use System\Twig\Extension as TwigExtension;
@@ -209,6 +210,11 @@ class ServiceProvider extends ModuleServiceProvider
          * Allow plugins to use the scheduler
          */
         Event::listen('console.schedule', function ($schedule) {
+            // Fix initial system migration with plugins that use settings for scheduling - see #3208
+            if (App::hasDatabase() && !Schema::hasTable(UpdateManager::instance()->getMigrationTableName())) {
+                return;
+            }
+
             $plugins = PluginManager::instance()->getPlugins();
             foreach ($plugins as $plugin) {
                 if (method_exists($plugin, 'registerSchedule')) {

--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -951,11 +951,10 @@ class UpdateManager
         return base64_encode(hash_hmac('sha512', http_build_query($data, '', '&'), base64_decode($secret), true));
     }
 
-    //
-    // Internals
-    //
-
-    protected function getMigrationTableName()
+    /**
+     * @return string
+     */
+    public function getMigrationTableName()
     {
         return Config::get('database.migrations', 'migrations');
     }


### PR DESCRIPTION
This is the other half left out from #3706, which stems from the same root cause the allowed change addresses for the `PluginManager`, but appears to have been rejected for covering scheduling in the same PR.

I switched the table existence check to the `UpdateManager`'s migration table. Though it's not functionally any different from checking for the plugin version table since the first `october:up` of course creates both, it feels a little more appropriate anyway.

Discussion about settings access in plugin's `registerSchedule()` preventing initial migration came up in #3208.