### PR TITLE
Added favicon management to back-end customisation

### DIFF
--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -416,6 +416,8 @@ return [
         'brand' => 'Brand',
         'logo' => 'Logo',
         'logo_description' => 'Upload a custom logo to use in the back-end.',
+        'favicon' => 'Favicon',
+        'favicon_description' => 'Upload a custom favicon to use in the back-end',
         'app_name' => 'App Name',
         'app_name_description' => 'This name is shown in the title area of the back-end.',
         'app_tagline' => 'App Tagline',

--- a/modules/backend/layouts/_head.htm
+++ b/modules/backend/layouts/_head.htm
@@ -7,7 +7,7 @@
 <meta name="backend-timezone" content="<?= e(Backend\Models\Preference::get('timezone')) ?>">
 <meta name="backend-locale" content="<?= e(Backend\Models\Preference::get('locale')) ?>">
 <meta name="csrf-token" content="<?= csrf_token() ?>">
-<link rel="icon" type="image/png" href="<?= Backend::skinAsset('assets/images/favicon.png') ?>">
+<link rel="icon" type="image/png" href="<?= e(Backend\Models\BrandSetting::getFavicon()) ?>">
 <title data-title-template="<?= empty($this->pageTitleTemplate) ? '%s' : e($this->pageTitleTemplate) ?> | <?= e(Backend\Models\BrandSetting::get('app_name')) ?>">
     <?= e(trans($this->pageTitle)) ?> | <?= e(Backend\Models\BrandSetting::get('app_name')) ?>
 </title>

--- a/modules/backend/models/BrandSetting.php
+++ b/modules/backend/models/BrandSetting.php
@@ -39,6 +39,7 @@ class BrandSetting extends Model
     public $settingsFields = 'fields.yaml';
 
     public $attachOne = [
+        'favicon' => \System\Models\File::class,
         'logo' => \System\Models\File::class
     ];
     
@@ -83,6 +84,17 @@ class BrandSetting extends Model
     public function afterSave()
     {
         Cache::forget(self::instance()->cacheKey);
+    }
+
+    public static function getFavicon()
+    {
+        $settings = self::instance();
+
+        if ($settings->favicon) {
+            return $settings->favicon->getPath();
+        }
+
+        return self::getDefaultFavicon() ?: null;
     }
 
     public static function getLogo()
@@ -145,6 +157,11 @@ class BrandSetting extends Model
     public static function isBaseConfigured()
     {
         return !!Config::get('brand');
+    }
+
+    public static function getDefaultFavicon()
+    {
+        return \Backend::skinAsset('assets/images/favicon.png');
     }
 
     public static function getDefaultLogo()

--- a/modules/backend/models/brandsetting/fields.yaml
+++ b/modules/backend/models/brandsetting/fields.yaml
@@ -29,6 +29,16 @@ tabs:
             tab: backend::lang.branding.brand
             span: left
 
+        favicon:
+            label: backend::lang.branding.favicon
+            type: fileupload
+            commentAbove: backend::lang.branding.favicon_description
+            mode: image
+            imageHeight: 32
+            tab: backend::lang.branding.brand
+            span: right
+            fileTypes: jpg,jpeg,bmp,png,webp,gif,svg,ico
+
         primary_color:
             label: backend::lang.branding.primary_color
             type: colorpicker


### PR DESCRIPTION
Added a field to the "customise back-end" area to allow for a custom favicon to be displayed in the backend instead of the default October logo.

If no file is specified, the existing October logo is used by default.

Note that this only customises the icon used in the back-end, not the front-end favicon.
