### PR TITLE
Possible fix for RainLab.Translate #209: saving translation data on related records

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1060,17 +1060,15 @@ class RelationController extends ControllerBehavior
         $this->forceManageMode = 'form';
         $this->beforeAjax();
         $saveData = $this->manageWidget->getSaveData();
+        $model = $this->manageWidget->model; // RainLab.Translate's MLControl sets internal translatable model state, so the same model instance used for getSaveData() must be saved
 
-        if ($this->viewMode == 'multi') {
-            $model = $this->relationModel->find($this->manageId);
-            $modelsToSave = $this->prepareModelsToSave($model, $saveData);
-            foreach ($modelsToSave as $modelToSave) {
-                $modelToSave->save(null, $this->manageWidget->getSessionKey());
-            }
+        $modelsToSave = $this->prepareModelsToSave($model, $saveData);
+        foreach ($modelsToSave as $modelToSave) {
+            $modelToSave->save(null, $this->manageWidget->getSessionKey());
         }
-        elseif ($this->viewMode == 'single') {
+
+        if ($this->viewMode == 'single') {
             $this->viewWidget->setFormValues($saveData);
-            $this->viewModel->save(null, $this->manageWidget->getSessionKey());
         }
 
         return $this->relationRefresh();


### PR DESCRIPTION
Reference rainlab/translate-plugin#209

I ran into this on a project, and this is my proposed fix. Essentially, the issue is that on a call to a `Form`  widget's `getSaveData()`,  any `MLControl` field sets up the internal translation data on the widget's model but returns only the default locale's translation as the field's save value. The RelationController then sets the save data on a separate model instance, but the internal translation data is not copied over since it's not a part of the save data, so when `save()` is called on that model, there is no translation data to save for the other locales.

I figure that either:
1. RainLab.Translate should be modified to include all translation data as part of the field save value so there's an external interface for copying everything necessary for a model. That feels like something that would likely break existing code and might end up requiring fairly extensive changes.

OR

2. RelationController can be updated to save the same model instance that has all the translation data set.

So, this PR does #2 because it doesn't seem like anything would be dependent on the current behavior. I tested it with `hasOne` and `hasMany` and it appears to do the correct thing, but I might be missing something.