### PR TITLE
Repaired Form widget renderField method

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -239,6 +239,8 @@ class Form extends WidgetBase
      */
     public function renderField($field, $options = [])
     {
+        $this->prepareVars();
+        
         if (is_string($field)) {
             if (!isset($this->allFields[$field])) {
                 throw new ApplicationException(Lang::get(
@@ -255,7 +257,6 @@ class Form extends WidgetBase
         }
         $targetPartial = $options['useContainer'] ? 'field-container' : 'field';
 
-        $this->prepareVars();
         return $this->makePartial($targetPartial, ['field' => $field]);
     }
 


### PR DESCRIPTION
In `Backend\Widgets\Form::renderField` method is calling of `prepareVars()` needed before using `$this->allFields` otherwise is this array always empty!