### PR TITLE
Fix the filter options will be escaped twice

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -934,7 +934,7 @@ class Filter extends WidgetBase
     {
         $processed = [];
         foreach ($options as $id => $result) {
-            $processed[] = ['id' => $id, 'name' => e(trans($result))];
+            $processed[] = ['id' => $id, 'name' => trans($result)];
         }
         return $processed;
     }


### PR DESCRIPTION
Reference: https://github.com/octobercms/october/pull/3793.  This commit added the e() function for translation results. 

Because the filter is using the mustache template, and the manual said: All variables are HTML escaped by default. If you want to return unescaped HTML, use the triple mustache: {{{name}}} (https://mustache.github.io/mustache.5.html)

That means the string will be escaped twice. So, I removed the e().