### PR TITLE
Add alias for jquery migrate (fixes #3917)

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -148,6 +148,7 @@ class CombineAssets
          * Common Aliases
          */
         $this->registerAlias('jquery', '~/modules/backend/assets/js/vendor/jquery.min.js');
+        $this->registerAlias('jquery.migrate', '~/modules/backend/assets/js/vendor/jquery.min.js');
         $this->registerAlias('framework', '~/modules/system/assets/js/framework.js');
         $this->registerAlias('framework.extras', '~/modules/system/assets/js/framework.extras.js');
         $this->registerAlias('framework.extras', '~/modules/system/assets/css/framework.extras.css');


### PR DESCRIPTION
This fixes the double alias that was introduced when jquery was updated and migrate was added.