### PR TITLE
Service Workers Invalid security token and Clear Site Data Security Headers

### DIFF
--- a/modules/backend/assets/js/auth/unistall-sw.js
+++ b/modules/backend/assets/js/auth/unistall-sw.js
@@ -1,0 +1,11 @@
+// Unistall a Service Worker before a User Signs in to prevent cache issues
+navigator.serviceWorker.getRegistrations().then(
+
+    function(registrations) {
+
+        for(let registration of registrations) {  
+            registration.unregister();
+
+        }
+
+});

--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -32,6 +32,10 @@ class Auth extends Controller
     public function __construct()
     {
         parent::__construct();
+		
+		// Add JS File to unistall SW to avoid Cookie Cache Issues when Signin, see github issue: #3707
+		$this->addJs('../../../modules/backend/assets/js/auth/unistall-sw.js');
+		
         $this->layout = 'auth';
     }
 
@@ -40,6 +44,9 @@ class Auth extends Controller
      */
     public function index()
     {
+		// Add Middleware to Clear Cache and Cookies before Signin, see github issue: #3707
+		$this->middleware(\Backend\Middleware\ClearSiteDataSignIn::class);
+		
         return Backend::redirect('backend/auth/signin');
     }
 
@@ -105,6 +112,10 @@ class Auth extends Controller
     public function signout()
     {
         BackendAuth::logout();
+		
+		// Add Middleware to Clear Cache all Data after Signout (securiity protection), see github issue: #3707
+		$this->middleware(\Backend\Middleware\ClearSiteDataSignOut::class);		
+		
         return Backend::redirect('backend');
     }
 

--- a/modules/backend/middleware/ClearSiteDataSignIn.php
+++ b/modules/backend/middleware/ClearSiteDataSignIn.php
@@ -1,0 +1,39 @@
+<?php namespace Backend\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Response;
+
+/**
+ * Clear the Cache and Cookies Before Signin
+ * We are using the W3c Clear Site Data API Header
+ * For more details see here: https://www.w3.org/TR/clear-site-data/
+ * Relates to github Issue: https://github.com/octobercms/october/issues/3707
+ *
+ * @package october\backend
+ * @author Alexey Bobkov, Samuel Georges
+ */
+class ClearSiteDataSignIn
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $response = $next($request);
+
+        if (!$response instanceof SymfonyResponse) {
+            $response = new Response($response);
+        }
+
+        $response->headers->set('Clear-Site-Data', 'cache, cookies');
+		
+        return $response;
+
+    }
+}

--- a/modules/backend/middleware/ClearSiteDataSignOut.php
+++ b/modules/backend/middleware/ClearSiteDataSignOut.php
@@ -1,0 +1,41 @@
+<?php namespace Backend\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Response;
+
+/**
+ * Clear the Cache and Cookies After Signout
+ * We are using the W3c Clear Site Data API Header
+ * For more details see here: https://www.w3.org/TR/clear-site-data/#example-signout
+ * Relates to github Issue: https://github.com/octobercms/october/issues/3707
+ *
+ * @package october\backend
+ * @author Alexey Bobkov, Samuel Georges
+ */
+class ClearSiteDataSignOut
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $response = $next($request);
+
+        if (!$response instanceof SymfonyResponse) {
+            $response = new Response($response);
+        }
+		
+		$response = $next($request);
+
+        	$response->headers->set('Clear-Site-Data', 'cache, cookies, storage, executionContexts');
+		
+        return $response;
+
+    }
+}


### PR DESCRIPTION
If a website has a Service Worker installed it would load and register before a User tries to login to the backend causing a "Invalid security token" message. This PR unregisters any installed Service Worker when a User opens the backend Signin webpage.

I have also added the NEW Security Headers to add Protection to October's Cache and Cookies. This includes two new Middleware that first clears any bad cached data before a User tries to login and the second Middleware will clear all the sensitive User Data when a User signs out of the Backend.

For more info on the new Security Header 'Clear Site Data' you can see the spec found here: https://www.w3.org/TR/clear-site-data/

This PR relates to the Github Issue found here: https://github.com/octobercms/october/issues/3707
