### PR TITLE
Delay backend controller middleware until after request is processed

### DIFF
--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -51,31 +51,48 @@ class BackendController extends ControllerBase
     protected $cmsHandling = false;
 
     /**
+     * Stores the requested controller so that the constructor is only run once
+     *
+     * @var Backend\Classes\Controller
+     */
+    protected $requestedController;
+
+    /**
      * Instantiate a new BackendController instance.
      */
     public function __construct()
     {
-        // Find requested controller to determine if any middleware has been attached
-        $pathParts = explode('/', str_replace(Request::root() . '/', '', Request::url()));
-        if (count($pathParts)) {
-            // Drop off preceding backend URL part if needed
-            if (!empty(Config::get('cms.backendUri', 'backend'))) {
-                array_shift($pathParts);
-            }
-            $path = implode('/', $pathParts);
+        $this->middleware(function ($request, $next) {
+            $response = $next($request);
 
-            $requestedController = $this->getRequestedController($path);
-            if (!is_null($requestedController) && count($requestedController['controller']->getMiddleware())) {
-                $action = $requestedController['action'];
+            // Find requested controller to determine if any middleware has been attached
+            $pathParts = explode('/', str_replace(Request::root() . '/', '', Request::url()));
+            if (count($pathParts)) {
+                // Drop off preceding backend URL part if needed
+                if (!empty(Config::get('cms.backendUri', 'backend'))) {
+                    array_shift($pathParts);
+                }
+                $path = implode('/', $pathParts);
 
-                // Collect applicable middleware and insert middleware into pipeline
-                collect($requestedController['controller']->getMiddleware())->reject(function ($data) use ($action) {
-                    return static::methodExcludedByOptions($action, $data['options']);
-                })->pluck('middleware')->map(function ($middleware) {
-                    $this->middleware($middleware);
-                });
+                $requestedController = $this->getRequestedController($path);
+                if (!is_null($requestedController) && count($requestedController['controller']->getMiddleware())) {
+                    $action = $requestedController['action'];
+
+                    // Collect applicable middleware and insert middleware into pipeline
+                    $controllerMiddleware = collect($requestedController['controller']->getMiddleware())
+                        ->reject(function ($data) use ($action) {
+                            return static::methodExcludedByOptions($action, $data['options']);
+                        })
+                        ->pluck('middleware');
+
+                    foreach ($controllerMiddleware as $middleware) {
+                        $middleware->call($requestedController['controller'], $request, $response);
+                    }
+                }
             }
-        }
+
+            return $response;
+        });
 
         $this->extendableConstruct();
     }
@@ -221,6 +238,10 @@ class BackendController extends ControllerBase
      */
     protected function findController($controller, $action, $inPath)
     {
+        if (isset($this->requestedController)) {
+            return $this->requestedController;
+        }
+
         /*
          * Workaround: Composer does not support case insensitivity.
          */
@@ -233,16 +254,16 @@ class BackendController extends ControllerBase
         }
 
         if (!class_exists($controller)) {
-            return false;
+            return $this->requestedController = null;
         }
 
         $controllerObj = App::make($controller);
 
         if ($controllerObj->actionExists($action)) {
-            return $controllerObj;
+            return $this->requestedController= $controllerObj;
         }
 
-        return false;
+        return $this->requestedController = null;
     }
 
     /**

--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -263,7 +263,7 @@ class BackendController extends ControllerBase
         $controllerObj = App::make($controller);
 
         if ($controllerObj->actionExists($action)) {
-            return $this->requestedController= $controllerObj;
+            return $this->requestedController = $controllerObj;
         }
 
         return $this->requestedController = null;

--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -63,6 +63,8 @@ class BackendController extends ControllerBase
     public function __construct()
     {
         $this->middleware(function ($request, $next) {
+            // Process the request before retrieving controller middleware, to allow for the session and auth data
+            // to be made available to the controller's constructor.
             $response = $next($request);
 
             // Find requested controller to determine if any middleware has been attached

--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -33,20 +33,16 @@ class Auth extends Controller
     {
         parent::__construct();
 
-        $this->middleware(function ($request, $next) {
-            $response = $next($request);
+        $this->middleware(function ($request, $response) {
             // Clear Cache and any previous data to fix Invalid security token issue, see github: #3707
             $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
-            return $response;
         })->only('signin');
 
 		// Only run on HTTPS connections
 		if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] === "on") {
-            $this->middleware(function ($request, $next) {
-                $response = $next($request);
+            $this->middleware(function ($request, $response) {
                 // Add HTTP Header 'Clear Site Data' to remove all Sensitive Data when signout, see github issue: #3707
                 $response->headers->set('Clear-Site-Data', 'cache, cookies, storage, executionContexts');
-                return $response;
             })->only('signout');
         }
 


### PR DESCRIPTION
Fixes #4183.

Delays the processing of controller middleware until after the request is processed, which will prevent issues with controllers in October CMS relying on session data and the like.

Note that this will make middleware act more like ["terminable middleware"](https://laravel.com/docs/5.5/middleware#terminable-middleware) in that you can retrieve the request, and manipulate the response, but you cannot manipulate the request. Therefore, there is a slight change to the `middleware` closure that will need to be provided by controller middleware.

```
public function __construct()
{
    $this->middleware(function ($request, $response) {
        // You can use any $response methods here, and refer to the $request
    });
}
```