### PR TITLE
Add  popup-allow-focus for the second range input

### DIFF
--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -159,7 +159,7 @@
                                         type="text"                                                                       \
                                         name="date"                                                                       \
                                         value="{{ date }}"                                                                \
-                                        class="form-control align-right"                                                  \
+                                        class="form-control align-right popup-allow-focus"                                                  \
                                         autocomplete="off"                                                                \
                                         placeholder="{{ before_placeholder }}" />                                         \
                                 </div>                                                                                    \


### PR DESCRIPTION
When list filters are in a modal, you cannot select the second field because it does not have  popup-allow-focus class.