### PR TITLE
Add assets prefix implementation within combineToFile method

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -207,7 +207,7 @@ class CombineAssets
         $this->storagePath = null;
 
         // Prefix all assets
-        if($localPath) {
+        if ($localPath) {
             if (substr($localPath, -1) !== '/') {
                 $localPath = $localPath.'/';
             }

--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -206,6 +206,17 @@ class CombineAssets
         // Disable cache always
         $this->storagePath = null;
 
+        // Prefix all assets
+        if($localPath) {
+            if (substr($localPath, -1) !== '/') {
+                $localPath = $localPath.'/';
+            }
+            $assets = array_map(function($asset) use ($localPath) {
+                if (substr($asset, 0, 1) === '@') return $asset;
+                return $localPath.$asset;
+            }, $assets);
+        }
+
         list($assets, $extension) = $this->prepareAssets($assets);
 
         $rewritePath = File::localToPublic(dirname($destination));


### PR DESCRIPTION
#3721 
Add missing implementation of assets `$localPath` prefix within CombineAssets::combineToFile method. Skipping aliases included.