### PR TITLE
Rename and deprecate prepareModel method in Lists widget

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -210,7 +210,7 @@ class ImportExportController extends ControllerBehavior
         catch (Exception $ex) {
             $this->controller->handleError($ex);
         }
-        
+
         $this->vars['sourceIndexOffset'] = $this->getImportSourceIndexOffset($importOptions['firstRowTitles']);
 
         return $this->importExportMakePartial('import_result_form');
@@ -334,7 +334,7 @@ class ImportExportController extends ControllerBehavior
 
         return $firstRow;
     }
-    
+
     /**
      * Get the index offset to add to the reported row number in status messages
      *
@@ -627,8 +627,8 @@ class ImportExportController extends ControllerBehavior
             ? 'getColumnValueRaw'
             : 'getColumnValue';
 
-        $model = $widget->prepareModel();
-        $results = $model->get();
+        $query = $widget->prepareQuery();
+        $results = $query->get();
         foreach ($results as $result) {
             $record = [];
             foreach ($columns as $column) {

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -343,7 +343,7 @@ class Lists extends WidgetBase
     /**
      * Applies any filters to the model.
      */
-    public function prepareModel()
+    public function prepareQuery()
     {
         $query = $this->model->newQuery();
         $primaryTable = $this->model->getTable();
@@ -566,16 +566,22 @@ class Lists extends WidgetBase
         return $query;
     }
 
+    public function prepareModel()
+    {
+        traceLog('Method ' . __METHOD__ . '() has been deprecated, please use the ' . __CLASS__ . '::prepareQuery() method instead.');
+        return $this->prepareQuery();
+    }
+
     /**
      * Returns all the records from the supplied model, after filtering.
      * @return Collection
      */
     protected function getRecords()
     {
-        $model = $this->prepareModel();
+        $query = $this->prepareQuery();
 
         if ($this->showTree) {
-            $records = $model->getNested();
+            $records = $query->getNested();
         }
         elseif ($this->showPagination) {
             $method            = $this->showPageNumbers ? 'paginate' : 'simplePaginate';
@@ -584,10 +590,10 @@ class Lists extends WidgetBase
                 // Restore the last visited page from the session if available.
                 $currentPageNumber = $this->getSession('lastVisitedPage');
             }
-            $records = $model->{$method}($this->recordsPerPage, $currentPageNumber);
+            $records = $query->{$method}($this->recordsPerPage, $currentPageNumber);
         }
         else {
-            $records = $model->get();
+            $records = $query->get();
         }
 
         /**


### PR DESCRIPTION
Renames the `prepareModel` method in the Lists widget to `prepareQuery` to better describe method functionality, as per @LukeTowers  suggestion here: https://github.com/octobercms/october/pull/4020#issuecomment-450537502