### PR TITLE
Removed css rule that makes filelist entries unreadable on touchscreen devices

### DIFF
--- a/modules/backend/assets/css/october.css
+++ b/modules/backend/assets/css/october.css
@@ -263,7 +263,6 @@ html.mobile .control-scrollbar{overflow:auto;-webkit-overflow-scrolling:touch}
 .control-filelist.filelist-hero.single-level ul li:active > a{background:#3498db;border-bottom:1px solid #3498db !important}
 .control-filelist.filelist-hero.single-level ul li:active > a span.title,.control-filelist.filelist-hero.single-level ul li:active > a span.description{color:#ffffff !important}
 .control-filelist.filelist-hero.single-level ul li:active > a .list-icon{color:#ffffff !important}
-.touch .control-filelist li:not(.active) a:hover{background:transparent}
 .control-scrollpanel{position:relative;background:#ecf0f1}
 .control-scrollpanel .control-scrollbar.vertical > .scrollbar-scrollbar{right:0}
 .tooltip .tooltip-inner{text-align:left;padding:5px 8px}

--- a/modules/backend/assets/less/controls/filelist.less
+++ b/modules/backend/assets/less/controls/filelist.less
@@ -424,7 +424,3 @@
         }
     }
 }
-
-.touch .control-filelist li:not(.active) a:hover {
-    background: transparent;
-}


### PR DESCRIPTION
The removed css rule makes filelist entries unreadable on touchscreen clients
that also have default pointer input support. When a touchscreen is detected the `touch` class is applied to the html element.

I'm not sure why this rule was there in the first place since `:hover` states for touchscreens are only very rarely supported.

Before: 

![peek 2018-09-12 18-40](https://user-images.githubusercontent.com/8600029/45439951-6a199080-b6bb-11e8-8896-f2f2974e1606.gif)

After:

![peek 2018-09-12 18-44](https://user-images.githubusercontent.com/8600029/45440221-004db680-b6bc-11e8-8c12-4acc9d58c224.gif)
