### PR TITLE
New Twig filters for assets

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -199,6 +199,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Determines if the asset combiner is disabled.
+    |--------------------------------------------------------------------------
+    |
+    | If the asset combining is disabled, themeJs, themeCss Twig filters won't
+    | combine arrays of assets into one single file and will leave them as
+    | they are and include assets per file individually. This setting
+    | won't make any effect to the basic Twig theme filter
+    |
+    */
+
+    'disableAssetCombine' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Check import timestamps when combining assets
     |--------------------------------------------------------------------------
     |
@@ -346,20 +360,20 @@ return [
     */
 
     'forceBytecodeInvalidation' => true,
-    
+
     /*
     |--------------------------------------------------------------------------
     | Twig Strict Variables
     |--------------------------------------------------------------------------
     |
-    | If strict_variables is disabled, Twig will silently ignore invalid 
+    | If strict_variables is disabled, Twig will silently ignore invalid
     | variables (variables and or attributes/methods that do not exist) and
     | replace them with a null value. When enabled, Twig throws an exception
     | instead. If set to null, it is enabled when debug mode (app.debug) is
     | enabled.
     |
     */
-    
+
     'enableTwigStrictVariables' => false,
 
     /*

--- a/modules/cms/helpers/Assets.php
+++ b/modules/cms/helpers/Assets.php
@@ -1,0 +1,36 @@
+<?php namespace Cms\Helpers;
+
+/**
+ * Assets Helper
+ *
+ * @package october\cms
+ * @see \Cms\Facades\Cms
+ * @author Alexey Bobkov, Samuel Georges
+ */
+class Assets
+{
+    const JS_TYPE_DEFAULT = 'text/javascript';
+
+    /**
+     * @param string $url
+     * @param string $type
+     * @param array  $attributes
+     *
+     * @return string
+     */
+    public static function renderJsAsset(string $url, string $type = self::JS_TYPE_DEFAULT, array $attributes = [])
+    {
+        return sprintf("<script type='%s' src='%s' %s></script>", $type, $url, implode(' ', $attributes));
+    }
+
+    /**
+     * @param string $url
+     * @param array  $attributes
+     *
+     * @return string
+     */
+    public static function renderCssAsset(string $url, array $attributes = [])
+    {
+        return sprintf("<link rel='stylesheet' href='%s' %s>", $url, implode(' ', $attributes));
+    }
+}


### PR DESCRIPTION
Hi guys!
I want to suggest a couple of new Twig filters to resolve octobercms/october#289, octobercms/october#1840 (and maybe some other previously opened issues with the same reason).

The usage example:

```
{{ [
	'assets/js/jquery.js',
	'assets/js/popper.min.js',
	'assets/js/bootstrap.js'
] | themeJs }}
```

With attributes:

```
{{ [
	'assets/js/jquery.js',
	'assets/js/popper.min.js',
	'assets/js/bootstrap.js'
] | themeJs('text/javascript', ["foo='bar'"]) }}
```

The same is for CSS with `themeCss` filter.

Depending on a new config setting `disableAssetCombine` (`null` by default) the filters will either return a single html node with a combined asset or multiple script or link nodes with single asset per node.

Please let me know what you think. 