### PR TITLE
Fix incorrect MediaLibrary links when base path is not the domain root

### DIFF
--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -73,10 +73,6 @@ class MediaLibrary
         $this->storageFolder = self::validatePath(Config::get('cms.storage.media.folder', 'media'), true);
         $this->storagePath = rtrim(Config::get('cms.storage.media.path', '/storage/app/media'), '/');
 
-        if (!starts_with($this->storagePath, ['//', 'http://', 'https://'])) {
-            $this->storagePath = Request::getBasePath() . $this->storagePath;
-        }
-
         $this->ignoreNames = Config::get('cms.storage.media.ignore', FileDefinitions::get('ignoreFiles'));
 
         $this->ignorePatterns = Config::get('cms.storage.media.ignorePatterns', ['^\..*']);


### PR DESCRIPTION
This PR fixes #4039, a bug that was introduced in PR #3536.

Currently the app root/base path is added to the `storagePath` variable in `MediaLibrary`, which is then used to generate the links with the `getPathUrl()` function. Since PR #3536 this is then also passed through the `Url::to()`function to adhere to the link policy, however the base path is added again in this method and therefore we get duplicated base paths in the final URL (only noticeable if your base path is not the domain root). This PR solves the issue by not adding the base path to `storagePath` in the `MediaLibrary`.

`storagePath` is a protected variable and not used anywhere else within the `MediaLibrary` so this should not cause any other problems, it would however affect anyone extending the `MediaLibrary` class and using this variable.

Unfortunately I have no experience using tests, and no the needed time to learn this within a reasonable timeframe for the need of this PR. Ping @w20k