### PR TITLE
Adds missing Content-Type header to CSV-export. (mentioned in #1313)

### DIFF
--- a/modules/backend/models/ExportModel.php
+++ b/modules/backend/models/ExportModel.php
@@ -63,6 +63,8 @@ abstract class ExportModel extends Model
         }
 
         $headers = Response::download($csvPath, $outputName)->headers->all();
+        $headers['Content-Type'][] = 'text/csv';
+
         $result = Response::make(File::get($csvPath), 200, $headers);
 
         @unlink($csvPath);


### PR DESCRIPTION
CSV Export got interpreted as HTML due to wrong Content-Type header. (Tested with Safari 11.1.2 on macOS 10.13.6 (17G65)).

Since the Content-Type gets set in the `prepare()` method of `BinaryFileResponse` (which does not get called here) the headers are missing it.

If someone can come up with a more elegant solution than hardcoding the type, please feel free to let me know. I'm relatively new to OctoberCMS.