### PR TITLE
Text Display issue

### DIFF
--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -282,7 +282,6 @@
         span {
             z-index: @zindex-checkbox;
             display: block;
-            width: 50%;
             position: absolute;
             top: 2px;
             left: -1px;


### PR DESCRIPTION
present on firefox and chrome the "Yes" text cuts off because of the width limit of the span
![](https://i.imgur.com/lwzxovH.png)