### PR TITLE
Adds missing Content-Type header to CSV-export. (mentioned in #1313)

### DIFF
--- a/modules/backend/models/ExportModel.php
+++ b/modules/backend/models/ExportModel.php
@@ -63,6 +63,8 @@ abstract class ExportModel extends Model
         }
 
         $headers = Response::download($csvPath, $outputName)->headers->all();
+        $headers['Content-Type'][] = 'text/csv';
+
         $result = Response::make(File::get($csvPath), 200, $headers);
 
         @unlink($csvPath);

--- a/modules/backend/models/ExportModel.php
+++ b/modules/backend/models/ExportModel.php
@@ -62,14 +62,7 @@ abstract class ExportModel extends Model
             throw new ApplicationException(Lang::get('backend::lang.import_export.file_not_found_error'));
         }
 
-        $headers = Response::download($csvPath, $outputName)->headers->all();
-        $headers['Content-Type'][] = 'text/csv';
-
-        $result = Response::make(File::get($csvPath), 200, $headers);
-
-        @unlink($csvPath);
-
-        return $result;
+        return Response::download($csvPath, $outputName)->deleteFileAfterSend(true);
     }
 
     /**

--- a/tests/unit/backend/models/ExportModelTest.php
+++ b/tests/unit/backend/models/ExportModelTest.php
@@ -72,7 +72,7 @@ class ExportModelTest extends TestCase
         $response->prepare($requestMock);
 
         $this->assertTrue($response->headers->has('Content-Type'), "Response is missing the Content-Type header!");
-        $this->assertTrue($response->headers->contains('Content-Type', 'text/plain'), "Content-Type is not \"text/csv\"!");
+        $this->assertTrue($response->headers->contains('Content-Type', 'text/plain'), "Content-Type is not \"text/plain\"!");
 
         @unlink(temp_path() . '/' . $csvName);
     }

--- a/tests/unit/backend/models/ExportModelTest.php
+++ b/tests/unit/backend/models/ExportModelTest.php
@@ -8,7 +8,16 @@ class ExampleExportModel extends ExportModel
 {
     public function exportData($columns, $sessionKey = null)
     {
-        return [];
+        return [
+            [
+                'foo' => 'bar',
+                'bar' => 'foo'
+            ],
+            [
+                'foo' => 'bar2',
+                'bar' => 'foo2'
+            ],
+        ];
     }
 }
 
@@ -46,6 +55,26 @@ class ExportModelTest extends TestCase
         $data = ['art direction', 'roman empire', 'sci-fi'];
         $result = self::callProtectedMethod($model, 'encodeArrayValue', [$data, '-']);
         $this->assertEquals('art direction-roman empire-sci\-fi', $result);
+    }
+
+    public function testExportContentType()
+    {
+        $model = new ExampleExportModel;
+
+        $csvName = $model->export(['foo' => 'title', 'bar' => 'title2'], []);
+
+        $response = $model->download($csvName);
+
+        $requestMock = $this
+            ->getMockBuilder('Illuminate\Http\Request')
+            ->setMethods()
+            ->getMock();
+        $response->prepare($requestMock);
+
+        $this->assertTrue($response->headers->has('Content-Type'), "Response is missing the Content-Type header!");
+        $this->assertTrue($response->headers->contains('Content-Type', 'text/plain'), "Content-Type is not \"text/csv\"!");
+
+        @unlink(temp_path() . '/' . $csvName);
     }
 
 }


### PR DESCRIPTION
CSV Export got interpreted as HTML due to wrong Content-Type header. (Tested with Safari 11.1.2 on macOS 10.13.6 (17G65)).

Since the Content-Type gets set in the `BinaryFileResponse->prepare()` method (which does not get called here) the headers are missing it.

If someone can come up with a more elegant solution than hardcoding the type, please feel free to let me know. I'm relatively new to OctoberCMS.