### PR TITLE
Fix repeater issues with child widgets (including nested repeaters) and duplicate field names

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -108,7 +108,7 @@ class Repeater extends FormWidgetBase
             $this->previewMode = true;
         }
 
-        $fieldName = $this->formField->getName(false);
+        $fieldName = $this->formField->getName(false).'_'.md5($this->formField->getName(true));
         $this->indexInputName = self::INDEX_PREFIX.$fieldName;
         $this->groupInputName = self::GROUP_PREFIX.$fieldName;
 
@@ -172,7 +172,12 @@ class Repeater extends FormWidgetBase
      */
     public function getSaveValue($value)
     {
-        return (array) $this->processSaveValue($value);
+        $formData = [];
+        foreach ($this->formWidgets as $index => $form) {
+            $formData[$index] = $form->getSaveData();
+        }
+        
+        return $this->processSaveValue($formData);
     }
 
     /**
@@ -182,10 +187,6 @@ class Repeater extends FormWidgetBase
      */
     protected function processSaveValue($value)
     {
-        if (!is_array($value) || !$value) {
-            return $value;
-        }
-
         if ($this->useGroups) {
             foreach ($value as $index => &$data) {
                 $data['_group'] = $this->getGroupCodeFromIndex($index);

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -113,7 +113,7 @@ class Repeater extends FormWidgetBase
             $this->previewMode = true;
         }
 
-        $fieldName = $this->formField->getName(false).'_'.md5($this->formField->getName(true));
+        $fieldName = implode('_', HtmlHelper::nameToArray($this->formField->getName()));
         $this->indexInputName = self::INDEX_PREFIX.$fieldName;
         $this->groupInputName = self::GROUP_PREFIX.$fieldName;
 

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -2,8 +2,8 @@
 
 use Lang;
 use ApplicationException;
-use Backend\Classes\FormField;
 use Backend\Classes\FormWidgetBase;
+use October\Rain\Html\Helper as HtmlHelper;
 
 /**
  * Repeater Form Widget
@@ -80,6 +80,11 @@ class Repeater extends FormWidgetBase
      * @var bool Stops nested repeaters populating from previous sibling.
      */
     protected static $onAddItemCalled = false;
+
+    /**
+     * @var bool Whether to add post data to existing items. See MLRepeater in RainLab.Translate plugin.
+     */
+    protected static $onlyExistingItems = false;
 
     protected $useGroups = false;
 
@@ -234,8 +239,14 @@ class Repeater extends FormWidgetBase
             }
         }
 
-        $itemIndexes = post($this->indexInputName, $loadedIndexes);
-        $itemGroups = post($this->groupInputName, $loadedGroups);
+        if (self::$onlyExistingItems) {
+            $itemIndexes = $loadedIndexes;
+            $itemGroups = $loadedGroups;
+        }
+        else {
+            $itemIndexes = post($this->indexInputName, $loadedIndexes);
+            $itemGroups = post($this->groupInputName, $loadedGroups);
+        }
 
         if (!count($itemIndexes)) {
             return;

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -71,4 +71,5 @@
         </div>
     </script>
 
+    <input type="hidden" name="<?= $existsInputName ?>" value="1" />
 </div>

--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -40,9 +40,6 @@
         <?php foreach ($widget->getFields() as $field): ?>
             <?= $widget->renderField($field) ?>
         <?php endforeach ?>
-        <?php if ($useGroups): ?>
-            <input type="hidden" name="<?= $widget->arrayName ?>[_group]" value="<?= $groupCode ?>" />
-        <?php endif ?>
     </div>
 
     <input type="hidden" name="<?= $indexInputName ?>[]" value="<?= $indexValue ?>" />

--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -42,9 +42,6 @@
         <?php endforeach ?>
     </div>
 
-    <input type="hidden" name="<?= $indexInputName ?>[]" value="<?= $indexValue ?>" />
-    <?php if ($useGroups): ?>
-        <input type="hidden" name="<?= $groupInputName ?>[]" value="<?= $groupCode ?>" />
-    <?php endif ?>
+    <input type="hidden" name="<?= $indexInputName ?>[<?= $indexValue ?>]" value="<?= $useGroups ? $groupCode : 1 ?>" />
 
 </li>


### PR DESCRIPTION
I believe that #3523 doesn't go deep enough into this issue (and to be fair, @Narkoleptika said he hadn't pursued it beyond fixing the immediate problem), so this PR reverts that commit to address the root cause.

There are two problems addressed here:

1. Repeaters add group information to the save value, but they do not pass through the data processing to any child widgets (which includes nested repeaters). This is what causes the lack of the `_group` index in child repeater save data in #3523, but it also prevents any other child widget that overrides `getSaveValue` from doing its own processing. This PR fixes that by building the save value through calling `getSaveData` on each child form widget and then tacking on group data if necessary as before.
2. Repeaters add index and group information to the form based on the repeater's field name (without array prefix), causing an issue if multiple repeaters have the same field name, which can come up through nesting or other usage. This could be fixed different ways, but I've just added an MD5 hash of the full field name to the simple field name.

The original test plugin PR (octoberrain/test-plugin#50) can be used to verify that this change works. I plan on eventually submitting a functional test case for this to prevent regressions, but the functional tests need some updating first, which is being discussed elsewhere.