### PR TITLE
Getting default values from data in formwidget

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -269,6 +269,7 @@ class Repeater extends FormWidgetBase
         $config->alias = $this->alias . 'Form'.$index;
         $config->arrayName = $this->getFieldName().'['.$index.']';
         $config->isNested = true;
+        $config->shouldFetchDefaultValues = self::$onAddItemCalled;
 
         $widget = $this->makeWidget('Backend\Widgets\Form', $config);
         $widget->bindToController();

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1081,7 +1081,11 @@ class Form extends WidgetBase
      * This should be done when model exists or when explicitly configured
      */
     protected function shouldFetchDefaultValues() {
-        return !$this->model->exists || object_get($this->config, 'shouldFetchDefaultValues');
+        $shouldFetchDefaultValues = object_get($this->config, 'shouldFetchDefaultValues');
+        if ($shouldFetchDefaultValues === false) {
+            return false;
+        }
+        return !$this->model->exists || $shouldFetchDefaultValues;
     }
 
     /**

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1069,11 +1069,19 @@ class Form extends WidgetBase
             $field = $this->allFields[$field];
         }
 
-        $defaultValue = !$this->model->exists
+        $defaultValue = $this->shouldFetchDefaultValues()
             ? $field->getDefaultFromData($this->data)
             : null;
 
         return $field->getValueFromData($this->data, $defaultValue);
+    }
+
+    /**
+     * Checks if default values should be taken from data.
+     * This should be done when model exists or when explicitly configured
+     */
+    protected function shouldFetchDefaultValues() {
+        return !$this->model->exists || object_get($this->config, 'shouldFetchDefaultValues');
     }
 
     /**


### PR DESCRIPTION
When adding a new repeater field in update context, default values for the added fields won't be respected.

Some issues where this was mentioned:
https://github.com/octobercms/october/issues/2445#issuecomment-274621932
#2013 

You can replicate this in the test plugin by adding a default value for some field in the config/repeater_fields.yaml 

When you *create* a new item using this repeater field, the default value will be set.
But when you *update* an item, the default value won't be set when adding a new group.

This PR should fix this problem.
