### PR TITLE
Fix max & min items is repeater when using groups

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -84,7 +84,7 @@
     }
 
     Repeater.prototype.clickAddGroupButton = function(ev) {
-        var  $self = this;
+        var $self = this;
         var templateHtml = $('> [data-group-palette-template]', this.$el).html(),
             $target = $(ev.target),
             $form = this.$el.closest('form'),

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -84,6 +84,7 @@
     }
 
     Repeater.prototype.clickAddGroupButton = function(ev) {
+        var  $self = this;
         var templateHtml = $('> [data-group-palette-template]', this.$el).html(),
             $target = $(ev.target),
             $form = this.$el.closest('form'),
@@ -107,6 +108,7 @@
 
                 $form.one('ajaxComplete', function() {
                     $loadContainer.loadIndicator('hide')
+                    $self.togglePrompt()
                 })
             })
 


### PR DESCRIPTION
Updated repeater when using the grouped functionality after adding the item was not removing the add more prompt if max-Items where reached.