### PR TITLE
fix css: 'width' style in backend columns.yaml  won't work when use c…

### DIFF
--- a/modules/system/assets/css/styles.css
+++ b/modules/system/assets/css/styles.css
@@ -36,7 +36,7 @@ fieldset{border:1px solid #c0c0c0;margin:0 2px;padding:0.35em 0.625em 0.75em}
 legend{border:0;padding:0}
 textarea{overflow:auto}
 optgroup{font-weight:bold}
-table{border-collapse:collapse;border-spacing:0}
+table{border-collapse:collapse;border-spacing:0;table-layout:auto;word-wrap:break-word;word-break:break-all}
 td,th{padding:0}
 *,*:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 html{font-size:62.5%;-webkit-tap-highlight-color:rgba(0,0,0,0)}

--- a/modules/system/assets/ui/less/site.normalize.less
+++ b/modules/system/assets/ui/less/site.normalize.less
@@ -415,6 +415,9 @@ optgroup {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: auto;
+  word-wrap: break-word;
+  word-break: break-all;
 }
 
 td,

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -36,7 +36,7 @@ fieldset{border:1px solid #c0c0c0;margin:0 2px;padding:0.35em 0.625em 0.75em}
 legend{border:0;padding:0}
 textarea{overflow:auto}
 optgroup{font-weight:bold}
-table{border-collapse:collapse;border-spacing:0}
+table{border-collapse:collapse;border-spacing:0;table-layout:auto;word-wrap:break-word;word-break:break-all}
 td,th{padding:0}
 *,*:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 html{font-size:62.5%;-webkit-tap-highlight-color:rgba(0,0,0,0)}


### PR DESCRIPTION
the 'width' style in backend columns.yaml won't work when use chrome,eg: the field is a very long url , the width of 'td' is not work
I set the columns.yaml like this:
![image](https://user-images.githubusercontent.com/14805513/46255372-d4f60480-c4ce-11e8-871f-29a0227499f5.png)
when I use firefox,it is normal:
![image](https://user-images.githubusercontent.com/14805513/46255429-5cdc0e80-c4cf-11e8-8740-4f41b2d46049.png)


but when i use chrome ,it looks like this:
![image](https://user-images.githubusercontent.com/14805513/46255392-f48d2d00-c4ce-11e8-86ce-6f98d9cd2d2e.png)
