### PR TITLE
Display backend 404 for non-existent backend urls if CMS module is not loaded

### DIFF
--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -96,7 +96,7 @@ class BackendController extends ControllerBase
      */
     protected function passToCmsController($url)
     {
-        if (class_exists('\Cms\Classes\Controller')) {
+        if (in_array('Cms', Config::get('cms.loadModules', [])))  {
             $this->cmsHandling = true;
             return App::make('Cms\Classes\Controller')->run($url);
         } else {

--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -96,7 +96,10 @@ class BackendController extends ControllerBase
      */
     protected function passToCmsController($url)
     {
-        if (in_array('Cms', Config::get('cms.loadModules', [])))  {
+        if (
+            in_array('Cms', Config::get('cms.loadModules', [])) &&
+            class_exists('\Cms\Classes\Controller')
+        ) {
             $this->cmsHandling = true;
             return App::make('Cms\Classes\Controller')->run($url);
         } else {


### PR DESCRIPTION
There are projects that sometimes only require the backend feature's to be used. This can be achieved by [disabling the active theme](https://github.com/octobercms/october/blob/3118660d834f161d513da08477be92281a2eb96a/config/cms.php#L14), [setting the backend URI to null](https://github.com/octobercms/october/blob/3118660d834f161d513da08477be92281a2eb96a/config/cms.php#L39), and [removing the CMS module from the active modules](https://github.com/octobercms/october/blob/3118660d834f161d513da08477be92281a2eb96a/config/cms.php#L105) in [config/cms.php](https://github.com/octobercms/october/blob/master/config/cms.php).

However, the current check for routing backend requests [only checks if the CMS Controller exists](https://github.com/octobercms/october/blob/3118660d834f161d513da08477be92281a2eb96a/modules/backend/classes/BackendController.php#L71). This will result in an exception being thrown if the above steps have been implemented because the CMS Controller technically exists, but there is no active theme to make the view from.

@alxy Found [the solution to check the `loadModules` array for `Cms`](https://github.com/octobercms/october/blob/26173486d39cdf4312535ecf247e3d7a161713b4/modules/system/reportwidgets/Status.php#L98)%5Bhttps://github.com/octobercms/october/blob/26173486d39cdf4312535ecf247e3d7a161713b4/modules/system/reportwidgets/Status.php#L98%5D) which will produce the backend 404 page as desired:

This PR addresses #4201.