### PR TITLE
Add the format parameter of the backend Lists text column type 

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1123,6 +1123,10 @@ class Lists extends WidgetBase
             $value = implode(', ', $value);
         }
 
+        if (is_string($column->format) && !empty($column->format)) {
+            $value = sprintf($column->format, $value);
+        }
+
         return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
     }
 


### PR DESCRIPTION
Fixes #3967 
Add a format parameter to the text column type of the backend Lists. So that the user can format the output text.
YAML for example:
```
expenses:
        lable: Expenses
        format: $ %.2f
```
Output:
```
$    99.00
```