### PR TITLE
Prevent plugins that cannot be instantiated from being loaded

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -11,7 +11,6 @@ use Schema;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use ApplicationException;
-use System\Models\EventLog;
 
 /**
  * Plugin manager

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -11,6 +11,7 @@ use Schema;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use ApplicationException;
+use System\Models\EventLog;
 
 /**
  * Plugin manager
@@ -121,17 +122,22 @@ class PluginManager
         $className = $namespace.'\Plugin';
         $classPath = $path.'/Plugin.php';
 
-        // Autoloader failed?
-        if (!class_exists($className)) {
-            include_once $classPath;
-        }
+        try {
+            // Autoloader failed?
+            if (!class_exists($className)) {
+                include_once $classPath;
+            }
 
-        // Not a valid plugin!
-        if (!class_exists($className)) {
+            // Not a valid plugin!
+            if (!class_exists($className)) {
+                return;
+            }
+
+            $classObj = new $className($this->app);
+        } catch (\Throwable $e) {
             return;
         }
 
-        $classObj = new $className($this->app);
         $classId = $this->getIdentifier($classObj);
 
         /*

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -5,6 +5,7 @@ use App;
 use Str;
 use File;
 use Lang;
+use Log;
 use View;
 use Config;
 use Schema;
@@ -134,6 +135,12 @@ class PluginManager
 
             $classObj = new $className($this->app);
         } catch (\Throwable $e) {
+            Log::error('Plugin ' . $className . ' could not be instantiated.', [
+                'message' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => $e->getTraceAsString()
+            ]);
             return;
         }
 

--- a/tests/fixtures/plugins/testvendor/goto/Plugin.php
+++ b/tests/fixtures/plugins/testvendor/goto/Plugin.php
@@ -1,0 +1,16 @@
+<?php namespace TestVendor\Goto;
+
+use System\Classes\PluginBase;
+
+class Plugin extends PluginBase
+{
+
+    public function pluginDetails()
+    {
+        return [
+            'name' => 'Invalid Test Plugin',
+            'description' => 'Test plugin used by unit tests to detect plugins with invalid namespaces.',
+            'author' => 'Test Vendor'
+        ];
+    }
+}

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -58,12 +58,21 @@ class PluginManagerTest extends TestCase
         $this->assertArrayHasKey('October.Tester', $result);
         $this->assertArrayHasKey('Database.Tester', $result);
         $this->assertArrayHasKey('TestVendor.Test', $result);
+        $this->assertArrayNotHasKey('TestVendor.Goto', $result);
 
         $this->assertInstanceOf('October\NoUpdates\Plugin', $result['October.NoUpdates']);
         $this->assertInstanceOf('October\Sample\Plugin', $result['October.Sample']);
         $this->assertInstanceOf('October\Tester\Plugin', $result['October.Tester']);
         $this->assertInstanceOf('Database\Tester\Plugin', $result['Database.Tester']);
         $this->assertInstanceOf('TestVendor\Test\Plugin', $result['TestVendor.Test']);
+    }
+
+    public function testUnloadablePlugin()
+    {
+        $manager = PluginManager::instance();
+        $pluginNamespaces = $manager->getPluginNamespaces();
+        $result = $manager->loadPlugin('\\testvendor\\goto', $pluginNamespaces['\\testvendor\\goto']);
+        $this->assertNull($result);
     }
 
     public function testGetPluginPath()
@@ -85,6 +94,7 @@ class PluginManagerTest extends TestCase
         $this->assertArrayHasKey('October.Tester', $result);
         $this->assertArrayHasKey('Database.Tester', $result);
         $this->assertArrayHasKey('TestVendor.Test', $result);
+        $this->assertArrayNotHasKey('TestVendor.Goto', $result);
 
         $this->assertInstanceOf('October\NoUpdates\Plugin', $result['October.NoUpdates']);
         $this->assertInstanceOf('October\Sample\Plugin', $result['October.Sample']);
@@ -115,12 +125,13 @@ class PluginManagerTest extends TestCase
         $manager = PluginManager::instance();
         $result = $manager->getPluginNamespaces();
 
-        $this->assertCount(5, $result);
+        $this->assertCount(6, $result);
         $this->assertArrayHasKey('\october\noupdates', $result);
         $this->assertArrayHasKey('\october\sample', $result);
         $this->assertArrayHasKey('\october\tester', $result);
         $this->assertArrayHasKey('\database\tester', $result);
         $this->assertArrayHasKey('\testvendor\test', $result);
+        $this->assertArrayHasKey('\testvendor\goto', $result);
     }
 
     public function testGetVendorAndPluginNames()


### PR DESCRIPTION
Per @LukeTowers [suggestion here](https://github.com/rainlab/builder-plugin/pull/261#issuecomment-443528752), this functionality wraps a portion of the `loadPlugin` function with a try..catch block. If, for any reason, the plugin cannot be instantiated (for example, if a parse error occurs or reserved keywords are used in the namespace), instead of bricking the site, this will simply prevent the plugin from being loaded.