### PR TITLE
Modfied error maker with extra funcitonality

### DIFF
--- a/modules/backend/traits/ErrorMaker.php
+++ b/modules/backend/traits/ErrorMaker.php
@@ -17,6 +17,22 @@ trait ErrorMaker
     protected $fatalError;
 
     /**
+     * @return boolean Wether a fatal error has been set or not.
+     */
+    public function hasFatalError() 
+    {
+        return !is_null($this->fatalError); 
+    }
+    
+    /**
+     * @return string The fatal error message
+     */
+    public function getFatalError() 
+    {
+       return $this->fatalError;
+    }
+    
+    /**
      * Sets standard page variables in the case of a controller error.
      */
     public function handleError($exception)


### PR DESCRIPTION
For my integration unit tests I had some failing due to a fatal error.
The only way to detected this is to check if the `$controller->vars['fatalError']` had been set which is not very elegant.

This would be more elegant, by allowing a simple call `$controller->hasFatalError()` because the status of some controllers with fatal errors is still 200.

