### PR TITLE
Fix input trigger on source field types with multiple selected values

### DIFF
--- a/modules/system/assets/ui/js/input.trigger.js
+++ b/modules/system/assets/ui/js/input.trigger.js
@@ -57,7 +57,7 @@
             this.updateTarget(!$(this.options.trigger + ':checked', this.triggerParent).length)
         }
         else if (this.triggerCondition == 'value') {
-            var trigger, triggerValue = ''
+            var trigger, triggered = false
 
             trigger = $(this.options.trigger, this.triggerParent)
                 .not('input[type=checkbox], input[type=radio], input[type=button], input[type=submit]')
@@ -67,11 +67,19 @@
                     .not(':not(input[type=checkbox]:checked, input[type=radio]:checked)')
             }
 
-            if (!!trigger.length) {
-                triggerValue = trigger.val()
-            }
+            var self = this
+            trigger.each(function() {
+                var triggerValue = $(this).val();
 
-            this.updateTarget($.inArray(triggerValue, this.triggerConditionValue) != -1)
+                $.each($.isArray(triggerValue) ? triggerValue : [triggerValue], function(key, val) {
+                    triggered = $.inArray(val, self.triggerConditionValue) != -1
+                    return !triggered
+                })
+
+                return !triggered
+            })
+
+            this.updateTarget(triggered)
         }
     }
 

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -4170,11 +4170,14 @@ self.onConditionChanged()})
 self.onConditionChanged()}
 TriggerOn.prototype.onConditionChanged=function(){if(this.triggerCondition=='checked'){this.updateTarget(!!$(this.options.trigger+':checked',this.triggerParent).length)}
 else if(this.triggerCondition=='unchecked'){this.updateTarget(!$(this.options.trigger+':checked',this.triggerParent).length)}
-else if(this.triggerCondition=='value'){var trigger,triggerValue=''
+else if(this.triggerCondition=='value'){var trigger,triggered=false
 trigger=$(this.options.trigger,this.triggerParent).not('input[type=checkbox], input[type=radio], input[type=button], input[type=submit]')
 if(!trigger.length){trigger=$(this.options.trigger,this.triggerParent).not(':not(input[type=checkbox]:checked, input[type=radio]:checked)')}
-if(!!trigger.length){triggerValue=trigger.val()}
-this.updateTarget($.inArray(triggerValue,this.triggerConditionValue)!=-1)}}
+var self=this
+trigger.each(function(){var triggerValue=$(this).val();$.each($.isArray(triggerValue)?triggerValue:[triggerValue],function(key,val){triggered=$.inArray(val,self.triggerConditionValue)!=-1
+return!triggered})
+return!triggered})
+this.updateTarget(triggered)}}
 TriggerOn.prototype.updateTarget=function(status){var self=this,actions=this.options.triggerAction.split('|')
 $.each(actions,function(index,action){self.updateTargetAction(action,status)})
 $(window).trigger('resize')


### PR DESCRIPTION
The problem is demonstrated in octoberrain/test-plugin#55. Currently, the form field trigger doesn't work on source fields with multiple selected values. This PR fixes the issue by running through all selected fields (e.g. `checkboxlist` with multiple selections) and handling an array as a result of `$.val()` on the trigger field (e.g. `taglist` or generic `<select>` using multiple attribute).