### PR TITLE
fixes enable defaults on repeater

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -284,7 +284,9 @@ class Repeater extends FormWidgetBase
         $config->alias = $this->alias . 'Form'.$index;
         $config->arrayName = $this->getFieldName().'['.$index.']';
         $config->isNested = true;
-        $config->enableDefaults = self::$onAddItemCalled;
+        if (self::$onAddItemCalled || $this->minItems > 0) {
+            $config->enableDefaults = true;
+        }
 
         $widget = $this->makeWidget('Backend\Widgets\Form', $config);
         $widget->bindToController();


### PR DESCRIPTION
This let the repeater display the default value of an item if has the minItems enabled. For example:

```yaml
  items:
    label: Items
    type: repeater
    titleFrom: name
    prompt: Add item
    minItems: 1
    form:
      fields:
        name:
          label: Name
          span: auto
          type: text
        item_type:
          label: Item Type
          span: auto
          type: dropdown
          options:
            Text: Text
            SafeHtml: Safe Html
            RawHtml: Raw Html
        xpath:
          label: Xpath
          default: //
        allowed_elements:
          label: Allowed Elements
          default: the default value here
          trigger:
            action: show
            field: item_type
            condition: value[SafeHtml]
```
