### PR TITLE
Fixed the readonly issue

### DIFF
--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -248,6 +248,7 @@ class FormField
      * - radio - creates a set of radio buttons.
      * - checkbox - creates a single checkbox.
      * - checkboxlist - creates a checkbox list.
+     * - switch - creates a switch field.
      * @param string $type Specifies a render mode as described above
      * @param array $config A list of render mode specific config.
      */
@@ -255,6 +256,7 @@ class FormField
     {
         $this->type = strtolower($type) ?: $this->type;
         $this->config = $this->evalConfig($config);
+
         return $this;
     }
 
@@ -422,6 +424,7 @@ class FormField
     {
         $result = array_get($this->attributes, $position, []);
         $result = $this->filterAttributes($result, $position);
+
         return $htmlBuild ? Html::attributes($result) : $result;
     }
 
@@ -445,6 +448,10 @@ class FormField
 
         if ($position == 'field' && $this->readOnly) {
             $attributes = $attributes + ['readonly' => 'readonly'];
+
+            if ($this->type == 'checkbox' || $this->type == 'switch') {
+                $attributes = $attributes + ['onclick' => 'return false;'];
+            }
         }
 
         return $attributes;
@@ -507,9 +514,7 @@ class FormField
             'data-trigger-closest-parent' => 'form'
         ];
 
-        $attributes = $attributes + $newAttributes;
-
-        return $attributes;
+        return $attributes + $newAttributes;
     }
 
     /**
@@ -548,8 +553,7 @@ class FormField
             $newAttributes['data-input-preset-prefix-input'] = $prefixInput;
         }
 
-        $attributes = $attributes + $newAttributes;
-        return $attributes;
+        return $attributes + $newAttributes;
     }
 
     /**


### PR DESCRIPTION
The readonly attribute doesn't work if the type of form field is checkbox or switch.