### PR TITLE
Add configuration for loading related model in FormField

### DIFF
--- a/modules/backend/classes/FormField.php
+++ b/modules/backend/classes/FormField.php
@@ -690,7 +690,7 @@ class FormField
         foreach ($keyParts as $key) {
 
             if ($result instanceof Model && $result->hasRelation($key)) {
-                if ($key == $lastField) {
+                if ($key == $lastField && ! $this->getConfig('useRelationData', false)) {
                     $result = $result->getRelationValue($key) ?: $default;
                 }
                 else {


### PR DESCRIPTION
By default the FormField only gets the keys for a relation, but this makes it impossible to use NestedForm in conjuction with a relation. This enhancement adds a flag `useRelationData` which defaults to `false` for backwards compatibility and when `true` fetches the relation's data into the field value.