### PR TITLE
Quick grammar fix to File Upload widget

### DIFF
--- a/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
+++ b/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
@@ -417,7 +417,7 @@
             units = 'bytes'
         } else if (file.size == 1) {
             size = 1
-            units = 'bytes'
+            units = 'byte'
         }
 
         return {


### PR DESCRIPTION
Related comment: https://github.com/octobercms/october/commit/4f3997c6de99ff5677b8b3a6e719c20612b8c37d#r32264364

Use singular term `byte` for a filesize of 1 byte in the File Upload widget.