### PR TITLE
Adapting the request log list for mobile screens

### DIFF
--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -62,8 +62,8 @@
             text-align: center;
             color: @color-checkbox-icon;
 
-            width: 18px;
-            height: 18px;
+            width: 19px;
+            height: 19px;
 
             position: absolute;
             left: -3px;

--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -38,7 +38,7 @@
 
 .custom-checkbox,
 .custom-radio {
-    padding-left: 23px;
+    padding-left: 15px;
     margin-top: 0;
 
     input[type=radio],
@@ -65,7 +65,6 @@
             width: 18px;
             height: 18px;
 
-            margin-right: 15px;
             position: absolute;
             left: -3px;
             top: 0;

--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -38,7 +38,7 @@
 
 .custom-checkbox,
 .custom-radio {
-    padding-left: 15px;
+    padding-left: 14px;
     margin-top: 0;
 
     input[type=radio],

--- a/modules/system/assets/ui/less/list.less
+++ b/modules/system/assets/ui/less/list.less
@@ -89,7 +89,7 @@ table.table.data {
             td, th { background-color: @color-list-accent; }
         }
         td, th {
-            padding: 12px 15px;
+            padding: 12px 15px 11px;
             color: @color-list-text;
             border-top: 2px solid white;
 
@@ -353,7 +353,7 @@ table.table.data {
     //
 
     .list-checkbox {
-        width: 43px;
+        width: 42px;
         vertical-align: top;
         border-right: 1px solid @color-list-border-light;
         .checkbox {
@@ -362,7 +362,7 @@ table.table.data {
         }
         .custom-checkbox {
             position: relative;
-            top: -14px;
+            top: -15px;
             label {
                 margin-right: 0;
                 margin-bottom: 0;
@@ -372,7 +372,7 @@ table.table.data {
 
     tbody tr td.list-checkbox {
         padding-left: (@padding-standard - 3); // Offset the border
-        padding-right: (@padding-standard - 17); // Offset the checkbox padding
+        padding-right: (@padding-standard - 18); // Offset the checkbox padding
     }
 
     thead tr th.list-checkbox {
@@ -419,6 +419,21 @@ table.table.data {
     .makeTreeLevel(8);
     .makeTreeLevel(9);
     .makeTreeLevel(10);
+}
+
+@media only screen and (-moz-min-device-pixel-ratio: 1.5), only screen and (-o-min-device-pixel-ratio: 3/2), only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-devicepixel-ratio: 1.5), only screen and (min-resolution: 1.5dppx) {
+    table.table.data {
+        thead {
+            .list-checkbox .custom-checkbox {
+                top: -1.595em;
+            }
+        }
+        .list-checkbox {
+            .custom-checkbox {
+                top: -13px;
+            }
+        }
+    }
 }
 
 //

--- a/modules/system/assets/ui/less/list.less
+++ b/modules/system/assets/ui/less/list.less
@@ -80,7 +80,7 @@ table.table.data {
         }
 
         .list-checkbox .custom-checkbox {
-            top: -18px;
+            top: -19px;
         }
     }
 

--- a/modules/system/assets/ui/less/list.less
+++ b/modules/system/assets/ui/less/list.less
@@ -79,12 +79,8 @@ table.table.data {
             padding-left: 10px;
         }
 
-        tr th:last-child a {
-            padding-right: 25px;
-        }
-
         .list-checkbox .custom-checkbox {
-            top: -16px;
+            top: -18px;
         }
     }
 
@@ -357,7 +353,7 @@ table.table.data {
     //
 
     .list-checkbox {
-        width: 52px;
+        width: 43px;
         vertical-align: top;
         border-right: 1px solid @color-list-border-light;
         .checkbox {
@@ -367,7 +363,6 @@ table.table.data {
         .custom-checkbox {
             position: relative;
             top: -14px;
-            left: -2px;
             label {
                 margin-right: 0;
                 margin-bottom: 0;
@@ -495,7 +490,6 @@ table.table.data {
                     line-height: 14px;
                     .icon(@list-ul);
                     display: inline-block;
-                    margin-left: 8px;
                     vertical-align: baseline;
                     .opacity(.6);
                 }

--- a/modules/system/controllers/requestlogs/config_list.yaml
+++ b/modules/system/controllers/requestlogs/config_list.yaml
@@ -8,7 +8,7 @@ modelClass: System\Models\RequestLog
 recordUrl: system/requestlogs/preview/:id
 noRecordsMessage: backend::lang.list.no_records
 recordsPerPage: 30
-showSetup: false
+showSetup: true
 showCheckboxes: true
 defaultSort:
     column: count

--- a/modules/system/controllers/requestlogs/config_list.yaml
+++ b/modules/system/controllers/requestlogs/config_list.yaml
@@ -8,7 +8,7 @@ modelClass: System\Models\RequestLog
 recordUrl: system/requestlogs/preview/:id
 noRecordsMessage: backend::lang.list.no_records
 recordsPerPage: 30
-showSetup: true
+showSetup: false
 showCheckboxes: true
 defaultSort:
     column: count

--- a/modules/system/models/requestlog/columns.yaml
+++ b/modules/system/models/requestlog/columns.yaml
@@ -5,6 +5,7 @@
 columns:
     status_code:
         label: system::lang.request_log.status_code
+        searchable: yes
         invisible: true
 
     url:

--- a/modules/system/models/requestlog/columns.yaml
+++ b/modules/system/models/requestlog/columns.yaml
@@ -5,8 +5,7 @@
 columns:
     status_code:
         label: system::lang.request_log.status_code
-        searchable: yes
-        width: 100px
+        invisible: true
 
     url:
         label: system::lang.request_log.url
@@ -15,4 +14,3 @@ columns:
 
     count:
         label: system::lang.request_log.count
-        width: 150px


### PR DESCRIPTION
On my phone with a diagonal of 5 inches - this list is very difficult to view

The list looks like on the left screenshot, and how does the list look like after my edits on right screenshot:

![photo_2018-08-31_08-45-54](https://user-images.githubusercontent.com/20097205/44895205-032fcb00-acfc-11e8-9795-a0b49c05c011.jpg)

I think this is more convenient and informative, since the column 'status_code' is always 404, and does not carry a payload