### PR TITLE
FormWidget TagList add handler onPaginationMore

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -47,6 +47,8 @@ class TagList extends FormWidgetBase
      */
     public $useKey = false;
 
+    public $perpage = 10;
+
     //
     // Object properties
     //
@@ -161,7 +163,12 @@ class TagList extends FormWidgetBase
         $options = $this->formField->options();
 
         if (!$options && $this->mode === static::MODE_RELATION) {
-            $options = $this->getRelationModel()->lists($this->nameFrom);
+
+            $options = $this->getRelationModel()
+                            ->where($this->nameFrom, 'like', post('q') .'%')
+                            ->skip( intval(post('page', 1)) * $this->perpage )
+                            ->limit($this->perpage)
+                            ->lists($this->nameFrom);
         }
 
         return $options;
@@ -196,4 +203,18 @@ class TagList extends FormWidgetBase
         }
     }
 
+    public function onPaginationMore() {
+
+        $resp = [ "results" => [], "pagination" => [ "more" => true ] ];
+
+        if( $options = $this->getFieldOptions() ) {
+
+            foreach ($options as $option) {
+
+                $resp["results"][] = [ "id" => $option, "text" => $option ];
+            }
+        }
+
+        return $resp;
+    }
 }

--- a/modules/backend/formwidgets/taglist/partials/_taglist.htm
+++ b/modules/backend/formwidgets/taglist/partials/_taglist.htm
@@ -6,6 +6,7 @@
 <select
     id="<?= $field->getId() ?>"
     name="<?= $field->getName() ?>[]"
+    data-handler="onPaginationMore"
     class="form-control custom-select <?= !count($fieldOptions) ? 'select-no-dropdown' : '' ?> select-hide-selected"
     <?php if ($customSeparators): ?>data-token-separators="<?= $customSeparators ?>"<?php endif ?>
     multiple


### PR DESCRIPTION
At the moment we are faced with the problem of a complete selection of tags instead of partial. Because of this, the search for tags takes too much.
In this pool request, we implemented automatic tag loading by parts when scrolling through the list.

This version fully compatible to previous