### PR TITLE
Colorpicker: value input support in modals

### DIFF
--- a/modules/backend/formwidgets/ColorPicker.php
+++ b/modules/backend/formwidgets/ColorPicker.php
@@ -43,6 +43,12 @@ class ColorPicker extends FormWidgetBase
      */
     public $showAlpha = false;
 
+    /**
+     * @var string  Append Colorpicker to a parent container
+     * Use css selector to define the container
+     */
+    public $appendTo = 'body';    
+    
     //
     // Object properties
     //
@@ -61,6 +67,7 @@ class ColorPicker extends FormWidgetBase
             'availableColors',
             'allowEmpty',
             'showAlpha',
+            'appendTo',
         ]);
     }
 
@@ -83,6 +90,7 @@ class ColorPicker extends FormWidgetBase
         $this->vars['availableColors'] = $availableColors = $this->getAvailableColors();
         $this->vars['allowEmpty'] = $this->allowEmpty;
         $this->vars['showAlpha'] = $this->showAlpha;
+        $this->vars['appendTo'] = $this->appendTo;
         $this->vars['isCustomColor'] = !in_array($value, $availableColors);
     }
 

--- a/modules/backend/formwidgets/colorpicker/assets/js/colorpicker.js
+++ b/modules/backend/formwidgets/colorpicker/assets/js/colorpicker.js
@@ -28,6 +28,7 @@
     ColorPicker.DEFAULTS = {
         showAlpha: false,
         allowEmpty: false,
+        appendTo: 'body',
         dataLocker: null
     }
 
@@ -53,6 +54,7 @@
                 showInput: true,
                 showAlpha: this.options.showAlpha,
                 allowEmpty: this.options.allowEmpty,
+                appendTo: self.setContainerParent(this.options.appendTo),
                 color: this.$customColor.data('hexColor'),
                 chooseText: $.oc.lang.get('colorpicker.choose', 'Ok'),
                 cancelText: '⨯',
@@ -75,6 +77,15 @@
         }
     }
 
+    /**
+    * Set a parent element for the ColorPicker (Spectrum) container
+    * If default parent container is body but backend modal found (.control-popup.modal) set the last as a parent to address known Spectrum issue with bootstrap modals
+    * Set a custom parent element when appendTo defined in field.yaml  
+    */
+    ColorPicker.prototype.setContainerParent = function(containerParent){    
+        return ($('.control-popup.modal').length && containerParent == 'body') ? '.control-popup.modal' : containerParent
+    }   
+               
     ColorPicker.prototype.setCustomColor = function(hexColor) {
         if (this.$customColor.length) {
             this.$customColor.data('hexColor', hexColor)

--- a/modules/backend/formwidgets/colorpicker/partials/_colorpicker.htm
+++ b/modules/backend/formwidgets/colorpicker/partials/_colorpicker.htm
@@ -7,6 +7,7 @@
         data-control="colorpicker"
         <?php if ($showAlpha): ?>data-show-alpha="<?= $showAlpha ?>"<?php endif ?>
         <?php if ($allowEmpty): ?>data-allow-empty="<?= $allowEmpty ?>"<?php endif ?>
+        <?php if ($appendTo): ?>data-append-to="<?= $appendTo ?>"<?php endif ?>
         data-data-locker="#<?= $this->getId('input') ?>">
 
         <ul>


### PR DESCRIPTION
**Issue**
When using colorpicker field in the relationship manager modal window it is impossible to set value manually in the colour input field because it is locked. This make the widget useless if you need to set a custom colour in the modal window.

**Background**
The modal container has the tabindex attribute set to "-1" to prevent access to items outside the model using tab. Colorpicker creates a parent container (.sp-container) to place custom colour selection code including colour value field. By default it is appended to body. _Since it is outside the modal window it cannot be edited because of tabindex value._
The issue is a part of Spectrum, which is sitting behind Colorpicker. [They recommend to use appendTo option when working with modal dialog.](https://bgrins.github.io/spectrum/#options-appendTo) However appenTo option is not configurable through October Colorpicker. 

Note: the issue has no relation to z-index definitions as in [992](https://github.com/octobercms/october/pull/992) or [1021](https://github.com/octobercms/october/issues/1021)

**Proposed Behavior**
By default Colorpicker container is appended to body. If relationship manager modal dialog is detected the container will be appended to the modal container. If more complicated modal structure involved developer may define appendTo option in the appropriate Colorpicker field of field.yaml.
```
fields:
	bg_colour:
		label: 'Select Colour'
		showAlpha: 1
		appendTo: '#mymodal'
		type: colorpicker
```
Setting appendTo is not required for standard October backend environment including relationship manager modal. It will be handled behind the scene.

**Solution**

1. Update colorpicker.js, ColorPicker.php and _colorpicker.htm to support appendTo option
2. Use a special function in colorpicker.js to set standard or custom parent container

**Testing**
It is pretty simple update. I have tested it on my stuff and it works reliably. The solution has no conflicts with my previous pull request [3940](https://github.com/octobercms/october/pull/3940). 
With both updates, the colorpicker is going to be finally usable in any backend context.  





