### PR TITLE
Fixed the Delete and Enter key can't be captured

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -172,7 +172,6 @@
 
         this.$textarea.on('froalaEditor.initialized', this.proxy(this.build))
         this.$textarea.on('froalaEditor.contentChanged', this.proxy(this.onChange))
-        this.$textarea.on('froalaEditor.keydown', this.proxy(this.onKeydown))
         this.$textarea.on('froalaEditor.html.get', this.proxy(this.onSyncContent))
         this.$textarea.on('froalaEditor.html.set', this.proxy(this.onSetContent))
         this.$form.on('oc.beforeRequest', this.proxy(this.onFormBeforeRequest))
@@ -209,7 +208,6 @@
 
         this.$textarea.off('froalaEditor.initialized', this.proxy(this.build))
         this.$textarea.off('froalaEditor.contentChanged', this.proxy(this.onChange))
-        this.$textarea.off('froalaEditor.keydown', this.proxy(this.onKeydown))
         this.$textarea.off('froalaEditor.html.get', this.proxy(this.onSyncContent))
         this.$textarea.off('froalaEditor.html.set', this.proxy(this.onSetContent))
         this.$form.off('oc.beforeRequest', this.proxy(this.onFormBeforeRequest))
@@ -224,6 +222,8 @@
 
         $(window).on('resize', this.proxy(this.updateLayout))
         $(window).on('oc.updateUi', this.proxy(this.updateLayout))
+        
+        editor.events.on('keydown', this.proxy(this.onKeydown) , true );
 
         this.$textarea.trigger('init.oc.richeditor', [this])
     }

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -223,7 +223,8 @@
         $(window).on('resize', this.proxy(this.updateLayout))
         $(window).on('oc.updateUi', this.proxy(this.updateLayout))
         
-        editor.events.on('keydown', this.proxy(this.onKeydown) , true );
+        // Bind the keydown listener here to ensure it gets handled before the Froala handlers
+        editor.events.on('keydown', this.proxy(this.onKeydown), true)
 
         this.$textarea.trigger('init.oc.richeditor', [this])
     }


### PR DESCRIPTION
The keydown event can not capture the Backspace(Delete) and Enter key event. 

Moved the binding keydown function into froalaEditor.initialized event to solve this issue. Please review this Froala Editor issue: https://github.com/froala/wysiwyg-editor/issues/1879

The editor.events doesn't support off function. So, can not call off function in the unregisterHandlers()