### PR TITLE
Revert changes made to self.hide after ajax

### DIFF
--- a/modules/system/assets/ui/js/popup.js
+++ b/modules/system/assets/ui/js/popup.js
@@ -274,6 +274,7 @@
         // Wait for animations to complete
         var self = this
         setTimeout(function() { self.setBackdrop(false) }, 250)
+        setTimeout(function() { self.hide() }, 500)
     }
 
     Popup.prototype.triggerEvent = function(eventName, params) {


### PR DESCRIPTION
This is needed as it removes leftover control-popover backdrops in any plugin backend that utilizes ajax in a popup modal (which is any of them that has relations or nested relations), so we will need to take a look at the dashboard widgets again.