### PR TITLE
Add backend.list.extendRecords event for export

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -629,6 +629,11 @@ class ImportExportController extends ControllerBehavior
 
         $query = $widget->prepareQuery();
         $results = $query->get();
+        
+        if ($event = $widget->fireSystemEvent('backend.list.extendRecords', [&$results])) {
+            $results = $event;
+        }
+        
         foreach ($results as $result) {
             $record = [];
             foreach ($columns as $column) {


### PR DESCRIPTION
Provides an opportunity to modify and / or return the $results collection object before the controller export it.

The same as Lists widget getRecords function:
https://github.com/octobercms/october/blob/9581b23d1e85ccfdc283946894afa2df177b304f/modules/backend/widgets/Lists.php#L614