### PR TITLE
fix: File name contains non-latin characters

### DIFF
--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -1582,7 +1582,7 @@ class MediaManager extends WidgetBase
      */
     protected function validateFileName($name)
     {
-        if (!preg_match('/^[\w@\.\s_\-]+$/iu', $name)) {
+        if (!preg_match('/^[[:ascii:]@\.\s_\-]+$/iu', $name)) {
             return false;
         }
 


### PR DESCRIPTION
Check for unsafe file extensions and name  throw exception https://github.com/octobercms/october/blob/develop/modules/system/classes/MediaLibrary.php#L492