### PR TITLE
In-browser filtering/searching of files in MediaManager

### DIFF
--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager-browser-min.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager-browser-min.js
@@ -335,7 +335,9 @@ if(this.lastSearchValue!==undefined&&this.lastSearchValue==value)
 return
 this.lastSearchValue=value
 this.clearSearchTrackInputTimer()
-this.searchTrackInputTimer=window.setTimeout(this.proxy(this.updateSearchResults),300)}
+var regex1=new RegExp("^((?!"+value+").)*$")
+this.$el.find('[data-item-type="file"]').show()
+this.$el.find('[data-item-type="file"]').filter(function(){return $(this).attr('data-public-url').match(regex1)}).hide()}
 MediaManager.prototype.deleteItems=function(){var items=this.$el.get(0).querySelectorAll('[data-type="media-item"].selected')
 if(!items.length){$.oc.alert(this.options.deleteEmpty)
 return}

--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
@@ -893,7 +893,11 @@
 
         this.clearSearchTrackInputTimer()
 
-        this.searchTrackInputTimer = window.setTimeout(this.proxy(this.updateSearchResults), 300)
+        var regex1 = new RegExp("^((?!" + value + ").)*$")
+        this.$el.find('[data-item-type="file"]').show()
+        this.$el.find('[data-item-type="file"]').filter(function(){
+            return $(this).attr('data-public-url').match(regex1)
+        }).hide()
     }
 
     //


### PR DESCRIPTION
By applying this change, MediaManager would filter (search) among the already loaded files in the current directory that are listed in the DOM, instead of polling the server for each search term change. 
In my use case, when searching through a directory that contains more than a thousand files, the server breaks.

Edit:
Just to point out, my server is a dedicated Core i7 with 8 cores, 32GB RAM and SSD disk, and it breaks on filtering files. So this is much more efficient. 