### PR TITLE
Append the color picker modal to parent element

### DIFF
--- a/modules/backend/formwidgets/colorpicker/assets/js/colorpicker.js
+++ b/modules/backend/formwidgets/colorpicker/assets/js/colorpicker.js
@@ -56,6 +56,7 @@
                 color: this.$customColor.data('hexColor'),
                 chooseText: $.oc.lang.get('colorpicker.choose', 'Ok'),
                 cancelText: '⨯',
+                appendTo: 'parent',
                 hide: function(color) {
                     var hex = color ? color.toHexString() : ''
                     self.$customColorSpan.css('background', hex)


### PR DESCRIPTION
This fixes #4117 
Currently, the color picker modal (palette) is appended to the body (default) which makes it unusable in Octobers modals, e.g. for related model forms. This fixes this issue by appending the spectrum div to the parent element.

Credits to @Samuell1 for finding this fix.