### PR TITLE
Fix resize event after element removal

### DIFF
--- a/modules/system/assets/ui/js/popover.js
+++ b/modules/system/assets/ui/js/popover.js
@@ -117,7 +117,9 @@
         this.reposition()
 
         $(window).on('resize.popoverReposition', function() {
-            self.reposition()
+            if (self.$container) {
+                self.reposition()
+            }
         })
 
         /*

--- a/modules/system/assets/ui/js/popover.js
+++ b/modules/system/assets/ui/js/popover.js
@@ -41,6 +41,7 @@
     }
 
     Popover.prototype.hidePopover = function() {
+        $(window).off('resize.popoverReposition')
         this.$container.remove();
         if (this.$overlay) this.$overlay.remove()
 
@@ -115,7 +116,7 @@
          */
         this.reposition()
 
-        $(window).on('resize', function(e) {
+        $(window).on('resize.popoverReposition', function() {
             self.reposition()
         })
 

--- a/modules/system/assets/ui/js/popover.js
+++ b/modules/system/assets/ui/js/popover.js
@@ -41,7 +41,6 @@
     }
 
     Popover.prototype.hidePopover = function() {
-        $(window).off('resize.popoverReposition')
         this.$container.remove();
         if (this.$overlay) this.$overlay.remove()
 
@@ -116,7 +115,7 @@
          */
         this.reposition()
 
-        $(window).on('resize.popoverReposition', function() {
+        $(window).on('resize', function() {
             if (self.$container) {
                 self.reposition()
             }


### PR DESCRIPTION
This prevents an error from popping up after the popover is hidden/removed `this.$container` is no longer available after removal so we need to unbind the `resize` event before that happens. Also gave the resize event a namespace so that it wouldn't unbind "all" `$('window')` resize events.

@LukeTowers :)