### PR TITLE
CodeEditor 'ctrl + f' dirty issue

### DIFF
--- a/modules/system/assets/ui/js/input.monitor.js
+++ b/modules/system/assets/ui/js/input.monitor.js
@@ -30,8 +30,8 @@
         this.$el.on('pause.oc.changeMonitor', this.proxy(this.pause))
         this.$el.on('resume.oc.changeMonitor', this.proxy(this.resume))
 
-        this.$el.on('keyup input paste', 'input, textarea:not(.ace_text-input)', this.proxy(this.onInputChange))
-        $('input:not([type=hidden]), textarea:not(.ace_text-input)', this.$el).each(function() {
+        this.$el.on('keyup input paste', 'input:not(.ace_search_field), textarea:not(.ace_text-input)', this.proxy(this.onInputChange))
+        $('input:not([type=hidden]):not(.ace_search_field), textarea:not(.ace_text-input)', this.$el).each(function() {
             $(this).data('oldval.oc.changeMonitor', $(this).val());
         })
 
@@ -60,7 +60,7 @@
         this.$el.off('unchange.oc.changeMonitor', this.proxy(this.unchange))
         this.$el.off('pause.oc.changeMonitor ', this.proxy(this.pause))
         this.$el.off('resume.oc.changeMonitor ', this.proxy(this.resume))
-        this.$el.off('keyup input paste', 'input, textarea:not(.ace_text-input)', this.proxy(this.onInputChange))
+        this.$el.off('keyup input paste', 'input:not(.ace_search_field), textarea:not(.ace_text-input)', this.proxy(this.onInputChange))
         this.$el.off('dispose-control', this.proxy(this.dispose))
 
         if (this.options.windowCloseConfirm)
@@ -69,6 +69,9 @@
 
     ChangeMonitor.prototype.change = function(ev, inputChange) {
         if (this.paused)
+            return
+
+        if (ev.target.className === 'ace_search_field')
             return
 
         if (!inputChange) {

--- a/modules/system/assets/ui/js/input.monitor.js
+++ b/modules/system/assets/ui/js/input.monitor.js
@@ -76,7 +76,7 @@
 
         if (!inputChange) {
             var type = $(ev.target).attr('type')
-            if (type == 'text' || type == "password")
+            if (type === 'text' || type === 'password')
                 return
         }
 
@@ -101,7 +101,7 @@
             return
 
         var $el = $(ev.target)
-        if ($el.data('oldval.oc.changeMonitor') != $el.val()) {
+        if ($el.data('oldval.oc.changeMonitor') !== $el.val()) {
 
             $el.data('oldval.oc.changeMonitor', $el.val());
             this.change(ev, true);
@@ -134,7 +134,7 @@
         return this.each(function () {
             var $this = $(this)
             var data  = $this.data('oc.changeMonitor')
-            var options = $.extend({}, ChangeMonitor.DEFAULTS, $this.data(), typeof option == 'object' && option)
+            var options = $.extend({}, ChangeMonitor.DEFAULTS, $this.data(), typeof option === 'object' && option)
 
             if (!data) $this.data('oc.changeMonitor', (data = new ChangeMonitor(this, options)))
         })

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3979,8 +3979,8 @@ ChangeMonitor.prototype.init=function(){this.$el.on('change',this.proxy(this.cha
 this.$el.on('unchange.oc.changeMonitor',this.proxy(this.unchange))
 this.$el.on('pause.oc.changeMonitor',this.proxy(this.pause))
 this.$el.on('resume.oc.changeMonitor',this.proxy(this.resume))
-this.$el.on('keyup input paste','input, textarea:not(.ace_text-input)',this.proxy(this.onInputChange))
-$('input:not([type=hidden]), textarea:not(.ace_text-input)',this.$el).each(function(){$(this).data('oldval.oc.changeMonitor',$(this).val());})
+this.$el.on('keyup input paste','input:not(.ace_search_field), textarea:not(.ace_text-input)',this.proxy(this.onInputChange))
+$('input:not([type=hidden]):not(.ace_search_field), textarea:not(.ace_text-input)',this.$el).each(function(){$(this).data('oldval.oc.changeMonitor',$(this).val());})
 if(this.options.windowCloseConfirm)
 $(window).on('beforeunload',this.proxy(this.onBeforeUnload))
 this.$el.one('dispose-control',this.proxy(this.dispose))
@@ -3996,14 +3996,16 @@ ChangeMonitor.prototype.unregisterHandlers=function(){this.$el.off('change',this
 this.$el.off('unchange.oc.changeMonitor',this.proxy(this.unchange))
 this.$el.off('pause.oc.changeMonitor ',this.proxy(this.pause))
 this.$el.off('resume.oc.changeMonitor ',this.proxy(this.resume))
-this.$el.off('keyup input paste','input, textarea:not(.ace_text-input)',this.proxy(this.onInputChange))
+this.$el.off('keyup input paste','input:not(.ace_search_field), textarea:not(.ace_text-input)',this.proxy(this.onInputChange))
 this.$el.off('dispose-control',this.proxy(this.dispose))
 if(this.options.windowCloseConfirm)
 $(window).off('beforeunload',this.proxy(this.onBeforeUnload))}
 ChangeMonitor.prototype.change=function(ev,inputChange){if(this.paused)
 return
+if(ev.target.className==='ace_search_field')
+return
 if(!inputChange){var type=$(ev.target).attr('type')
-if(type=='text'||type=="password")
+if(type==='text'||type==='password')
 return}
 if(!this.$el.hasClass('oc-data-changed')){this.$el.trigger('changed.oc.changeMonitor')
 this.$el.addClass('oc-data-changed')}}
@@ -4014,7 +4016,7 @@ this.$el.removeClass('oc-data-changed')}}
 ChangeMonitor.prototype.onInputChange=function(ev){if(this.paused)
 return
 var $el=$(ev.target)
-if($el.data('oldval.oc.changeMonitor')!=$el.val()){$el.data('oldval.oc.changeMonitor',$el.val());this.change(ev,true);}}
+if($el.data('oldval.oc.changeMonitor')!==$el.val()){$el.data('oldval.oc.changeMonitor',$el.val());this.change(ev,true);}}
 ChangeMonitor.prototype.pause=function(){this.paused=true}
 ChangeMonitor.prototype.resume=function(){this.paused=false}
 ChangeMonitor.prototype.onBeforeUnload=function(){if($.contains(document.documentElement,this.$el.get(0))&&this.$el.hasClass('oc-data-changed'))
@@ -4023,7 +4025,7 @@ ChangeMonitor.DEFAULTS={windowCloseConfirm:false}
 var old=$.fn.changeMonitor
 $.fn.changeMonitor=function(option){return this.each(function(){var $this=$(this)
 var data=$this.data('oc.changeMonitor')
-var options=$.extend({},ChangeMonitor.DEFAULTS,$this.data(),typeof option=='object'&&option)
+var options=$.extend({},ChangeMonitor.DEFAULTS,$this.data(),typeof option==='object'&&option)
 if(!data)$this.data('oc.changeMonitor',(data=new ChangeMonitor(this,options)))})}
 $.fn.changeMonitor.Constructor=ChangeMonitor
 $.fn.changeMonitor.noConflict=function(){$.fn.changeMonitor=old


### PR DESCRIPTION
Fix for issue #946

Changes:
-  Removed ace_search_field from tracking by input.monitor
-  Minor code style cleanup

Working example (gif):
![oct-07-2018 19-57-59](https://user-images.githubusercontent.com/1053320/46812497-80c80b80-cd7d-11e8-84f3-a4a62e74ffe2.gif)
