### PR TITLE
Fix setting default values for repeater in update context

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -268,7 +268,7 @@ class Repeater extends FormWidgetBase
         $config->alias = $this->alias . 'Form'.$index;
         $config->arrayName = $this->getFieldName().'['.$index.']';
         $config->isNested = true;
-        $config->shouldFetchDefaultValues = self::$onAddItemCalled;
+        $config->enableDefaults = self::$onAddItemCalled;
 
         $widget = $this->makeWidget('Backend\Widgets\Form', $config);
         $widget->bindToController();

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -268,6 +268,7 @@ class Repeater extends FormWidgetBase
         $config->alias = $this->alias . 'Form'.$index;
         $config->arrayName = $this->getFieldName().'['.$index.']';
         $config->isNested = true;
+        $config->shouldFetchDefaultValues = self::$onAddItemCalled;
 
         $widget = $this->makeWidget('Backend\Widgets\Form', $config);
         $widget->bindToController();

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1071,7 +1071,7 @@ class Form extends WidgetBase
             $field = $this->allFields[$field];
         }
 
-        $defaultValue = !$this->model->exists
+        $defaultValue = $this->shouldFetchDefaultValues()
             ? $field->getDefaultFromData($this->data)
             : null;
 
@@ -1081,6 +1081,18 @@ class Form extends WidgetBase
         );
     }
 
+    /**
+     * Checks if default values should be taken from data.
+     * This should be done when model exists or when explicitly configured
+     */
+    protected function shouldFetchDefaultValues() {
+        $shouldFetchDefaultValues = object_get($this->config, 'shouldFetchDefaultValues');
+        if ($shouldFetchDefaultValues === false) {
+            return false;
+        }
+        return !$this->model->exists || $shouldFetchDefaultValues;
+    }
+    
     /**
      * Returns a HTML encoded value containing the other fields this
      * field depends on

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1086,13 +1086,13 @@ class Form extends WidgetBase
      * This should be done when model exists or when explicitly configured
      */
     protected function shouldFetchDefaultValues() {
-        $shouldFetchDefaultValues = object_get($this->config, 'shouldFetchDefaultValues');
-        if ($shouldFetchDefaultValues === false) {
+        $enableDefaults = object_get($this->config, 'enableDefaults');
+        if ($enableDefaults === false) {
             return false;
         }
-        return !$this->model->exists || $shouldFetchDefaultValues;
+        return !$this->model->exists || $enableDefaults;
     }
-    
+
     /**
      * Returns a HTML encoded value containing the other fields this
      * field depends on


### PR DESCRIPTION
This PR is a completion of #3766 which seems abandoned.

When setting a default value for a repeater group field, it does not get filled when the context is anything other than `create`. This PR copies the code from #3766 and adds the changes suggest by @LukeTowers in https://github.com/octobercms/october/pull/3766#issuecomment-426720874.

How to (from old PR):
_You can replicate this in the test plugin by adding a default value for some field in the config/repeater_fields.yaml_

_When you create a new item using this repeater field, the default value will be set.
But when you update an item, the default value won't be set when adding a new group._