### PR TITLE
Enhance theme configuration to support array fields

### DIFF
--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -116,6 +116,10 @@ class ThemeData extends Model
          * Repeater form fields store arrays and must be jsonable.
          */
         foreach ($this->getFormFields() as $id => $field) {
+            if ($pos = strpos($id, '[')) {
+                $this->jsonable[] = substr($id, 0, $pos);
+            }
+            
             if (!isset($field['type'])) {
                 continue;
             }


### PR DESCRIPTION
Theme configuration doesn't currently support array fields without also defining them as jsonable or using a repeater. This enhancement automatically registers any fields that are named as an array (eg heading[color]) as jsonable.