### PR TITLE
Discard empty event results

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -445,7 +445,7 @@ class Form extends WidgetBase
          */
         $eventResults = $this->fireSystemEvent('backend.form.refresh', [$result], false);
 
-        foreach ($eventResults as $eventResult) {
+        foreach (array_filter($eventResults) as $eventResult) {
             $result = $eventResult + $result;
         }
 


### PR DESCRIPTION
There is a bug when having a wildcard event listener the `onRefresh` method of the form widget stops working:

> Symfony\Component\Debug\Exception\FatalThrowableError: Unsupported operand types in /project/modules/backend/widgets/Form.php:450

The problem here is that a wildcard event will return an array with a single `null` value in it. 

This will trigger an exception when trying to merge the results with `$eventResult + $result` (null + [])

You can reproduce the bug by adding a simple wildcard event listener in any plugin and then use a `dependsOn` option on any field.

```php
\Event::listen('*', function() {});
```

When changing the field's value the `onRefresh` method is triggered and the exception is thrown.

My proposed solution is to filter out empty array values before merging.