### PR TITLE
Added registerMailLayouts method to PluginBase

### DIFF
--- a/modules/system/classes/MailManager.php
+++ b/modules/system/classes/MailManager.php
@@ -340,6 +340,11 @@ class MailManager
 
         $plugins = PluginManager::instance()->getPlugins();
         foreach ($plugins as $pluginId => $pluginObj) {
+            $layouts = $pluginObj->registerMailLayouts();
+            if (is_array($layouts)) {
+                $this->registerMailLayouts($layouts);
+            }
+
             $templates = $pluginObj->registerMailTemplates();
             if (is_array($templates)) {
                 $this->registerMailTemplates($templates);

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -203,6 +203,22 @@ class PluginBase extends ServiceProviderBase
     }
 
     /**
+     * Registers any mail layouts implemented by this plugin.
+     * The layouts must be returned in the following format:
+     *
+     *     return [
+     *         'marketing'    => 'acme.blog::layouts.marketing',
+     *         'notification' => 'acme.blog::layouts.notification',
+     *     ];
+     *
+     * @return array
+     */
+    public function registerMailLayouts()
+    {
+        return [];
+    }
+
+    /**
      * Registers any mail templates implemented by this plugin.
      * The templates must be returned in the following format:
      *


### PR DESCRIPTION
This PR adds support for a `registerMailLayouts` method on the `PluginBase`  base class. 

This builds on the modifications made in #3847 to bring the registration of layouts, templates and partials into line.

This closes #3820, the documentation was updated in https://github.com/octobercms/docs/pull/326