### PR TITLE
Apply Model Filters Before Data Saved

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -232,6 +232,8 @@ class FormController extends ControllerBehavior
 
         $this->initForm($model);
 
+        $model->forceFill($this->formWidget->getSaveData());
+
         $this->controller->formBeforeSave($model);
         $this->controller->formBeforeCreate($model);
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -240,7 +240,7 @@ class Form extends WidgetBase
     public function renderField($field, $options = [])
     {
         $this->prepareVars();
-        
+
         if (is_string($field)) {
             if (!isset($this->allFields[$field])) {
                 throw new ApplicationException(Lang::get(
@@ -1121,6 +1121,7 @@ class Form extends WidgetBase
     public function getSaveData()
     {
         $this->defineFormFields();
+        $this->applyFiltersFromModel();
 
         $result = [];
 


### PR DESCRIPTION
Fixes #4144 
- and https://octobercms.com/forum/post/usage-of-hidden-form-field?page=1#post-26291

### TL;DR
Cannot save value of hidden field even after `$field->hidden = false` is called in `Model::filterFields`

### Long Story
- Add `hidden: true` to any form field in yaml configuration file.
- Then add:
```
my_field:
  hidden: true
  dependsOn:
    - some_other_field
```
- Add `filterFields` method to model class:
```
public function filterFields($fields) {
  $fields->my_field->hidden = false;
}
```
- `my_field` value will never be **saved**!
