### PR TITLE
Filtering the list without session

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -869,8 +869,10 @@ class Filter extends WidgetBase
             $scope = $this->getScope($scope);
         }
 
-        $cacheKey = 'scope-'.$scope->scopeName;
-        $this->putSession($cacheKey, $value);
+        if (!isset($scope->config['session']) || $scope->config['session']) {
+            $cacheKey = 'scope-'.$scope->scopeName;
+            $this->putSession($cacheKey, $value);
+        }
 
         $scope->value = $value;
     }


### PR DESCRIPTION
The current behavior of october loads a list page by filtering the list depend on the session of the previous selected value. 
That's pretty good but there is cases where we want the client to see the list page for the first load with the same filter value without putting it in the session.

This PR let the developer to set a filter with setting in which prevent the filter from saving to session.

For example the bellow filter `email_verified` prevents to save it to session and load the list page for the first time with the same value
```
    email_verified:
        label: Email Verified
        type: switch
        default: 2
        session: false
        conditions:
        - is_email_verified = '0'
        - is_email_verified = '1'

```

ps: this changes keep the behavior of october the same as before without any breaking changes.