### PR TITLE
Return 500 when asset exception caught

### DIFF
--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -4,6 +4,7 @@ use Lang;
 use ApplicationException;
 use Illuminate\Routing\Controller as ControllerBase;
 use Exception;
+use Response;
 
 /**
  * The is the master controller for system related routing.
@@ -36,7 +37,7 @@ class SystemController extends ControllerBase
 
         }
         catch (Exception $ex) {
-            return '/* '.e($ex->getMessage()).' */';
+            return Response::make('/* '.e($ex->getMessage()).' */', 404);
         }
     }
 }

--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -37,7 +37,7 @@ class SystemController extends ControllerBase
 
         }
         catch (Exception $ex) {
-            return Response::make('/* '.e($ex->getMessage()).' */', 404);
+            return Response::make('/* '.e($ex->getMessage()).' */', 500);
         }
     }
 }


### PR DESCRIPTION
Right now if you try to load assets that don't exist `200` is returned.
This PR will return `500` for any caught exception.

Before:
```
HTTP/1.1 200 OK
Server: nginx/1.15.0
Content-Type: text/html; charset=UTF-8
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: no-cache, private
Date: Fri, 15 Feb 2019 20:57:38 GMT

/* The combiner file &#039;541208ee51c521bbfa180fe046910ad0&#039; is not found. */⏎          
```

After:
```
HTTP/1.1 500
Server: nginx/1.15.0
Content-Type: text/html; charset=UTF-8
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: no-cache, private
Date: Fri, 15 Feb 2019 21:18:23 GMT

/* The combiner file &#039;725cc5a8ab3f7bb5d2f5104e047079bfdfda&#039; is not found. */⏎      
```