### PR TITLE
Swoole support: avoid header_remove()

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -244,6 +244,7 @@ class CombineAssets
          *
          * Swoole http server can only run in cli environment, and we cannot use header()
          * or header_remove() with swoole, or we get errors that headers already sent.
+         * see: https://github.com/octobercms/october/pull/3773
          */
         if (php_sapi_name() != 'cli') {
             header_remove();

--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -242,11 +242,11 @@ class CombineAssets
         /*
          * Set 304 Not Modified header, if necessary
          *
-         * Swoole http server can only run in cli environment, and we cannot use header()
-         * or header_remove() with swoole, or we get errors that headers already sent.
+         * We cannot use header() or header_remove() with swoole,
+         * or we get errors that headers were already sent.
          * see: https://github.com/octobercms/october/pull/3773
          */
-        if (php_sapi_name() != 'cli') {
+        if (!App::serverIsSwoole()) {
             header_remove();
         }
 

--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -241,8 +241,14 @@ class CombineAssets
 
         /*
          * Set 304 Not Modified header, if necessary
+         *
+         * Swoole http server can only run in cli environment, and we cannot use header()
+         * or header_remove() with swoole, or we get errors that headers already sent.
          */
-        header_remove();
+        if (php_sapi_name() != 'cli') {
+            header_remove();
+        }
+
         $response = Response::make();
         $response->header('Content-Type', $mime);
         $response->header('Cache-Control', 'private, max-age=604800');


### PR DESCRIPTION
Header modification is not supported with Swoole. Functions like header() or header_remove() will cause an error.
See:
https://github.com/swooletw/laravel-swoole/wiki/Z1.-Notices
https://github.com/scil/LaravelFly/wiki/Coding-Requirement

Discussion here: https://github.com/octobercms/october/issues/3746