### PR TITLE
Fix default value translation

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1072,10 +1072,13 @@ class Form extends WidgetBase
         }
 
         $defaultValue = !$this->model->exists
-            ? trans($field->getDefaultFromData($this->data))
+            ? $field->getDefaultFromData($this->data)
             : null;
 
-        return $field->getValueFromData($this->data, $defaultValue);
+        return $field->getValueFromData(
+            $this->data, 
+            is_string($defaultValue) ? trans($defaultValue) : $defaultValue
+        );
     }
 
     /**


### PR DESCRIPTION
This is a fix for an issue reported here: https://github.com/octobercms/october/commit/a1fb23a98446579659ddb73836e5b12f9bcf76e8#diff-d7b489cccf21c7a4400772ca5d6968c6

Basically, we can have default values that are not strings (e.g. for repeater fields). And in these cases we now get an error. This PR ensures that we only try to translate default values when they are strings.