### PR TITLE
Allow plugins to register their own mail partials

### DIFF
--- a/modules/system/classes/MailManager.php
+++ b/modules/system/classes/MailManager.php
@@ -341,11 +341,14 @@ class MailManager
         $plugins = PluginManager::instance()->getPlugins();
         foreach ($plugins as $pluginId => $pluginObj) {
             $templates = $pluginObj->registerMailTemplates();
-            if (!is_array($templates)) {
-                continue;
+            if (is_array($templates)) {
+                $this->registerMailTemplates($templates);
             }
 
-            $this->registerMailTemplates($templates);
+            $partials = $pluginObj->registerMailPartials();
+            if (is_array($partials)) {
+                $this->registerMailPartials($partials);
+            }
         }
     }
 

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -219,6 +219,22 @@ class PluginBase extends ServiceProviderBase
     }
 
     /**
+     * Registers any mail partials implemented by this plugin.
+     * The partials must be returned in the following format:
+     *
+     *     return [
+     *         'tracking'  => 'acme.blog::partials.tracking',
+     *         'promotion' => 'acme.blog::partials.promotion',
+     *     ];
+     *
+     * @return array
+     */
+    public function registerMailPartials()
+    {
+        return [];
+    }
+
+    /**
      * Registers a new console (artisan) command
      *
      * @param string $key The command name

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -207,8 +207,8 @@ class PluginBase extends ServiceProviderBase
      * The templates must be returned in the following format:
      *
      *     return [
-     *         ['acme.blog::mail.welcome' => 'This is a description of the welcome template'],
-     *         ['acme.blog::mail.forgot_password' => 'This is a description of the forgot password template'],
+     *         'acme.blog::mail.welcome',
+     *         'acme.blog::mail.forgot_password',
      *     ];
      *
      * @return array


### PR DESCRIPTION
This PR adds support for plugins to register their own mail partials. This is done by adding a `registerMailPartials` method to the plugin base class. 

If it gets merged I will update the docs accordingly:
http://octobercms.com/docs/services/mail#mail-template-registration