### PR TITLE
[UX] Tab Icons

### DIFF
--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -70,12 +70,7 @@ class FormField
      * @var string Specifies if this field belongs to a tab.
      */
     public $tab;
-    
-    /**
-     * @var string Specifies an icon to use for a tab.
-     */
-    public $tabIcon;
-    
+
     /**
      * @var string Display mode. Text, textarea
      */
@@ -200,16 +195,7 @@ class FormField
         $this->tab = $value;
         return $this;
     }
-    
-    /**
-     * Icon to use for a tab.
-     */
-    public function tabIcon($value)
-    {
-        $this->tabIcon = $value;
-        return $this;
-    }
-    
+
     /**
      * Sets a side of the field on a form.
      * @param string $value Specifies a side. Possible values: left, right, full
@@ -324,9 +310,6 @@ class FormField
         }
         if (isset($config['tab'])) {
             $this->tab($config['tab']);
-        }
-        if (isset($config['tabIcon'])) {
-            $this->tabIcon($config['tabIcon']);
         }
         if (isset($config['commentAbove'])) {
             $this->comment($config['commentAbove'], 'above');

--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -70,7 +70,12 @@ class FormField
      * @var string Specifies if this field belongs to a tab.
      */
     public $tab;
-
+    
+    /**
+     * @var string Specifies an icon to use for a tab.
+     */
+    public $tabIcon;
+    
     /**
      * @var string Display mode. Text, textarea
      */
@@ -195,7 +200,16 @@ class FormField
         $this->tab = $value;
         return $this;
     }
-
+    
+    /**
+     * Icon to use for a tab.
+     */
+    public function tabIcon($value)
+    {
+        $this->tabIcon = $value;
+        return $this;
+    }
+    
     /**
      * Sets a side of the field on a form.
      * @param string $value Specifies a side. Possible values: left, right, full
@@ -310,6 +324,9 @@ class FormField
         }
         if (isset($config['tab'])) {
             $this->tab($config['tab']);
+        }
+        if (isset($config['tabIcon'])) {
+            $this->tabIcon($config['tabIcon']);
         }
         if (isset($config['commentAbove'])) {
             $this->comment($config['commentAbove'], 'above');

--- a/modules/backend/classes/FormTabs.php
+++ b/modules/backend/classes/FormTabs.php
@@ -173,7 +173,23 @@ class FormTabs implements IteratorAggregate, ArrayAccess
 
         return $tablessFields;
     }
-
+    
+    /**
+     * Returns the first instance of a tab icon in a collection for a tab.
+     * @param string $name
+     * @return string
+     */
+    public function getIcon($name)
+    {
+        foreach ($this->fields as $tab => $fields) {
+            foreach ($fields as $fieldName => $field) {
+                if ($field->tab == $name && !empty($field->tabIcon)) {
+                    return $field->tabIcon;
+                }
+            }
+        }
+    }
+    
     /**
      * Returns a tab pane CSS class.
      * @param string $index

--- a/modules/backend/classes/FormTabs.php
+++ b/modules/backend/classes/FormTabs.php
@@ -31,7 +31,12 @@ class FormTabs implements IteratorAggregate, ArrayAccess
      * @var string Default tab label to use when none is specified.
      */
     public $defaultTab = 'backend::lang.form.undefined_tab';
-
+    
+    /**
+     * @var string List of icons for their corresponding tabs.
+     */
+    public $icons;
+    
     /**
      * @var bool Should these tabs stretch to the bottom of the page layout.
      */
@@ -81,7 +86,11 @@ class FormTabs implements IteratorAggregate, ArrayAccess
         if (array_key_exists('defaultTab', $config)) {
             $this->defaultTab = $config['defaultTab'];
         }
-
+        
+        if (array_key_exists('icons', $config)) {
+            $this->icons = $config['icons'];
+        }
+        
         if (array_key_exists('stretch', $config)) {
             $this->stretch = $config['stretch'];
         }
@@ -175,19 +184,13 @@ class FormTabs implements IteratorAggregate, ArrayAccess
     }
     
     /**
-     * Returns the first instance of a tab icon in a collection for a tab.
+     * Returns an icon for the tab based on the tab's name.
      * @param string $name
      * @return string
      */
     public function getIcon($name)
     {
-        foreach ($this->fields as $tab => $fields) {
-            foreach ($fields as $fieldName => $field) {
-                if ($field->tab == $name && !empty($field->tabIcon)) {
-                    return $field->tabIcon;
-                }
-            }
-        }
+        return $this->icons[$name];
     }
     
     /**

--- a/modules/backend/classes/FormTabs.php
+++ b/modules/backend/classes/FormTabs.php
@@ -190,7 +190,9 @@ class FormTabs implements IteratorAggregate, ArrayAccess
      */
     public function getIcon($name)
     {
-        return $this->icons[$name];
+        if(!empty($this->icons[$name])) {
+            return $this->icons[$name];
+        }
     }
     
     /**

--- a/modules/backend/classes/FormTabs.php
+++ b/modules/backend/classes/FormTabs.php
@@ -33,9 +33,9 @@ class FormTabs implements IteratorAggregate, ArrayAccess
     public $defaultTab = 'backend::lang.form.undefined_tab';
     
     /**
-     * @var string List of icons for their corresponding tabs.
+     * @var array List of icons for their corresponding tabs.
      */
-    public $icons;
+    public $icons = [];
     
     /**
      * @var bool Should these tabs stretch to the bottom of the page layout.

--- a/modules/backend/widgets/form/partials/_form_tabs.htm
+++ b/modules/backend/widgets/form/partials/_form_tabs.htm
@@ -15,7 +15,7 @@
     <ul class="nav nav-tabs">
         <?php $index = 0; foreach ($tabs as $name => $fields): ?>
             <li class="<?= $index++==0?'active':''?>">
-                <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><span class="oc-<?= $tabs->getIcon($name) ?>"></span><?php endif; ?><?= e(trans($name)) ?></a>
+                <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><span class="<?= $tabs->getIcon($name) ?>"></span><?php endif; ?><?= e(trans($name)) ?></a>
             </li>
         <?php endforeach ?>
     </ul>

--- a/modules/backend/widgets/form/partials/_form_tabs.htm
+++ b/modules/backend/widgets/form/partials/_form_tabs.htm
@@ -14,7 +14,9 @@
 <div class="<?= $navCss ?>">
     <ul class="nav nav-tabs">
         <?php $index = 0; foreach ($tabs as $name => $fields): ?>
+        <li class="<?= $index++==0?'active':''?>">
             <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><i class="oc-<?= $tabs->getIcon($name) ?>"></i><?php endif; ?><?= e(trans($name)) ?></a>
+        </li>
         <?php endforeach ?>
     </ul>
 </div>

--- a/modules/backend/widgets/form/partials/_form_tabs.htm
+++ b/modules/backend/widgets/form/partials/_form_tabs.htm
@@ -14,9 +14,9 @@
 <div class="<?= $navCss ?>">
     <ul class="nav nav-tabs">
         <?php $index = 0; foreach ($tabs as $name => $fields): ?>
-        <li class="<?= $index++==0?'active':''?>">
-            <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><i class="oc-<?= $tabs->getIcon($name) ?>"></i><?php endif; ?><?= e(trans($name)) ?></a>
-        </li>
+            <li class="<?= $index++==0?'active':''?>">
+                <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><i class="oc-<?= $tabs->getIcon($name) ?>"></i><?php endif; ?><?= e(trans($name)) ?></a>
+            </li>
         <?php endforeach ?>
     </ul>
 </div>

--- a/modules/backend/widgets/form/partials/_form_tabs.htm
+++ b/modules/backend/widgets/form/partials/_form_tabs.htm
@@ -15,7 +15,7 @@
     <ul class="nav nav-tabs">
         <?php $index = 0; foreach ($tabs as $name => $fields): ?>
             <li class="<?= $index++==0?'active':''?>">
-                <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><i class="oc-<?= $tabs->getIcon($name) ?>"></i><?php endif; ?><?= e(trans($name)) ?></a>
+                <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><span class="oc-<?= $tabs->getIcon($name) ?>"></span><?php endif; ?><?= e(trans($name)) ?></a>
             </li>
         <?php endforeach ?>
     </ul>

--- a/modules/backend/widgets/form/partials/_form_tabs.htm
+++ b/modules/backend/widgets/form/partials/_form_tabs.htm
@@ -14,7 +14,7 @@
 <div class="<?= $navCss ?>">
     <ul class="nav nav-tabs">
         <?php $index = 0; foreach ($tabs as $name => $fields): ?>
-            <li class="<?= $index++==0?'active':''?>"><a href="#<?= $type.'tab-'.$index ?>"><?= e(trans($name)) ?></a></li>
+            <a href="#<?= $type.'tab-'.$index ?>"><?php if ($tabs->getIcon($name)): ?><i class="oc-<?= $tabs->getIcon($name) ?>"></i><?php endif; ?><?= e(trans($name)) ?></a>
         <?php endforeach ?>
     </ul>
 </div>

--- a/modules/system/assets/ui/less/tab.less
+++ b/modules/system/assets/ui/less/tab.less
@@ -110,6 +110,9 @@
                     border-top: 2px solid @color-tab-border;
                     margin-top: -4px;
                     padding-top: 7px;
+                    > span:not([class*="oc-"]) {
+                        margin-right: 8px;
+                    }                    
                 }
             }
 

--- a/modules/system/assets/ui/less/tab.less
+++ b/modules/system/assets/ui/less/tab.less
@@ -110,7 +110,7 @@
                     border-top: 2px solid @color-tab-border;
                     margin-top: -4px;
                     padding-top: 7px;
-                    > span:not([class*="oc-"]) {
+                    > span:not([class*="oc-icon"]) {
                         margin-right: 8px;
                     }                    
                 }


### PR DESCRIPTION
The way the tabs are currently used seems to be fine with me. There is this issue here: https://github.com/octobercms/october/issues/3856

Follwoing @LukeTowers advice the way it works is:

```
tabs:
     icons:
          'tab name here': 'icon-class-here'
     fields:
         test:
             label: test
             tab: 'tab name here'
````

also added it in the docs: https://github.com/octobercms/docs/pull/330