### PR TITLE
Remove dead HTTP Header

### DIFF
--- a/modules/backend/layouts/_head.htm
+++ b/modules/backend/layouts/_head.htm
@@ -1,5 +1,4 @@
 <meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=0, minimal-ui">
 <meta name="robots" content="noindex">
 <meta name="apple-mobile-web-app-capable" content="yes">

--- a/modules/backend/layouts/auth.htm
+++ b/modules/backend/layouts/auth.htm
@@ -2,7 +2,6 @@
 <html lang="<?= App::getLocale() ?>" class="no-js">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=0">
         <meta name="robots" content="noindex">
         <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
The following HTTP Header is not used by any Browser anymore and so there is no need to have this line of code.

```html
<meta http-equiv="X-UA-Compatible" content="IE=edge">
```

Internet Explorer and Edge do not use this anymore and Microsoft recommend to remove this dead HTTP Header.