### PR TITLE
Redirect user to last available page in list widget if current page is unavailable

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -210,7 +210,7 @@ class ImportExportController extends ControllerBehavior
         catch (Exception $ex) {
             $this->controller->handleError($ex);
         }
-        
+
         $this->vars['sourceIndexOffset'] = $this->getImportSourceIndexOffset($importOptions['firstRowTitles']);
 
         return $this->importExportMakePartial('import_result_form');
@@ -334,7 +334,7 @@ class ImportExportController extends ControllerBehavior
 
         return $firstRow;
     }
-    
+
     /**
      * Get the index offset to add to the reported row number in status messages
      *
@@ -627,8 +627,8 @@ class ImportExportController extends ControllerBehavior
             ? 'getColumnValueRaw'
             : 'getColumnValue';
 
-        $model = $widget->prepareModel();
-        $results = $model->get();
+        $query = $widget->prepareQuery();
+        $results = $query->get();
         foreach ($results as $result) {
             $record = [];
             foreach ($columns as $column) {

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -343,7 +343,7 @@ class Lists extends WidgetBase
     /**
      * Applies any filters to the model.
      */
-    public function prepareModel()
+    public function prepareQuery()
     {
         $query = $this->model->newQuery();
         $primaryTable = $this->model->getTable();
@@ -566,16 +566,22 @@ class Lists extends WidgetBase
         return $query;
     }
 
+    public function prepareModel()
+    {
+        traceLog('Method ' . __METHOD__ . '() has been deprecated, please use the ' . __CLASS__ . '::prepareQuery() method instead.');
+        return $this->prepareQuery();
+    }
+
     /**
      * Returns all the records from the supplied model, after filtering.
      * @return Collection
      */
     protected function getRecords()
     {
-        $model = $this->prepareModel();
+        $query = $this->prepareQuery();
 
         if ($this->showTree) {
-            $records = $model->getNested();
+            $records = $query->getNested();
         }
         elseif ($this->showPagination) {
             $method            = $this->showPageNumbers ? 'paginate' : 'simplePaginate';
@@ -584,10 +590,10 @@ class Lists extends WidgetBase
                 // Restore the last visited page from the session if available.
                 $currentPageNumber = $this->getSession('lastVisitedPage');
             }
-            $records = $model->{$method}($this->recordsPerPage, $currentPageNumber);
+            $records = $query->{$method}($this->recordsPerPage, $currentPageNumber);
         }
         else {
-            $records = $model->get();
+            $records = $query->get();
         }
 
         /**

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -585,13 +585,8 @@ class Lists extends WidgetBase
         }
         elseif ($this->showPagination) {
             $method            = $this->showPageNumbers ? 'paginate' : 'simplePaginate';
-<<<<<<< HEAD
             $currentPageNumber = $this->getCurrentPageNumber($query);
             $records = $query->{$method}($this->recordsPerPage, $currentPageNumber);
-=======
-            $currentPageNumber = $this->getCurrentPageNumber($model);
-            $records = $model->{$method}($this->recordsPerPage, $currentPageNumber);
->>>>>>> dcb609d1cffa3ba78375ad95a89d4b58d9704612
         }
         else {
             $records = $query->get();
@@ -628,17 +623,10 @@ class Lists extends WidgetBase
      *
      * This will override the current page number provided by the user if it is past the last page of available records.
      *
-<<<<<<< HEAD
      * @param object $query
      * @return int
      */
     protected function getCurrentPageNumber($query)
-=======
-     * @param object $model
-     * @return int
-     */
-    protected function getCurrentPageNumber($model)
->>>>>>> dcb609d1cffa3ba78375ad95a89d4b58d9704612
     {
         $currentPageNumber = $this->currentPageNumber;
 
@@ -650,11 +638,7 @@ class Lists extends WidgetBase
         $currentPageNumber = intval($currentPageNumber);
 
         if ($currentPageNumber > 1) {
-<<<<<<< HEAD
             $count = $query->count();
-=======
-            $count = $model->count();
->>>>>>> dcb609d1cffa3ba78375ad95a89d4b58d9704612
 
             // If the current page number is higher than the amount of available pages, go to the last available page
             if ($count <= (($currentPageNumber - 1) * $this->recordsPerPage)) {


### PR DESCRIPTION
Fixes #4008.

If the user's current page number (via session or via POST) is no longer available in a list widget, this fix will override the current page number to use the last available page number instead.

This should prevent people from being unable to navigate to a previous page of records if they delete the last record in a page or change the number of records per page.
