### PR TITLE
Defer plugin installs from cli advanced step until October is installed

### DIFF
--- a/modules/system/console/OctoberInstall.php
+++ b/modules/system/console/OctoberInstall.php
@@ -71,16 +71,27 @@ class OctoberInstall extends Command
         $this->setupAdminUser();
         $this->setupCommonValues();
 
+        $chosenToInstall = [];
+
         if ($this->confirm('Configure advanced options?', false)) {
             $this->setupEncryptionKey();
             $this->setupAdvancedValues();
-            $this->askToInstallPlugins();
+            $chosenToInstall = $this->askToInstallPlugins();
         }
         else {
             $this->setupEncryptionKey(true);
         }
 
         $this->setupMigrateDatabase();
+
+        foreach($chosenToInstall as $pluginCode) {
+            $this->output->writeln('<info>Installing plugin '.$pluginCode.'</info>');
+            $this->callSilent('plugin:install', [
+                'name' => $pluginCode
+            ]);
+            $this->output->writeln('<info>'.$pluginCode.' installed successfully.</info>');
+        }
+
         $this->displayOutro();
     }
 
@@ -120,20 +131,14 @@ class OctoberInstall extends Command
     }
 
     protected function askToInstallPlugins() {
+        $chosenToInstall = [];
         if ($this->confirm('Install the October.Drivers plugin?', false)) {
-            $this->output->writeln('<info>Installing plugin October.Drivers</info>');
-            $this->callSilent('plugin:install', [
-                'name' => 'October.Drivers'
-            ]);
-            $this->output->writeln('<info>October.Drivers installed successfully.</info>');
+            $chosenToInstall[] = 'October.Drivers';
         }
         if($this->confirm('Install the Rainlab.Builder plugin?', false)) {
-            $this->output->writeln('<info>Installing plugin Rainlab.Builder</info>');
-            $this->callSilent('plugin:install', [
-                'name' => 'Rainlab.Builder'
-            ]);
-            $this->output->writeln('<info>Rainlab.Builder installed successfully.</info>');
+            $chosenToInstall[] = 'Rainlab.Builder';
         }
+        return $chosenToInstall;
     }
 
     //

--- a/modules/system/console/OctoberInstall.php
+++ b/modules/system/console/OctoberInstall.php
@@ -84,12 +84,12 @@ class OctoberInstall extends Command
 
         $this->setupMigrateDatabase();
 
-        foreach($chosenToInstall as $pluginCode) {
-            $this->output->writeln('<info>Installing plugin '.$pluginCode.'</info>');
+        foreach ($chosenToInstall as $pluginCode) {
+            $this->output->writeln('<info>Installing plugin ' . $pluginCode . '</info>');
             $this->callSilent('plugin:install', [
                 'name' => $pluginCode
             ]);
-            $this->output->writeln('<info>'.$pluginCode.' installed successfully.</info>');
+            $this->output->writeln('<info>' . $pluginCode . ' installed successfully.</info>');
         }
 
         $this->displayOutro();
@@ -135,7 +135,7 @@ class OctoberInstall extends Command
         if ($this->confirm('Install the October.Drivers plugin?', false)) {
             $chosenToInstall[] = 'October.Drivers';
         }
-        if($this->confirm('Install the Rainlab.Builder plugin?', false)) {
+        if ($this->confirm('Install the Rainlab.Builder plugin?', false)) {
             $chosenToInstall[] = 'Rainlab.Builder';
         }
         return $chosenToInstall;


### PR DESCRIPTION
Fixes #4155

Read about the problem here: https://github.com/octobercms/october/issues/4155
The following code was introduced here: https://github.com/octobercms/october/pull/2974 but it worked back then.

What I did was to return a list of plugin codes from `askToInstallPlugins` function instead of trying to install them right away, then after `setupMigrateDatabase` function is called, loop over the returned array and install the plugins the user chose.

The output then is:
```
Seeded System
Seeded Backend
Installing plugin October.Drivers
October.Drivers installed successfully.
Installing plugin Rainlab.Builder
Rainlab.Builder installed successfully.
```

