### PR TITLE
Don't error out if multiple rows found in a hasOne relation

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -498,6 +498,10 @@ class Lists extends WidgetBase
                     ? DbDongle::raw("group_concat(" . $sqlSelect . " separator ', ')")
                     : DbDongle::raw($sqlSelect);
 
+                if ($relationType == 'hasOne') {
+                    $countQuery->limit(1);
+                }
+
                 $joinSql = $countQuery->select($joinSql)->toSql();
 
                 $selects[] = Db::raw("(".$joinSql.") as ".$alias);


### PR DESCRIPTION
## The Issue

The Lists widget will error out if you define a hasOne relation column but multiple related records are found in the database.

## In Depth
Say I have the following two tables:
```
foo (
  id
  bar_id
  name
)

bar (
  id
)
```
My _Bar_ model defines a _hasOne_ relation to the _Foo_ model and my Bar List is displaying the relation like so:
```yaml
foo:
    label: Name
    type: relation
    relation: bar_id
    select: name
```
This will work perfectly fine unless the _foo_ table has multiple records with the same _bar_id_ in which case the Lists widget will generate the following SQL:

```sql
select 
	`bar`.*, 
	(select name from `foo` where `bar`.`id` = `foo`.`bar_id`) as `name` 
from `bar` 
order by `id` desc
```
resulting in the SQL error:
> Subquery returns more than 1 row

The list will fail to render with no visible error to the end user - it merely says no records found even if there are hundreds of records in the DB.

## Solution

This PR just checks for a hasOne relation type and limits the subquery to the first result, fixing the SQL error by returning the first matching row. This PR is backwards compatible and will not break existing installations - in fact it may slightly improve efficiency on existing installations as the DB engine doesn't need to keep looking after it's found its first result.