### PR TITLE
RecordFinder nameFromRelation allows to query a related model

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -277,7 +277,7 @@ class RecordFinder extends FormWidgetBase
         $nameFrom = explode('.', $this->nameFrom);
         foreach ($nameFrom as $attribute) {
             if (!empty($name->{$attribute})){
-              $name = $name->{$attribute};
+                $name = $name->{$attribute};
             }
         }
         return $name;

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -17,7 +17,6 @@ use Backend\Classes\FormWidgetBase;
  *        prompt: Click the Find button to find a user
  *        keyFrom: id
  *        nameFrom: name
- *        nameFromRelation: null
  *        descriptionFrom: email
  *        conditions: email = "bob@example.com"
  *        scope: whereActive
@@ -43,14 +42,9 @@ class RecordFinder extends FormWidgetBase
     public $keyFrom = 'id';
 
     /**
-     * @var string Relation column to display for the name
+     * @var string Relation column to display for the name. Can use the dot notation to query a related model
      */
     public $nameFrom = 'name';
-
-    /**
-     * @var string Get nameFrom using a model relationship
-     */
-    public $nameFromRelation;
 
     /**
      * @var string Relation column to display for the description
@@ -139,7 +133,6 @@ class RecordFinder extends FormWidgetBase
             'prompt',
             'keyFrom',
             'nameFrom',
-            'nameFromRelation',
             'descriptionFrom',
             'scope',
             'conditions',
@@ -280,8 +273,9 @@ class RecordFinder extends FormWidgetBase
             return null;
         }
 
-        if ($this->nameFromRelation && $this->relationModel->{$this->nameFromRelation}){
-          return $this->relationModel->{$this->nameFromRelation}->{$this->nameFrom};
+        list($relation,$attribute) = explode('.', $this->nameFrom,2);
+        if (!empty($attribute) && !empty($relation)){
+          return $this->relationModel->$relation->$attribute;
         }
 
         return $this->relationModel->{$this->nameFrom};

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -273,7 +273,7 @@ class RecordFinder extends FormWidgetBase
             return null;
         }
 
-        list($relation,$attribute) = explode('.', $this->nameFrom,2);
+        list($relation,$attribute) = array_pad(explode('.', $this->nameFrom,2), 2, null);
         if (!empty($attribute) && !empty($this->relationModel->$relation)){
           return $this->relationModel->$relation->$attribute;
         }

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -17,6 +17,7 @@ use Backend\Classes\FormWidgetBase;
  *        prompt: Click the Find button to find a user
  *        keyFrom: id
  *        nameFrom: name
+ *        nameFromRelation: null
  *        descriptionFrom: email
  *        conditions: email = "bob@example.com"
  *        scope: whereActive
@@ -45,6 +46,11 @@ class RecordFinder extends FormWidgetBase
      * @var string Relation column to display for the name
      */
     public $nameFrom = 'name';
+
+    /**
+     * @var string Get nameFrom using a model relationship
+     */
+    public $nameFromRelation;
 
     /**
      * @var string Relation column to display for the description
@@ -133,6 +139,7 @@ class RecordFinder extends FormWidgetBase
             'prompt',
             'keyFrom',
             'nameFrom',
+            'nameFromRelation',
             'descriptionFrom',
             'scope',
             'conditions',
@@ -271,6 +278,10 @@ class RecordFinder extends FormWidgetBase
     {
         if (!$this->relationModel || !$this->nameFrom) {
             return null;
+        }
+
+        if ($this->nameFromRelation && $this->relationModel->{$this->nameFromRelation}){
+          return $this->relationModel->{$this->nameFromRelation}->{$this->nameFrom};
         }
 
         return $this->relationModel->{$this->nameFrom};

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -273,12 +273,14 @@ class RecordFinder extends FormWidgetBase
             return null;
         }
 
-        list($relation,$attribute) = array_pad(explode('.', $this->nameFrom,2), 2, null);
-        if (!empty($attribute) && !empty($this->relationModel->$relation)){
-          return $this->relationModel->$relation->$attribute;
+        $name = $this->relationModel;
+        $nameFrom = explode('.', $this->nameFrom);
+        foreach ($nameFrom as $attribute) {
+            if (!empty($name->{$attribute})){
+              $name = $name->{$attribute};
+            }
         }
-
-        return $this->relationModel->{$this->nameFrom};
+        return $name;
     }
 
     public function getDescriptionValue()

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -274,7 +274,7 @@ class RecordFinder extends FormWidgetBase
         }
 
         list($relation,$attribute) = explode('.', $this->nameFrom,2);
-        if (!empty($attribute) && !empty($relation)){
+        if (!empty($attribute) && !empty($this->relationModel->$relation)){
           return $this->relationModel->$relation->$attribute;
         }
 

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -276,7 +276,7 @@ class RecordFinder extends FormWidgetBase
         $name = $this->relationModel;
         $nameFrom = explode('.', $this->nameFrom);
         foreach ($nameFrom as $attribute) {
-            if (!empty($name->{$attribute})){
+            if (!empty($name->{$attribute})) {
                 $name = $name->{$attribute};
             }
         }


### PR DESCRIPTION
Hello

WRT the RecordFinder widget of the Backend Forms

Even though the current implementation of RecordFinder allows for columns of related models to be shown in the Find Record modal, there was no way to show this value in the Name field when selected.

This PR allows for just that by specifying the related model (as defined in the Model) in the fields.yaml

```
fields:
      top_level_version:
        tab: 'General info'
        label: Some label
        nameFromRelation: related_model
        nameFrom: name
        list: $/alpapan/biobench/models/mainmodel/columns.yaml
        type: recordfinder
        required: 1
        span: auto
```

where the model is:
```
public $belongsTo = [
      'related_model'=>[
        'alpapan\biobench\Models\RelatedModel',
        'table' => 'alpapan_biobench_related_model',
        'key' => 'seq_top_id'
      ],
```

This configuration will show the _name_ of the RelatedModel Model instead of the _name_ of the MainModel


NB: The existing code already allows for relationships in columns, just not the recordfinder.

```
columns:
    related_model_name:
      label: Some name
      type: text
      select: name
      relation: related_model
```