### PR TITLE
Make default format options configurable

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -597,9 +597,9 @@ class ImportExportController extends ControllerBehavior
          */
         $defaultOptions = [
             'fileName' => $this->exportFileName,
-            'delimiter' => $this->getConfig('formatOptions[delimiter]', ','),
-            'enclosure' => $this->getConfig('formatOptions[enclosure]', '"'),
-            'escape' => $this->getConfig('formatOptions[escape]', '\\'),
+            'delimiter' => $this->getConfig('defaultFormatOptions[delimiter]', ','),
+            'enclosure' => $this->getConfig('defaultFormatOptions[enclosure]', '"'),
+            'escape' => $this->getConfig('defaultFormatOptions[escape]', '\\'),
         ];
 
         $options = array_merge($defaultOptions, $options);
@@ -801,10 +801,10 @@ class ImportExportController extends ControllerBehavior
         $presetMode = post('format_preset');
 
         $options = [
-            'delimiter' => $this->getConfig('formatOptions[delimiter]'),
-            'enclosure' => $this->getConfig('formatOptions[enclosure]'),
-            'escape' => $this->getConfig('formatOptions[escape]'),
-            'encoding' => $this->getConfig('formatOptions[encoding]'),
+            'delimiter' => $this->getConfig('defaultFormatOptions[delimiter]'),
+            'enclosure' => $this->getConfig('defaultFormatOptions[enclosure]'),
+            'escape' => $this->getConfig('defaultFormatOptions[escape]'),
+            'encoding' => $this->getConfig('defaultFormatOptions[encoding]'),
         ];
 
         if ($presetMode == 'custom') {

--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -799,10 +799,10 @@ class ImportExportController extends ControllerBehavior
         $presetMode = post('format_preset');
 
         $options = [
-            'delimiter' => null,
-            'enclosure' => null,
-            'escape' => null,
-            'encoding' => null
+            'delimiter' => $this->getConfig('formatOptions[delimiter]'),
+            'enclosure' => $this->getConfig('formatOptions[enclosure]'),
+            'escape' => $this->getConfig('formatOptions[escape]'),
+            'encoding' => $this->getConfig('formatOptions[encoding]'),
         ];
 
         if ($presetMode == 'custom') {

--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -597,8 +597,9 @@ class ImportExportController extends ControllerBehavior
          */
         $defaultOptions = [
             'fileName' => $this->exportFileName,
-            'delimiter' => ',',
-            'enclosure' => '"'
+            'delimiter' => $this->getConfig('formatOptions[delimiter]', ','),
+            'enclosure' => $this->getConfig('formatOptions[enclosure]', '"'),
+            'escape' => $this->getConfig('formatOptions[escape]', '\\'),
         ];
 
         $options = array_merge($defaultOptions, $options);
@@ -609,6 +610,7 @@ class ImportExportController extends ControllerBehavior
         $csv = CsvWriter::createFromFileObject(new SplTempFileObject);
         $csv->setDelimiter($options['delimiter']);
         $csv->setEnclosure($options['enclosure']);
+        $csv->setEscape($options['escape']);
 
         /*
          * Add headers


### PR DESCRIPTION
If the default format mode is selected, there is no chance to configure the format options for delimiter, enclosure, escape and encoding. This considers a new config file item `formatOptions` and falls back to `null` if it is not specified.

I will also provide a PR to the docs.