### PR TITLE
Set the report widget alias from container and base

### DIFF
--- a/modules/backend/classes/ReportWidgetBase.php
+++ b/modules/backend/classes/ReportWidgetBase.php
@@ -14,6 +14,13 @@ class ReportWidgetBase extends WidgetBase
     public function __construct($controller, $properties = [])
     {
         $this->properties = $this->validateProperties($properties);
+        
+        /*
+         * If no alias is set by the backend_user_preferences configuration.
+         */
+        if (!isset($this->alias)) {
+            $this->alias = $properties['alias'] ?? $this->defaultAlias;
+        }
 
         parent::__construct($controller);
     }

--- a/modules/backend/widgets/ReportContainer.php
+++ b/modules/backend/widgets/ReportContainer.php
@@ -235,6 +235,8 @@ class ReportContainer extends WidgetBase
             $alias = 'report_container_'.$this->context.'_'.$num;
         }
         while (array_key_exists($alias, $widgets));
+        
+        $widget->alias = $alias;
 
         $sortOrder = 0;
         foreach ($widgets as $widgetInfo) {


### PR DESCRIPTION
ReportContainer.php already get the unique widget alias, but forgot to set to the widget. 

In this way, we can get different widget alias with the same reportwidget, just like this:

report_container_dashboard_4
report_container_dashboard_5