### PR TITLE
Allow multiline changelog messages on plugin page and preserve correct order of updates

### DIFF
--- a/modules/system/classes/VersionManager.php
+++ b/modules/system/classes/VersionManager.php
@@ -126,21 +126,7 @@ class VersionManager
      */
     protected function applyPluginUpdate($code, $version, $details)
     {
-        if (is_array($details)) {
-            $fileNamePattern = "/^[a-z_\-0-9]*\.php$/i";
-
-            $comments = array_filter($details, function($detail) use ($fileNamePattern) {
-                return !preg_match($fileNamePattern, $detail);
-            });
-
-            $scripts = array_filter($details, function($detail) use ($fileNamePattern) {
-                return preg_match($fileNamePattern, $detail);
-            });
-        }
-        else {
-            $comments = (array)$details;
-            $scripts = [];
-        }
+        list($comments, $scripts) = $this->extractScriptsAndComments($details);
 
         /*
          * Apply scripts, if any
@@ -535,4 +521,29 @@ class VersionManager
 
         return $this;
     }
+
+    /**
+     * @param $details
+     *
+     * @return array
+     */
+    protected function extractScriptsAndComments($details)
+    {
+        if (is_array($details)) {
+            $fileNamePattern = '/^[a-z_\-0-9]*\.php$/i';
+
+            $comments = array_values(array_filter($details, function ($detail) use ($fileNamePattern) {
+                return !preg_match($fileNamePattern, $detail);
+            }));
+
+            $scripts = array_values(array_filter($details, function ($detail) use ($fileNamePattern) {
+                return preg_match($fileNamePattern, $detail);
+            }));
+        } else {
+            $comments = (array)$details;
+            $scripts = [];
+        }
+
+        return array($comments, $scripts);
+}
 }

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -181,7 +181,7 @@ class Updates extends Controller
         $contents = [];
 
         try {
-            $updates = (array)Yaml::parseFile($path.'/'.$filename);
+            $updates = (array) Yaml::parseFile($path.'/'.$filename);
 
             foreach ($updates as $version => $details) {
                 if (!is_array($details)) {

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -176,21 +176,28 @@ class Updates extends Controller
         }
     }
 
-    protected function getPluginVersionFile($path, $filename)
+    protected function getPluginVersionFile($path, $filename): array
     {
         $contents = [];
 
         try {
-            $updates = Yaml::parseFile($path.'/'.$filename);
-            $updates = is_array($updates) ? array_reverse($updates) : [];
+            $updates = (array)Yaml::parseFile($path.'/'.$filename);
 
             foreach ($updates as $version => $details) {
-                $contents[$version] = is_array($details)
+                $changelogForVersion = is_array($details)
                     ? array_shift($details)
                     : $details;
+
+                $contents[$version] = array_filter(
+                    array_map('trim', explode(';', $changelogForVersion))
+                );
             }
         }
         catch (Exception $ex) {}
+
+        uksort($contents, function ($a, $b) {
+            return version_compare($b, $a);
+        });
 
         return $contents;
     }

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -176,7 +176,7 @@ class Updates extends Controller
         }
     }
 
-    protected function getPluginVersionFile($path, $filename): array
+    protected function getPluginVersionFile($path, $filename)
     {
         $contents = [];
 

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -184,13 +184,16 @@ class Updates extends Controller
             $updates = (array)Yaml::parseFile($path.'/'.$filename);
 
             foreach ($updates as $version => $details) {
-                $changelogForVersion = is_array($details)
-                    ? array_shift($details)
-                    : $details;
+                if (!is_array($details)) {
+                    $details = (array)$details;
+                }
 
-                $contents[$version] = array_filter(
-                    array_map('trim', explode(';', $changelogForVersion))
-                );
+                //Filter out update scripts
+                $details = array_filter($details, function($string) use ($path) {
+                    return !File::exists($path . '/updates/' . $string);
+                });
+
+                $contents[$version] = $details;
             }
         }
         catch (Exception $ex) {}

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -190,7 +190,7 @@ class Updates extends Controller
 
                 //Filter out update scripts
                 $details = array_filter($details, function($string) use ($path) {
-                    return !File::exists($path . '/updates/' . $string);
+                    return !preg_match('/^[a-z_\-0-9]*\.php$/i', $string) || !File::exists($path . '/updates/' . $string);
                 });
 
                 $contents[$version] = $details;

--- a/modules/system/controllers/updates/details.htm
+++ b/modules/system/controllers/updates/details.htm
@@ -76,10 +76,12 @@
                 <div class="plugin-details-content">
                     <?php if ($changelog): ?>
                         <dl>
-                            <?php foreach ($changelog as $version => $comment): ?>
-                                <dt><?= e($version) ?></dt>
-                                <dd><?= e($comment) ?></dd>
-                            <?php endforeach ?>
+                            <?php foreach ($changelog as $version => $comments): ?>
+                                <?php foreach ($comments as $index => $comment): ?>
+                                    <dt><?= !$index ? e($version): '' ?></dt>
+                                    <dd><?= e($comment) ?></dd>
+                                <?php endforeach; ?>
+                            <?php endforeach; ?>
                         </dl>
                     <?php else: ?>
                         <p><?= e(trans('system::lang.updates.details_changelog_missing')) ?></p>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,11 @@
             <directory>./vendor/october/rain/tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">./modules/</directory>
+        </whitelist>
+    </filter>
     <php>
         <env name="APP_ENV" value="testing" />
         <env name="CACHE_DRIVER" value="array" />

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,11 +18,6 @@
             <directory>./vendor/october/rain/tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">./modules/</directory>
-        </whitelist>
-    </filter>
     <php>
         <env name="APP_ENV" value="testing" />
         <env name="CACHE_DRIVER" value="array" />

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,4 +19,34 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
         return $app;
     }
 
+    //
+    // Helpers
+    //
+
+    protected static function callProtectedMethod($object, $name, $params = [])
+    {
+        $className = get_class($object);
+        $class = new ReflectionClass($className);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $params);
+    }
+
+    public static function getProtectedProperty($object, $name)
+    {
+        $className = get_class($object);
+        $class = new ReflectionClass($className);
+        $property = $class->getProperty($name);
+        $property->setAccessible(true);
+        return $property->getValue($object);
+    }
+
+    public static function setProtectedProperty($object, $name, $value)
+    {
+        $className = get_class($object);
+        $class = new ReflectionClass($className);
+        $property = $class->getProperty($name);
+        $property->setAccessible(true);
+        return $property->setValue($object, $value);
+    }
 }

--- a/tests/fixtures/plugins/october/tester/updates/version.yaml
+++ b/tests/fixtures/plugins/october/tester/updates/version.yaml
@@ -1,12 +1,18 @@
+1.0.5:
+    - Create blog settings table
+    - Another update message
+    - Yet one more update message
+    - create_blog_settings_table.php
+1.0.4: Another fix
+1.0.3: Bug fix update that uses no scripts
+1.0.2:
+    - Create blog post comments table
+    - Multiple update messages are allowed
+    - create_comments_table.php
 1.0.1:
     - Added some upgrade file and some seeding
     - some_upgrade_file.php
     - some_seeding_file.php
-1.0.2:
-    - Create blog post comments table
-    - create_comments_table.php
-1.0.3: Bug fix update that uses no scripts
-1.0.4: Another fix
-1.0.5: 
-    - Create blog settings table
-    - create_blog_settings_table.php
+
+
+

--- a/tests/unit/backend/models/ExportModelTest.php
+++ b/tests/unit/backend/models/ExportModelTest.php
@@ -27,19 +27,6 @@ class ExportModelTest extends TestCase
 {
 
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    //
     // Tests
     //
 

--- a/tests/unit/backend/models/ImportModelTest.php
+++ b/tests/unit/backend/models/ImportModelTest.php
@@ -18,19 +18,6 @@ class ImportModelTest extends TestCase
 {
 
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    //
     // Tests
     //
 

--- a/tests/unit/cms/classes/CmsExceptionTest.php
+++ b/tests/unit/cms/classes/CmsExceptionTest.php
@@ -12,37 +12,6 @@ use October\Rain\Exception\SystemException;
 class CmsExceptionTest extends TestCase
 {
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    public static function getProtectedProperty($object, $name)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->getValue($object);
-    }
-
-    public static function setProtectedProperty($object, $name, $value)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->setValue($object, $value);
-    }
-
-    //
     // Tests
     //
 

--- a/tests/unit/system/classes/CombineAssetsTest.php
+++ b/tests/unit/system/classes/CombineAssetsTest.php
@@ -13,37 +13,6 @@ class CombineAssetsTest extends TestCase
     }
 
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    public static function getProtectedProperty($object, $name)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->getValue($object);
-    }
-
-    public static function setProtectedProperty($object, $name, $value)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->setValue($object, $value);
-    }
-
-    //
     // Tests
     //
 

--- a/tests/unit/system/classes/MarkupManagerTest.php
+++ b/tests/unit/system/classes/MarkupManagerTest.php
@@ -13,37 +13,6 @@ class MarkupManagerTest extends TestCase
     }
 
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    public static function getProtectedProperty($object, $name)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->getValue($object);
-    }
-
-    public static function setProtectedProperty($object, $name, $value)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->setValue($object, $value);
-    }
-
-    //
     // Tests
     //
 

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -13,37 +13,6 @@ class PluginManagerTest extends TestCase
     }
 
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    public static function getProtectedProperty($object, $name)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->getValue($object);
-    }
-
-    public static function setProtectedProperty($object, $name, $value)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->setValue($object, $value);
-    }
-
-    //
     // Tests
     //
 

--- a/tests/unit/system/classes/UpdatesControllerTest.php
+++ b/tests/unit/system/classes/UpdatesControllerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use System\Controllers\Updates;
+
+class UpdatesControllerTest extends TestCase
+{
+
+    //
+    // Tests
+    //
+
+    public function testGetPluginVersionFile()
+    {
+        $controller = $this->getMockBuilder(Updates::class)->disableOriginalConstructor()->getMock();
+
+        $expectedVersions = [
+            '1.0.5' => [
+                'Create blog settings table',
+                'Another update message',
+                'Yet one more update message'
+            ],
+            '1.0.4' => [
+                'Another fix'
+            ],
+            '1.0.3' => [
+                'Bug fix update that uses no scripts'
+            ],
+            '1.0.2' => [
+                'Create blog post comments table',
+                'Multiple update messages are allowed'
+            ],
+            '1.0.1' => [
+                'Added some upgrade file and some seeding',
+                'some_upgrade_file.php', //does not exist
+                'some_seeding_file.php' //does not exist
+            ]
+        ];
+
+        $versions = self::callProtectedMethod(
+            $controller,
+            'getPluginVersionFile',
+            [
+                base_path().'/tests/fixtures/plugins/october/tester/',
+                'updates/version.yaml'
+            ]
+        );
+
+        $this->assertNotNull($versions);
+        $this->assertEquals($expectedVersions, $versions);
+    }
+}

--- a/tests/unit/system/classes/VersionManagerTest.php
+++ b/tests/unit/system/classes/VersionManagerTest.php
@@ -15,37 +15,6 @@ class VersionManagerTest extends TestCase
     }
 
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    public static function getProtectedProperty($object, $name)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->getValue($object);
-    }
-
-    public static function setProtectedProperty($object, $name, $value)
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $property = $class->getProperty($name);
-        $property->setAccessible(true);
-        return $property->setValue($object, $value);
-    }
-
-    //
     // Tests
     //
 
@@ -119,4 +88,89 @@ class VersionManagerTest extends TestCase
         $this->assertArrayHasKey('1.0.5', $result);
     }
 
+    /**
+     * @dataProvider versionInfoProvider
+     *
+     * @param $versionInfo
+     * @param $expectedComments
+     * @param $expectedScripts
+     */
+    public function testExtractScriptsAndComments($versionInfo, $expectedComments, $expectedScripts)
+    {
+        $manager = VersionManager::instance();
+        list($comments, $scripts) = self::callProtectedMethod($manager, 'extractScriptsAndComments', [$versionInfo]);
+
+        $this->assertInternalType('array', $comments);
+        $this->assertInternalType('array', $scripts);
+
+        $this->assertEquals($expectedComments, $comments);
+        $this->assertEquals($expectedScripts, $scripts);
+    }
+
+    public function versionInfoProvider()
+    {
+        return [
+            [
+                'A single update comment string',
+                [
+                    'A single update comment string'
+                ],
+                []
+            ],
+            [
+                [
+                    'A classic update comment string followed by script',
+                    'update_script.php'
+                ],
+                [
+                    'A classic update comment string followed by script'
+                ],
+                [
+                    'update_script.php'
+                ]
+            ],
+            [
+                [
+                    'scripts_can_go_first.php',
+                    'An update comment string after the script',
+                ],
+                [
+                    'An update comment string after the script'
+                ],
+                [
+                    'scripts_can_go_first.php'
+                ]
+            ],
+            [
+                [
+                    'scripts_can_go_first.php',
+                    'An update comment string after the script',
+                    'scripts_can_go_anywhere.php',
+                ],
+                [
+                    'An update comment string after the script'
+                ],
+                [
+                    'scripts_can_go_first.php',
+                    'scripts_can_go_anywhere.php'
+                ]
+            ],
+            [
+                [
+                    'scripts_can_go_first.php',
+                    'The first update comment',
+                    'scripts_can_go_anywhere.php',
+                    'The second update comment',
+                ],
+                [
+                    'The first update comment',
+                    'The second update comment'
+                ],
+                [
+                    'scripts_can_go_first.php',
+                    'scripts_can_go_anywhere.php'
+                ]
+            ]
+        ];
+    }
 }

--- a/tests/unit/system/traits/AssetMakerTest.php
+++ b/tests/unit/system/traits/AssetMakerTest.php
@@ -17,19 +17,6 @@ class AssetMakerTest extends TestCase
     }
 
     //
-    // Helpers
-    //
-
-    protected static function callProtectedMethod($object, $name, $params = [])
-    {
-        $className = get_class($object);
-        $class = new ReflectionClass($className);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $params);
-    }
-
-    //
     // Tests
     //
 


### PR DESCRIPTION
Some prerequisites for this.

Plugin development documentation shows versions.yaml file example:
![image](https://user-images.githubusercontent.com/3897579/51678643-cd55f080-1fd4-11e9-8e24-f7483c914888.png)

And the system expects such order in `modules/system/controllers/Updates.php::getPluginVersionFile`:

```
$updates = is_array($updates) ? array_reverse($updates) : [];
```

So it reverses the order of updates to show with the latest update on the top.

On the other hand, the documentation does not tell that we **must** follow ascending order of updates, because both orders work fine and `VersionManager` actually sorts versions to get updates in proper order.

This leads to situation, when plugin updates on plugin changelog tab are listed starting from the oldest, like here:

<img width="625" alt="before" src="https://user-images.githubusercontent.com/3897579/51679046-c7144400-1fd5-11e9-8159-0e2c8700e337.png">
 
This PR fixes such behavior and makes sure that the order of updates on that page is from the newest to the oldest no matter which order you use in `versions.yaml`. Also, I don't really like a limitation with single changelog message per update, therefore this PR also explodes update message by ";" and shows resulting messages on new lines which allows to simulate multiple messages. In my case the list looks like this after PR:

<img width="663" alt="after" src="https://user-images.githubusercontent.com/3897579/51679338-997bca80-1fd6-11e9-9c54-772900a1d4fd.png">
  