### PR TITLE
Fixed scoreboard label in mail partial update view

### DIFF
--- a/modules/system/controllers/mailpartials/update.htm
+++ b/modules/system/controllers/mailpartials/update.htm
@@ -13,7 +13,7 @@
             <div class="scoreboard">
                 <div data-control="toolbar">
                     <div class="scoreboard-item title-value">
-                        <h4><?= e(trans('system::lang.mail_templates.layout')) ?></h4>
+                        <h4><?= e(trans('system::lang.mail_templates.partial')) ?></h4>
                         <p><?= $formModel->code ?></p>
                     </div>
                 </div>


### PR DESCRIPTION
I stumbled upon a wrong label while working on the mail stuff. This PR sets the correct translation string.