### PR TITLE
Reuse the model instance from Form widget

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1062,7 +1062,7 @@ class RelationController extends ControllerBehavior
         $saveData = $this->manageWidget->getSaveData();
 
         if ($this->viewMode == 'multi') {
-            $model = $this->relationModel->find($this->manageId);
+            $model = $this->manageWidget->model;
             $modelsToSave = $this->prepareModelsToSave($model, $saveData);
             foreach ($modelsToSave as $modelToSave) {
                 $modelToSave->save(null, $this->manageWidget->getSessionKey());


### PR DESCRIPTION
This fixes https://github.com/rainlab/translate-plugin/issues/209

This is a potentially breaking change. In my tests, everything went smooth, however I am almost certain that it affects a lot of cases that I have not thought of.