### PR TITLE
Swoole support: avoid exit() usage

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -645,7 +645,11 @@ class ImportExportController extends ControllerBehavior
          * Output
          */
         $csv->output($options['fileName']);
-        exit;
+
+        // Do not kill Swoole http server if we're running that
+        if (php_sapi_name() != "cli") {
+            exit;
+        }
     }
 
     //

--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\Behaviors;
 
+use App;
 use Str;
 use Lang;
 use View;
@@ -647,7 +648,7 @@ class ImportExportController extends ControllerBehavior
         $csv->output($options['fileName']);
 
         // Do not kill Swoole http server if we're running that
-        if (php_sapi_name() != "cli") {
+        if (!App::serverIsSwoole()) {
             exit;
         }
     }

--- a/modules/backend/controllers/Files.php
+++ b/modules/backend/controllers/Files.php
@@ -26,7 +26,11 @@ class Files extends Controller
     {
         try {
             echo $this->findFileObject($code)->output();
-            exit;
+
+            // Do not kill Swoole http server if we're running that
+            if (php_sapi_name() != "cli") {
+                exit;
+            }
         }
         catch (Exception $ex) {}
 
@@ -44,7 +48,11 @@ class Files extends Controller
                 $height,
                 compact('mode', 'extension')
             );
-            exit;
+
+            // Do not kill Swoole http server if we're running that
+            if (php_sapi_name() != "cli") {
+                exit;
+            }
         }
         catch (Exception $ex) {}
 

--- a/modules/backend/controllers/Files.php
+++ b/modules/backend/controllers/Files.php
@@ -28,7 +28,7 @@ class Files extends Controller
             echo $this->findFileObject($code)->output();
 
             // Do not kill Swoole http server if we're running that
-            if (php_sapi_name() != "cli") {
+            if (!App::serverIsSwoole()) {
                 exit;
             }
         }
@@ -50,7 +50,7 @@ class Files extends Controller
             );
 
             // Do not kill Swoole http server if we're running that
-            if (php_sapi_name() != "cli") {
+            if (!App::serverIsSwoole()) {
                 exit;
             }
         }

--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -425,7 +425,10 @@ class FileUpload extends FormWidgetBase
             Response::json($ex->getMessage(), 400)->send();
         }
 
-        exit;
+        // Do not kill Swoole http server if we're running that
+        if (php_sapi_name() != "cli") {
+            exit;
+        }
     }
 
     /**

--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\FormWidgets;
 
+use App;
 use Input;
 use Request;
 use Response;
@@ -426,7 +427,7 @@ class FileUpload extends FormWidgetBase
         }
 
         // Do not kill Swoole http server if we're running that
-        if (php_sapi_name() != "cli") {
+        if (!App::serverIsSwoole()) {
             exit;
         }
     }

--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\Widgets;
 
+use App;
 use Url;
 use Str;
 use Lang;
@@ -1573,7 +1574,7 @@ class MediaManager extends WidgetBase
         }
 
         // Do not kill Swoole http server if we're running that
-        if (php_sapi_name() != "cli") {
+        if (!App::serverIsSwoole()) {
             exit;
         }
     }

--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -1572,7 +1572,10 @@ class MediaManager extends WidgetBase
             Response::json($ex->getMessage(), 400)->send();
         }
 
-        exit;
+        // Do not kill Swoole http server if we're running that
+        if (php_sapi_name() != "cli") {
+            exit;
+        }
     }
 
     /**


### PR DESCRIPTION
because exit() would kill the swoole http server worker in which the request is run.

discussion: https://github.com/octobercms/october/issues/3746