### PR TITLE
Fix inconsistency with filesize display in file upload widget

### DIFF
--- a/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
+++ b/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
@@ -176,7 +176,11 @@
     }
 
     FileUpload.prototype.onUploadAddedFile = function(file) {
-        var $object = $(file.previewElement).data('dzFileObject', file)
+        var $object = $(file.previewElement).data('dzFileObject', file),
+            filesize = this.getFilesize(file)
+
+        // Change filesize format to match October\Rain\Filesystem\Filesystem::sizeToString() format
+        $(file.previewElement).find('[data-dz-size]').html('<strong>' + filesize.size + '</strong> ' + filesize.units);
 
         // Remove any exisiting objects for single variety
         if (!this.options.isMulti) {
@@ -383,6 +387,42 @@
         // Reset maxFiles counter
         if (!isPopulated) {
             this.dropzone.removeAllFiles()
+        }
+    }
+
+    /*
+     * Replicates the formatting of October\Rain\Filesystem\Filesystem::sizeToString(). This method will return
+     * an object with the file size amount and the unit used as `size` and `units` respectively.
+     */
+    FileUpload.prototype.getFilesize = function (file) {
+        var formatter = new Intl.NumberFormat('en', {
+                style: 'decimal',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            }),
+            size = 0,
+            units = 'bytes'
+
+        if (file.size >= 1073741824) {
+            size = formatter.format(file.size / 1073741824)
+            units = 'GB'
+        } else if (file.size >= 1048576) {
+            size = formatter.format(file.size / 1048576)
+            units = 'MB'
+        } else if (file.size >= 1024) {
+            size = formatter.format(file.size / 1024)
+            units = 'KB'
+        } else if (file.size > 1) {
+            size = file.size
+            units = 'bytes'
+        } else if (file.size == 1) {
+            size = 1
+            units = 'bytes'
+        }
+
+        return {
+            size: size,
+            units: units
         }
     }
 

--- a/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
+++ b/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
@@ -180,7 +180,7 @@
             filesize = this.getFilesize(file)
 
         // Change filesize format to match October\Rain\Filesystem\Filesystem::sizeToString() format
-        $(file.previewElement).find('[data-dz-size]').html('<strong>' + filesize.size + '</strong> ' + filesize.units);
+        $(file.previewElement).find('[data-dz-size]').html('<strong>' + filesize.size + '</strong> ' + filesize.units)
 
         // Remove any exisiting objects for single variety
         if (!this.options.isMulti) {


### PR DESCRIPTION
Fixes #4085.

Updates the file preview that is created by Dropzone.js in the `fileupload` widget to match the filesize format with the one that is generated by the `October\Rain\Filesystem\Filesystem::sizeToString()` method, to maintain consistency between newly uploaded files and ones uploaded previously.