### PR TITLE
Fix the form field may hide in the preview mode

### DIFF
--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -511,7 +511,7 @@ class FormField
             'data-trigger' => '[name="'.$fullTriggerField.'"]',
             'data-trigger-action' => $triggerAction,
             'data-trigger-condition' => $triggerCondition,
-            'data-trigger-closest-parent' => 'form'
+            'data-trigger-closest-parent' => 'form, div[data-control="formwidget"]'
         ];
 
         return $attributes + $newAttributes;

--- a/modules/system/assets/ui/js/input.trigger.js
+++ b/modules/system/assets/ui/js/input.trigger.js
@@ -28,9 +28,17 @@
             this.triggerConditionValue = (match) ? match : [""]
         }
 
-        this.triggerParent = this.options.triggerClosestParent !== undefined
-            ? $el.closest(this.options.triggerClosestParent)
-            : undefined
+        this.triggerParent = undefined
+        if (this.options.triggerClosestParent !== undefined) {
+            var closestParentElements = this.options.triggerClosestParent.split(',')
+            for (var i = 0; i < closestParentElements.length; i++) {
+                var $triggerElement = $el.closest(closestParentElements[i])
+                if ($triggerElement.length) {
+                    this.triggerParent = $triggerElement
+                    break
+                }
+            }
+        }
 
         if (
             this.triggerCondition == 'checked' ||


### PR DESCRIPTION
The triggerParent and data-trigger-closest-parent added for getting the trigger field in current form. Reference: https://github.com/octobercms/october/commit/7e3cf98a7532cdcf249d1c8dcba0dcf2443e8c46

However, there is no form element in the preview mode. 
In the preview mode, it can get the parent element from div[data-control="formwidget"].