### PR TITLE
Fixes issue 3741 - MediaLibrary filenames too strict

### DIFF
--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -487,6 +487,7 @@ class MediaLibrary
             preg_quote(')', '/'),
             preg_quote('[', '/'),
             preg_quote(']', '/'),
+            preg_quote(',', '/'),
             preg_quote('=', '/'),
         ];
 

--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -475,7 +475,22 @@ class MediaLibrary
         /*
          * Validate folder names
          */
-        if (!preg_match('/^[\w@\.\s_\-\/]+$/iu', $path)) {
+        $regexWhitelist = [
+            '\w', // any word character
+            preg_quote('@', '/'),
+            preg_quote('.', '/'),
+            '\s', // whitespace character
+            preg_quote('-', '/'),
+            preg_quote('_', '/'),
+            preg_quote('/', '/'),
+            preg_quote('(', '/'),
+            preg_quote(')', '/'),
+            preg_quote('[', '/'),
+            preg_quote(']', '/'),
+            preg_quote('=', '/'),
+        ];
+
+        if (!preg_match('/^[' . implode('', $regexWhitelist) . ']+$/iu', $path)) {
             throw new ApplicationException(Lang::get('system::lang.media.invalid_path', compact('path')));
         }
 
@@ -686,21 +701,21 @@ class MediaLibrary
             switch ($sortSettings['by']) {
                 case self::SORT_BY_TITLE:
                     $result = strcasecmp($a->path, $b->path);
-                break;
+                    break;
                 case self::SORT_BY_SIZE:
                     if ($a->size < $b->size) {
                         $result = -1;
                     } else {
                         $result = $a->size > $b->size ? 1 : 0;
                     }
-                break;
+                    break;
                 case self::SORT_BY_MODIFIED:
                     if ($a->lastModified < $b->lastModified) {
                         $result = -1;
                     } else {
                         $result = $a->lastModified > $b->lastModified ? 1 : 0;
                     }
-                break;
+                    break;
             }
 
             // Reverse the polarity of the result to direct sorting in a descending order instead

--- a/tests/unit/system/classes/MediaLibraryTest.php
+++ b/tests/unit/system/classes/MediaLibraryTest.php
@@ -33,6 +33,10 @@ class MediaLibraryTest extends TestCase // @codingStandardsIgnoreLine
             ['file.ext'],
             ['file..ext'],
             ['file...ext'],
+            ['one,two.ext'],
+            ['one(two)[].ext'],
+            ['one=(two)[].ext'],
+            ['one_(two)[].ext'],
         ];
     }
 


### PR DESCRIPTION
fixes #3741 

Filename checks in `MediaLibrary` are too strict after implementing XSS protection. Valid file paths are marked invalid due to a very strict regular expression.

## Issue
If a file is added to the `storage/app/media` directory that did not match the pattern `/^[\w@\.\s_\-\/]+$/iu`, an `ApplicationException` is thrown. The checks were too strict, and did not allow parenthesis, commas, or braces. Files uploaded or copied here prior to build 438 worked as expected until build 438+ was installed. The backend Media component would refuse to load and throw an exception if a file that did not match this pattern was present on the filesystem.

If a twig template used the `media` filter against a file that does not match this pattern, an exception is thrown.

## Resolution
Although this is not an end-all fix, it should solve for most edge cases in the event that a user upgraded to October > build 437 from build <= 437. It still does not solve for valid file paths with valid unicode characters.