### PR TITLE
Added manual deleted_at checks

### DIFF
--- a/modules/backend/classes/AuthManager.php
+++ b/modules/backend/classes/AuthManager.php
@@ -163,6 +163,36 @@ class AuthManager extends RainAuthManager
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function createUserModelQuery()
+    {
+        return parent::createUserModelQuery()->withTrashed();
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function validateUserModel($user)
+    {
+        if ( ! $user instanceof $this->userModel) {
+            return false;
+        }
+
+        // Perform the deleted_at check manually since the relevant migrations
+        // might not have been run yet during the update to build 444.
+        // @see https://github.com/octobercms/october/issues/3999
+        if (array_key_exists('deleted_at', $user->getAttributes())
+            && $user->deleted_at !== null
+            && $user->deleted_at->lt(now())) {
+            return false;
+        }
+
+        return $user;
+    }
+
+    /**
      * Returns an array of registered permissions belonging to a given role code
      * @param string $role
      * @param bool $includeOrphans

--- a/modules/backend/classes/AuthManager.php
+++ b/modules/backend/classes/AuthManager.php
@@ -183,9 +183,7 @@ class AuthManager extends RainAuthManager
         // Perform the deleted_at check manually since the relevant migrations
         // might not have been run yet during the update to build 444.
         // @see https://github.com/octobercms/october/issues/3999
-        if (array_key_exists('deleted_at', $user->getAttributes())
-            && $user->deleted_at !== null
-            && $user->deleted_at->lt(now())) {
+        if (array_key_exists('deleted_at', $user->getAttributes()) && $user->deleted_at !== null) {
             return false;
         }
 


### PR DESCRIPTION
It is possible that the user model gets fetched using the SoftDelete
trait before the relevant migrations were applied during an update.
To fix this edge case the user model is always fetched using the
`withTrashed` scope and the `deleted_at` check is done manually afterwards.

see https://github.com/octobercms/october/issues/3999, https://github.com/octobercms/october/issues/4046 and https://github.com/octobercms/library/pull/371