### PR TITLE
fix hide event firing twice

### DIFF
--- a/modules/system/assets/ui/js/popup.js
+++ b/modules/system/assets/ui/js/popup.js
@@ -274,7 +274,6 @@
         // Wait for animations to complete
         var self = this
         setTimeout(function() { self.setBackdrop(false) }, 250)
-        setTimeout(function() { self.hide() }, 500)
     }
 
     Popup.prototype.triggerEvent = function(eventName, params) {


### PR DESCRIPTION
the setTimeout fires after the modal already hides so it ends up firing twice which causes an error cause the element's no longer there

this is the error:
```
Uncaught TypeError: Cannot read property 'get' of null
    at Popup.triggerEvent (storm-min.js?v443:3732)
    at Popup.hide (storm-min.js?v443:3741)
    at storm-min.js?v443:3730
```

Present in the Master and Development branch
@LukeTowers :)