### PR TITLE
Escape output to prevent XSS injections

### DIFF
--- a/modules/backend/behaviors/reordercontroller/partials/_records.htm
+++ b/modules/backend/behaviors/reordercontroller/partials/_records.htm
@@ -7,7 +7,7 @@
     >
         <div class="record">
             <a href="javascript:;" class="move"></a>
-            <span><?= $this->reorderGetRecordName($record) ?></span>
+            <span><?= e($this->reorderGetRecordName($record)) ?></span>
             <input name="record_ids[]" type="hidden" value="<?= $record->getKey() ?>" />
         </div>
 

--- a/modules/backend/widgets/search/partials/_search.htm
+++ b/modules/backend/widgets/search/partials/_search.htm
@@ -3,7 +3,7 @@
         placeholder="<?= $placeholder ?>"
         type="text"
         name="<?= $this->getName() ?>"
-        value="<?= $value ?>"
+        value="<?= e($value) ?>"
         data-request="<?= $this->getEventHandler('onSubmit') ?>"
         <?= !$searchOnEnter ? 'data-track-input' : '' ?>
         data-load-indicator

--- a/modules/system/controllers/maillayouts/update.htm
+++ b/modules/system/controllers/maillayouts/update.htm
@@ -14,7 +14,7 @@
                 <div data-control="toolbar">
                     <div class="scoreboard-item title-value">
                         <h4><?= e(trans('system::lang.mail_templates.layout')) ?></h4>
-                        <p><?= $formModel->code ?></p>
+                        <p><?= e($formModel->code) ?></p>
                     </div>
                 </div>
             </div>

--- a/modules/system/controllers/mailpartials/update.htm
+++ b/modules/system/controllers/mailpartials/update.htm
@@ -14,7 +14,7 @@
                 <div data-control="toolbar">
                     <div class="scoreboard-item title-value">
                         <h4><?= e(trans('system::lang.mail_templates.partial')) ?></h4>
-                        <p><?= $formModel->code ?></p>
+                        <p><?= e($formModel->code) ?></p>
                     </div>
                 </div>
             </div>

--- a/modules/system/controllers/mailtemplates/update.htm
+++ b/modules/system/controllers/mailtemplates/update.htm
@@ -14,7 +14,7 @@
                 <div data-control="toolbar">
                     <div class="scoreboard-item title-value">
                         <h4><?= e(trans('system::lang.mail_templates.template')) ?></h4>
-                        <p><?= $formModel->code ?></p>
+                        <p><?= e($formModel->code) ?></p>
                     </div>
                 </div>
             </div>

--- a/modules/system/controllers/requestlogs/_referer_field.htm
+++ b/modules/system/controllers/requestlogs/_referer_field.htm
@@ -2,7 +2,7 @@
     <div class="form-control control-simplelist with-icons">
         <ul>
             <?php foreach ((array) $formModel->referer as $referer): ?>
-                <li class="oc-icon-file-o"><?= $referer ?></li>
+                <li class="oc-icon-file-o"><?= e($referer) ?></li>
             <?php endforeach ?>
         </ul>
     </div>


### PR DESCRIPTION
Another commit with some escaping to prevent / minimize XSS injections.

I came across a serious security flaw, the 1 with the referer (see file changes); It enables **ANY** user to inject an XSS payload to the backend by modifying the referer header in the request (not very hard to exploit).

I came across an (old) issue today (https://github.com/octobercms/october/issues/2465). I totally agree that we should use a template engine like Twig in the backend since it prevents XSS injections in many cases (by default). (not saying it's the holy grail)

At this moment many input values / variables are not escaped in the backend, I am sure there are more XSS vulnerabilities in OctoberCMS after this & previous commit I made.

Besides OctoberCMS having XSS vulnerabilities in it's core (referer / reorder vulnerabilties) many developers will create plugins which are also vulnerable since it's very easy to forget the **e()** function in templates. This will result in a market place full of vulnerable plugins, I checked some of the top plugins and found out that some of them are vulnerable to XSS injections.