### PR TITLE
Fix for unit test

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -28,6 +28,8 @@ use Backend\Classes\WidgetManager;
 use October\Rain\Support\ModuleServiceProvider;
 use October\Rain\Router\Helper as RouterHelper;
 use Illuminate\Support\Facades\Schema;
+use System\Helpers\UrlGenerator;
+use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 
 class ServiceProvider extends ModuleServiceProvider
 {
@@ -57,7 +59,9 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerAssetBundles();
         $this->registerValidator();
         $this->registerGlobalViewVars();
-
+        
+        $this->updateUrlHelper();
+        
         /*
          * Register other module providers
          */
@@ -545,5 +549,10 @@ class ServiceProvider extends ModuleServiceProvider
     protected function registerGlobalViewVars()
     {
         View::share('appName', Config::get('app.name'));
+    }
+    
+    protected function updateUrlHelper() 
+    {
+        $this->app->bind(UrlGeneratorContract::class, UrlGenerator::class);
     }
 }

--- a/modules/system/helpers/UrlGenerator.php
+++ b/modules/system/helpers/UrlGenerator.php
@@ -8,8 +8,15 @@ class UrlGenerator extends BaseUrlGenerator
     {
         $url = parent::to($path, $extra, $secure);
         
+        // for systems that don't use / for a directorry seperator
+        // and coders that re-use a part of a path that has a windows
+        // directory for example(results of glob, etc..)
+        if(DIRECTORY_SEPARATOR !== '/') {       
+            $url = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        }
+        
         $url = preg_replace('/([^:])(\/{2,})/', '$1/', $url);
-
+        
         return $url;
     }
 }

--- a/modules/system/helpers/UrlGenerator.php
+++ b/modules/system/helpers/UrlGenerator.php
@@ -1,0 +1,15 @@
+<?php namespace System\Helpers;
+
+use Illuminate\Routing\UrlGenerator as BaseUrlGenerator;
+
+class UrlGenerator extends BaseUrlGenerator
+{
+    public function to($path, $extra = [], $secure = null) 
+    {
+        $url = parent::to($path, $extra, $secure);
+        
+        $url = preg_replace('/([^:])(\/{2,})/', '$1/', $url);
+
+        return $url;
+    }
+}

--- a/tests/unit/cms/classes/ControllerTest.php
+++ b/tests/unit/cms/classes/ControllerTest.php
@@ -475,7 +475,7 @@ ESC;
     public function testComponentWithOnRender()
     {
         $theme = Theme::load('test');
-        $controller = new Controller($theme); 
+        $controller = new Controller($theme);
         $response = $controller->run('/component-custom-render')->getContent();
 
         $content = <<<ESC

--- a/tests/unit/cms/classes/ControllerTest.php
+++ b/tests/unit/cms/classes/ControllerTest.php
@@ -19,18 +19,19 @@ class ControllerTest extends TestCase
         include_once base_path() . '/tests/fixtures/plugins/october/tester/components/ContentBlock.php';
         include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Comments.php';
         include_once base_path() . '/tests/fixtures/plugins/october/tester/classes/Users.php';
+        
     }
 
     public function testThemeUrl()
     {
         $theme = Theme::load('test');
         $controller = new Controller($theme);
-
+        
         $url = $controller->themeUrl();
-        $this->assertEquals(config('app.url') . 'themes/test', $url);
+        $this->assertEquals(config('app.url').substr(config('cms.themesPath').'/test', 1), $url);
 
         $url = $controller->themeUrl('foo/bar.css');
-        $this->assertEquals(config('app.url') . '/themes/test/foo/bar.css', $url);
+        $this->assertEquals(config('app.url').substr(config('cms.themesPath'), 1).'/test/foo/bar.css', $url);
 
         //
         // These tests seem to bear different results
@@ -475,7 +476,7 @@ ESC;
     public function testComponentWithOnRender()
     {
         $theme = Theme::load('test');
-        $controller = new Controller($theme);
+        $controller = new Controller($theme); 
         $response = $controller->run('/component-custom-render')->getContent();
 
         $content = <<<ESC

--- a/tests/unit/cms/classes/ControllerTest.php
+++ b/tests/unit/cms/classes/ControllerTest.php
@@ -27,10 +27,10 @@ class ControllerTest extends TestCase
         $controller = new Controller($theme);
 
         $url = $controller->themeUrl();
-        $this->assertEquals('http://localhost/themes/test', $url);
+        $this->assertEquals(config('app.url') . 'themes/test', $url);
 
         $url = $controller->themeUrl('foo/bar.css');
-        $this->assertEquals('http://localhost/themes/test/foo/bar.css', $url);
+        $this->assertEquals(config('app.url') . '/themes/test/foo/bar.css', $url);
 
         //
         // These tests seem to bear different results

--- a/tests/unit/cms/classes/ControllerTest.php
+++ b/tests/unit/cms/classes/ControllerTest.php
@@ -26,11 +26,17 @@ class ControllerTest extends TestCase
         $theme = Theme::load('test');
         $controller = new Controller($theme);
         
-        $url = $controller->themeUrl();
-        $this->assertEquals(config('app.url').substr(config('cms.themesPath').'/test', 1), $url);
+        $configUrl = config('app.url') . '/' . config('cms.themesPath');
+        
+        $url = $controller->themeUrl();        
+        $compareToUrl = preg_replace('/([^:])(\/{2,})/', '$1/', $configUrl . '/test');
+        
+        $this->assertEquals($compareToUrl, $url);
 
         $url = $controller->themeUrl('foo/bar.css');
-        $this->assertEquals(config('app.url').substr(config('cms.themesPath'), 1).'/test/foo/bar.css', $url);
+        $compareToUrl = preg_replace('/([^:])(\/{2,})/', '$1/', $configUrl . '/test/foo/bar.css');
+        
+        $this->assertEquals($compareToUrl, $url);
 
         //
         // These tests seem to bear different results

--- a/tests/unit/cms/classes/ControllerTest.php
+++ b/tests/unit/cms/classes/ControllerTest.php
@@ -29,12 +29,12 @@ class ControllerTest extends TestCase
         $configUrl = config('app.url') . '/' . config('cms.themesPath');
         
         $url = $controller->themeUrl();        
-        $compareToUrl = preg_replace('/([^:])(\/{2,})/', '$1/', $configUrl . '/test');
+        $compareToUrl = url($configUrl . '/test');
         
         $this->assertEquals($compareToUrl, $url);
 
         $url = $controller->themeUrl('foo/bar.css');
-        $compareToUrl = preg_replace('/([^:])(\/{2,})/', '$1/', $configUrl . '/test/foo/bar.css');
+        $compareToUrl = url($configUrl . '/test/foo/bar.css');
         
         $this->assertEquals($compareToUrl, $url);
 

--- a/tests/unit/cms/classes/ControllerTest.php
+++ b/tests/unit/cms/classes/ControllerTest.php
@@ -19,7 +19,6 @@ class ControllerTest extends TestCase
         include_once base_path() . '/tests/fixtures/plugins/october/tester/components/ContentBlock.php';
         include_once base_path() . '/tests/fixtures/plugins/october/tester/components/Comments.php';
         include_once base_path() . '/tests/fixtures/plugins/october/tester/classes/Users.php';
-        
     }
 
     public function testThemeUrl()

--- a/tests/unit/system/classes/UrlGeneratorTest.php
+++ b/tests/unit/system/classes/UrlGeneratorTest.php
@@ -1,0 +1,18 @@
+<?php
+use System\Classes\PluginManager;
+
+class UrlGeneratorTest extends TestCase
+{
+    public function testStrippedSlashes() 
+    {
+        $this->assertEquals('http://example.com', url('http://example.com'));
+        $this->assertEquals('http://example.com/foo/bar', url('http://example.com//foo/bar'));
+        $this->assertEquals('http://example.com/foo/bar', url('http://example.com//foo//bar'));
+        $this->assertEquals('http://example.com/foo/bar', url('http://example.com//foo///bar'));
+        $this->assertEquals('http://example.com/foo/bar/', url('http://example.com/foo/bar/'));
+        $this->assertEquals('http://example.com/foo/bar/', url('http://example.com/foo/bar//'));
+        
+        // last slashes should be removed in this scenario
+        $this->assertEquals(preg_replace('/([^:])(\/{2,})/', '$1/', config('app.url') . '/foo/bar'), url('/foo/bar//'));
+    }
+}


### PR DESCRIPTION
 It always tests against an absolute url instead of the url set in the app.url configuration

When october is installed in a subdirectory and the url is different than the hardcoded test url. Of if one has set a test domain via the hosts.conf it would always test against a wrong url.

```
$ ./vendor/bin/phpunit
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

..............................................................  62 / 332 ( 18%)
....F......................................................... 124 / 332 ( 37%)
.............................................................. 186 / 332 ( 56%)
.............................................................. 248 / 332 ( 74%)
.............................................................. 310 / 332 ( 93%)
......................                                         332 / 332 (100%)

Time: 1.55 minutes, Memory: 38.00MB

There was 1 failure:

1) ControllerTest::testThemeUrl
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'http://localhost/themes/test'
+'http://localhost/exitoffice/themes/test'

```

Not sure if app.config + cms.themesPath is correct, but I would think it would have to be so that the settings that are set match the settings that are generated by the internal code.
