### PR TITLE
add file specific aliases (resolves #3909)

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -150,7 +150,9 @@ class CombineAssets
         $this->registerAlias('jquery', '~/modules/backend/assets/js/vendor/jquery-and-migrate.min.js');
         $this->registerAlias('framework', '~/modules/system/assets/js/framework.js');
         $this->registerAlias('framework.extras', '~/modules/system/assets/js/framework.extras.js');
+        $this->registerAlias('framework.extras.js', '~/modules/system/assets/js/framework.extras.js');
         $this->registerAlias('framework.extras', '~/modules/system/assets/css/framework.extras.css');
+        $this->registerAlias('framework.extras.css', '~/modules/system/assets/css/framework.extras.css');
 
         /*
          * Deferred registration


### PR DESCRIPTION
This pull request adds two new aliases for the files associated with `framework.extras`. This resolves the issue that when using the alias as a single entry in the combiner, it always loads the `js` files, as the combiner can not determine the correct filetype without any other files.