### PR TITLE
[WIP] Relation manage filters

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -559,20 +559,6 @@ class RelationController extends ControllerBehavior
         $filterConfig->alias = $this->alias . 'Filter';
         $filterWidget = $this->makeWidget('Backend\Widgets\Filter', $filterConfig);
 
-        /*
-         * Filter Widget with extensibility
-         */
-        $filterWidget->bindEvent('filter.extendScopes', function () use ($filterWidget) {
-            $this->controller->listFilterExtendScopes($filterWidget);
-        });
-
-        /*
-         * Extend the query of the list of options
-         */
-        $filterWidget->bindEvent('filter.extendQuery', function ($query, $scope) {
-            $this->controller->listFilterExtendQuery($query, $scope);
-        });
-
         return $filterWidget;
     }
 

--- a/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_manage_list.htm
@@ -11,6 +11,9 @@
             <?php if ($relationSearchWidget): ?>
                 <?= $relationSearchWidget->render() ?>
             <?php endif ?>
+            <?php if ($relationFilterWidget): ?>
+                <?= $relationFilterWidget->render() ?>
+            <?php endif ?>
             <?= $relationManageWidget->render() ?>
         </div>
 

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -98,7 +98,7 @@ class Filter extends WidgetBase
      */
     public function renderScopeElement($scope)
     {
-        $params = ['scope' => $scope];
+        $params = ['scope' => $scope, 'alias' => $this->alias];
 
         switch ($scope->type) {
             case 'date':

--- a/modules/backend/widgets/filter/partials/_scope_text.htm
+++ b/modules/backend/widgets/filter/partials/_scope_text.htm
@@ -3,7 +3,7 @@
         <?= e(trans($scope->label)) ?>:
         <input type="text"
                name="options[value][]"
-               data-request="listFilter::onFilterUpdate"
+               data-request="<?= $alias ?>::onFilterUpdate"
                data-request-data="'scopeName':'<?= $scope->scopeName ?>'"
                data-track-input
                data-load-indicator

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -38,6 +38,11 @@
     // =================
 
     FilterWidget.prototype.initFilterDate = function () {
+        this.unregisterHandlersDate() // Unregister any previously defined handlers
+        this.registerHandlersDate()
+    }
+
+    FilterWidget.prototype.registerHandlersDate = function() {
         var self = this
 
         this.$el.on('show.oc.popover', 'a.filter-scope-date', function () {
@@ -60,43 +65,62 @@
             }, 200)
         })
 
-        this.$el.on('click', 'a.filter-scope-date', function () {
-            var $scope = $(this),
-                scopeName = $scope.data('scope-name')
+        this.$el.on('click', 'a.filter-scope-date', $.proxy(this.onClickScopeDate, this))
+        $(document).on('click', '#controlFilterPopoverDate [data-trigger="filter"]', $.proxy(this.onClickFilterDate, this))
+        $(document).on('click', '#controlFilterPopoverDate [data-trigger="clear"]', $.proxy(this.onClickClearDate, this))
+    }
 
-            // Ignore if already opened
-            if ($scope.hasClass('filter-scope-open')) return
+    FilterWidget.prototype.unregisterHandlersDate = function() {
+        this.$el.off('show.oc.popover', 'a.filter-scope-date')
+        this.$el.off('hiding.oc.popover', 'a.filter-scope-date')
+        this.$el.off('hide.oc.popover', 'a.filter-scope-date')
 
-            // Ignore if another popover is opened
-            if (null !== self.activeScopeName) return
+        this.$el.off('click', 'a.filter-scope-date', $.proxy(this.onClickScopeDate, this))
+        $(document).off('click', '#controlFilterPopoverDate [data-trigger="filter"]', $.proxy(this.onClickFilterDate, this))
+        $(document).off('click', '#controlFilterPopoverDate [data-trigger="clear"]', $.proxy(this.onClickClearDate, this))
+    }
 
-            self.$activeScope = $scope
-            self.activeScopeName = scopeName
-            self.isActiveScopeDirty = false
+    /*
+     * Event handlers
+     */
 
-            if ($scope.hasClass('range')) {
-                self.displayPopoverRange($scope)
-            }
-            else {
-                self.displayPopoverDate($scope)
-            }
+    FilterWidget.prototype.onClickScopeDate = function (ev) {
+        var $scope = $(ev.currentTarget),
+            scopeName = $scope.data('scope-name')
 
-            $scope.addClass('filter-scope-open')
-        })
+        // Ignore if already opened
+        if ($scope.hasClass('filter-scope-open')) return
 
-        $(document).on('click', '#controlFilterPopoverDate [data-trigger="filter"]', function (e) {
-            e.preventDefault()
-            e.stopPropagation()
+        // Ignore if another popover is opened
+        if (null !== this.activeScopeName) return
 
-            self.filterByDate()
-        })
+        this.$activeScope = $scope
+        this.activeScopeName = scopeName
+        this.isActiveScopeDirty = false
 
-        $(document).on('click', '#controlFilterPopoverDate [data-trigger="clear"]', function (e) {
-            e.preventDefault()
-            e.stopPropagation()
+        if ($scope.hasClass('range')) {
+            this.displayPopoverRange($scope)
+        }
+        else {
 
-            self.filterByDate(true)
-        })
+            this.displayPopoverDate($scope)
+        }
+
+        $scope.addClass('filter-scope-open')
+    }
+
+    FilterWidget.prototype.onClickFilterDate = function (e) {
+        e.preventDefault()
+        e.stopPropagation()
+
+        this.filterByDate()
+    }
+
+    FilterWidget.prototype.onClickClearDate = function (e) {
+        e.preventDefault()
+        e.stopPropagation()
+
+        this.filterByDate(true)
     }
 
     /*

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -200,7 +200,6 @@
             highlightModalTarget: true,
             closeOnPageClick: true,
             placement: 'bottom',
-            container: this.$el,
             onCheckDocumentClickTarget: function (target) {
                 return self.onCheckDocumentClickTargetDatePicker(target)
             }
@@ -230,7 +229,6 @@
             highlightModalTarget: true,
             closeOnPageClick: true,
             placement: 'bottom',
-            container: this.$el,
             onCheckDocumentClickTarget: function (target) {
                 return self.onCheckDocumentClickTargetDatePicker(target)
             }

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -38,15 +38,24 @@
     // =================
 
     FilterWidget.prototype.initFilterDate = function () {
-        this.unregisterHandlersDate() // Unregister any previously defined handlers
-        this.registerHandlersDate()
-    }
-
-    FilterWidget.prototype.registerHandlersDate = function() {
         var self = this
 
-        this.$el.on('show.oc.popover', 'a.filter-scope-date', function () {
+        this.$el.on('show.oc.popover', 'a.filter-scope-date', function (event) {
             self.initDatePickers($(this).hasClass('range'))
+
+            $(event.relatedTarget).on('click', '#controlFilterPopoverDate [data-trigger="filter"]', function (e) {
+                e.preventDefault()
+                e.stopPropagation()
+
+                self.filterByDate()
+            })
+
+            $(event.relatedTarget).on('click', '#controlFilterPopoverDate [data-trigger="clear"]', function (e) {
+                e.preventDefault()
+                e.stopPropagation()
+
+                self.filterByDate(true)
+            })
         })
 
         this.$el.on('hiding.oc.popover', 'a.filter-scope-date', function () {
@@ -65,62 +74,29 @@
             }, 200)
         })
 
-        this.$el.on('click', 'a.filter-scope-date', $.proxy(this.onClickScopeDate, this))
-        $(document).on('click', '#controlFilterPopoverDate [data-trigger="filter"]', $.proxy(this.onClickFilterDate, this))
-        $(document).on('click', '#controlFilterPopoverDate [data-trigger="clear"]', $.proxy(this.onClickClearDate, this))
-    }
+        this.$el.on('click', 'a.filter-scope-date', function () {
+            var $scope = $(this),
+                scopeName = $scope.data('scope-name')
 
-    FilterWidget.prototype.unregisterHandlersDate = function() {
-        this.$el.off('show.oc.popover', 'a.filter-scope-date')
-        this.$el.off('hiding.oc.popover', 'a.filter-scope-date')
-        this.$el.off('hide.oc.popover', 'a.filter-scope-date')
+            // Ignore if already opened
+            if ($scope.hasClass('filter-scope-open')) return
 
-        this.$el.off('click', 'a.filter-scope-date', $.proxy(this.onClickScopeDate, this))
-        $(document).off('click', '#controlFilterPopoverDate [data-trigger="filter"]', $.proxy(this.onClickFilterDate, this))
-        $(document).off('click', '#controlFilterPopoverDate [data-trigger="clear"]', $.proxy(this.onClickClearDate, this))
-    }
+            // Ignore if another popover is opened
+            if (null !== self.activeScopeName) return
 
-    /*
-     * Event handlers
-     */
+            self.$activeScope = $scope
+            self.activeScopeName = scopeName
+            self.isActiveScopeDirty = false
 
-    FilterWidget.prototype.onClickScopeDate = function (ev) {
-        var $scope = $(ev.currentTarget),
-            scopeName = $scope.data('scope-name')
+            if ($scope.hasClass('range')) {
+                self.displayPopoverRange($scope)
+            }
+            else {
+                self.displayPopoverDate($scope)
+            }
 
-        // Ignore if already opened
-        if ($scope.hasClass('filter-scope-open')) return
-
-        // Ignore if another popover is opened
-        if (null !== this.activeScopeName) return
-
-        this.$activeScope = $scope
-        this.activeScopeName = scopeName
-        this.isActiveScopeDirty = false
-
-        if ($scope.hasClass('range')) {
-            this.displayPopoverRange($scope)
-        }
-        else {
-
-            this.displayPopoverDate($scope)
-        }
-
-        $scope.addClass('filter-scope-open')
-    }
-
-    FilterWidget.prototype.onClickFilterDate = function (e) {
-        e.preventDefault()
-        e.stopPropagation()
-
-        this.filterByDate()
-    }
-
-    FilterWidget.prototype.onClickClearDate = function (e) {
-        e.preventDefault()
-        e.stopPropagation()
-
-        this.filterByDate(true)
+            $scope.addClass('filter-scope-open')
+        })
     }
 
     /*

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -200,6 +200,7 @@
             highlightModalTarget: true,
             closeOnPageClick: true,
             placement: 'bottom',
+            container: this.$el,
             onCheckDocumentClickTarget: function (target) {
                 return self.onCheckDocumentClickTargetDatePicker(target)
             }
@@ -229,6 +230,7 @@
             highlightModalTarget: true,
             closeOnPageClick: true,
             placement: 'bottom',
+            container: this.$el,
             onCheckDocumentClickTarget: function (target) {
                 return self.onCheckDocumentClickTargetDatePicker(target)
             }

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -270,12 +270,12 @@
             data = { loading: true }
             isLoaded = false
         }
-        
+
         data = $.extend({}, data, {
             apply_button_text: this.getLang('filter.scopes.apply_button_text', 'Apply'),
             clear_button_text: this.getLang('filter.scopes.clear_button_text', 'Clear')
         })
-        
+
         data.scopeName = scopeName
         data.optionsHandler = self.options.optionsHandler
 
@@ -290,9 +290,9 @@
             placement: 'bottom',
             container: container
         })
-        
+
         this.toggleFilterButtons()
-        
+
         // Load options for the first time
         if (!isLoaded) {
             self.loadOptions(scopeName)
@@ -304,8 +304,7 @@
      * otherwise returns a deferred promise object.
      */
     FilterWidget.prototype.loadOptions = function(scopeName) {
-        var $form = this.$el.closest('form'),
-            self = this,
+        var self = this,
             data = { scopeName: scopeName }
 
         /*
@@ -320,7 +319,7 @@
         /*
          * Request options from server
          */
-        return $form.request(this.options.optionsHandler, {
+        return this.$el.request(this.options.optionsHandler, {
             data: data,
             success: function(data) {
                 self.fillOptions(scopeName, data.options)
@@ -416,14 +415,13 @@
         if (!this.isActiveScopeDirty || !this.options.updateHandler)
             return
 
-        var $form = this.$el.closest('form'),
-            data = {
-                scopeName: scopeName,
-                options: this.scopeValues[scopeName]
-            }
+        var data = {
+            scopeName: scopeName,
+            options: this.scopeValues[scopeName]
+        }
 
         $.oc.stripeLoadIndicator.show()
-        $form.request(this.options.updateHandler, {
+        this.$el.request(this.options.updateHandler, {
             data: data
         }).always(function(){
             $.oc.stripeLoadIndicator.hide()
@@ -438,14 +436,13 @@
         this.scopeValues[scopeName] = isChecked
 
         if (this.options.updateHandler) {
-            var $form = this.$el.closest('form'),
-                data = {
-                    scopeName: scopeName,
-                    value: isChecked
-                }
+            var data = {
+                scopeName: scopeName,
+                value: isChecked
+            }
 
             $.oc.stripeLoadIndicator.show()
-            $form.request(this.options.updateHandler, {
+            this.$el.request(this.options.updateHandler, {
                 data: data
             }).always(function(){
                 $.oc.stripeLoadIndicator.hide()
@@ -463,14 +460,13 @@
         this.scopeValues[scopeName] = switchValue
 
         if (this.options.updateHandler) {
-            var $form = this.$el.closest('form'),
-                data = {
-                    scopeName: scopeName,
-                    value: switchValue
-                }
+            var data = {
+                scopeName: scopeName,
+                value: switchValue
+            }
 
             $.oc.stripeLoadIndicator.show()
-            $form.request(this.options.updateHandler, {
+            this.$el.request(this.options.updateHandler, {
                 data: data
             }).always(function(){
                 $.oc.stripeLoadIndicator.hide()

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -37,6 +37,11 @@
     // =================
 
     FilterWidget.prototype.initFilterNumber = function () {
+        this.unregisterHandlersNumber() // Unregister any previously defined handlers
+        this.registerHandlersNumber()
+    }
+
+    FilterWidget.prototype.registerHandlersNumber = function() {
         var self = this
 
         this.$el.on('show.oc.popover', 'a.filter-scope-number', function () {
@@ -55,41 +60,54 @@
             }, 200)
         })
 
-        this.$el.on('click', 'a.filter-scope-number', function () {
-            var $scope = $(this),
-                scopeName = $scope.data('scope-name')
+        this.$el.on('click', 'a.filter-scope-number', $.proxy(this.onClickScopeNumber, this))
+        $(document).on('click', '#controlFilterPopoverNum [data-trigger="filter"]', $.proxy(this.onClickFilterNumber, this))
+        $(document).on('click', '#controlFilterPopoverNum [data-trigger="clear"]', $.proxy(this.onClickClearNumber, this))
+    }
 
-            // Ignore if already opened
-            if ($scope.hasClass('filter-scope-open')) return
+    FilterWidget.prototype.unregisterHandlersNumber = function() {
+        this.$el.off('show.oc.popover', 'a.filter-scope-number')
+        this.$el.off('hide.oc.popover', 'a.filter-scope-number')
 
-            // Ignore if another popover is opened
-            if (null !== self.activeScopeName) return
-            self.$activeScope = $scope
-            self.activeScopeName = scopeName
-            self.isActiveScopeDirty = false
+        this.$el.off('click', 'a.filter-scope-number', $.proxy(this.onClickScopeNumber, this))
+        $(document).off('click', '#controlFilterPopoverNum [data-trigger="filter"]', $.proxy(this.onClickFilterNumber, this))
+        $(document).off('click', '#controlFilterPopoverNum [data-trigger="clear"]', $.proxy(this.onClickClearNumber, this))
+    }
 
-            if ($scope.hasClass('range')) {
-                self.displayPopoverNumberRange($scope)
-            }
-            else {
-                self.displayPopoverNumber($scope)
-            }
+    FilterWidget.prototype.onClickScopeNumber = function (ev) {
+        var $scope = $(ev.currentTarget),
+            scopeName = $scope.data('scope-name')
 
-            $scope.addClass('filter-scope-open')
-        })
+        // Ignore if already opened
+        if ($scope.hasClass('filter-scope-open')) return
 
-        $(document).on('click', '#controlFilterPopoverNum [data-trigger="filter"]', function (e) {
-            e.preventDefault()
-            e.stopPropagation()
-            self.filterByNumber()
-        })
+        // Ignore if another popover is opened
+        if (null !== this.activeScopeName) return
+        this.$activeScope = $scope
+        this.activeScopeName = scopeName
+        this.isActiveScopeDirty = false
 
-        $(document).on('click', '#controlFilterPopoverNum [data-trigger="clear"]', function (e) {
-            e.preventDefault()
-            e.stopPropagation()
+        if ($scope.hasClass('range')) {
+            this.displayPopoverNumberRange($scope)
+        }
+        else {
+            this.displayPopoverNumber($scope)
+        }
 
-            self.filterByNumber(true)
-        })
+        $scope.addClass('filter-scope-open')
+    }
+
+    FilterWidget.prototype.onClickFilterNumber = function (e) {
+        e.preventDefault()
+        e.stopPropagation()
+        this.filterByNumber()
+    }
+
+    FilterWidget.prototype.onClickClearNumber = function (e) {
+        e.preventDefault()
+        e.stopPropagation()
+
+        this.filterByNumber(true)
     }
 
     /*
@@ -192,6 +210,7 @@
             highlightModalTarget: true,
             closeOnPageClick: true,
             placement: 'bottom',
+            container: this.$el
         })
     }
 
@@ -218,6 +237,7 @@
             highlightModalTarget: true,
             closeOnPageClick: true,
             placement: 'bottom',
+            container: this.$el,
         })
     }
 

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -37,15 +37,23 @@
     // =================
 
     FilterWidget.prototype.initFilterNumber = function () {
-        this.unregisterHandlersNumber() // Unregister any previously defined handlers
-        this.registerHandlersNumber()
-    }
-
-    FilterWidget.prototype.registerHandlersNumber = function() {
         var self = this
 
-        this.$el.on('show.oc.popover', 'a.filter-scope-number', function () {
+        this.$el.on('show.oc.popover', 'a.filter-scope-number', function (event) {
             self.initNumberInputs($(this).hasClass('range'))
+
+            $(event.relatedTarget).on('click', '#controlFilterPopoverNum [data-trigger="filter"]', function (e) {
+                e.preventDefault()
+                e.stopPropagation()
+                self.filterByNumber()
+            })
+
+            $(event.relatedTarget).on('click', '#controlFilterPopoverNum [data-trigger="clear"]', function (e) {
+                e.preventDefault()
+                e.stopPropagation()
+
+                self.filterByNumber(true)
+            })
         })
 
         this.$el.on('hide.oc.popover', 'a.filter-scope-number', function () {
@@ -60,54 +68,28 @@
             }, 200)
         })
 
-        this.$el.on('click', 'a.filter-scope-number', $.proxy(this.onClickScopeNumber, this))
-        $(document).on('click', '#controlFilterPopoverNum [data-trigger="filter"]', $.proxy(this.onClickFilterNumber, this))
-        $(document).on('click', '#controlFilterPopoverNum [data-trigger="clear"]', $.proxy(this.onClickClearNumber, this))
-    }
+        this.$el.on('click', 'a.filter-scope-number', function () {
+            var $scope = $(this),
+                scopeName = $scope.data('scope-name')
 
-    FilterWidget.prototype.unregisterHandlersNumber = function() {
-        this.$el.off('show.oc.popover', 'a.filter-scope-number')
-        this.$el.off('hide.oc.popover', 'a.filter-scope-number')
+            // Ignore if already opened
+            if ($scope.hasClass('filter-scope-open')) return
 
-        this.$el.off('click', 'a.filter-scope-number', $.proxy(this.onClickScopeNumber, this))
-        $(document).off('click', '#controlFilterPopoverNum [data-trigger="filter"]', $.proxy(this.onClickFilterNumber, this))
-        $(document).off('click', '#controlFilterPopoverNum [data-trigger="clear"]', $.proxy(this.onClickClearNumber, this))
-    }
+            // Ignore if another popover is opened
+            if (null !== self.activeScopeName) return
+            self.$activeScope = $scope
+            self.activeScopeName = scopeName
+            self.isActiveScopeDirty = false
 
-    FilterWidget.prototype.onClickScopeNumber = function (ev) {
-        var $scope = $(ev.currentTarget),
-            scopeName = $scope.data('scope-name')
+            if ($scope.hasClass('range')) {
+                self.displayPopoverNumberRange($scope)
+            }
+            else {
+                self.displayPopoverNumber($scope)
+            }
 
-        // Ignore if already opened
-        if ($scope.hasClass('filter-scope-open')) return
-
-        // Ignore if another popover is opened
-        if (null !== this.activeScopeName) return
-        this.$activeScope = $scope
-        this.activeScopeName = scopeName
-        this.isActiveScopeDirty = false
-
-        if ($scope.hasClass('range')) {
-            this.displayPopoverNumberRange($scope)
-        }
-        else {
-            this.displayPopoverNumber($scope)
-        }
-
-        $scope.addClass('filter-scope-open')
-    }
-
-    FilterWidget.prototype.onClickFilterNumber = function (e) {
-        e.preventDefault()
-        e.stopPropagation()
-        this.filterByNumber()
-    }
-
-    FilterWidget.prototype.onClickClearNumber = function (e) {
-        e.preventDefault()
-        e.stopPropagation()
-
-        this.filterByNumber(true)
+            $scope.addClass('filter-scope-open')
+        })
     }
 
     /*
@@ -237,7 +219,7 @@
             highlightModalTarget: true,
             closeOnPageClick: true,
             placement: 'bottom',
-            container: this.$el,
+            container: this.$el
         })
     }
 

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -191,8 +191,7 @@
             modal: false,
             highlightModalTarget: true,
             closeOnPageClick: true,
-            placement: 'bottom',
-            container: this.$el
+            placement: 'bottom'
         })
     }
 
@@ -218,8 +217,7 @@
             modal: false,
             highlightModalTarget: true,
             closeOnPageClick: true,
-            placement: 'bottom',
-            container: this.$el
+            placement: 'bottom'
         })
     }
 


### PR DESCRIPTION
**This PR is a WIP**

It aims at making [list filters](https://octobercms.com/docs/backend/lists#list-filters) available for the RelationController, specifically the manage widget.

Example usage in `config_relation.yaml`:
```
posts:
    label: Posts
    list: ~/plugins/october/test/models/post/columns.yaml
    form: ~/plugins/october/test/models/post/fields_simple.yaml
    manage:
        showSearch: true
        filter:
            scopes:
                published_at:
                    label: Date
                    type: daterange
                    conditions: created_at >= ':after' AND created_at <= ':before'
                username:
                    label: Name
                    type: text
                    conditions: name = :value
                    size: 2
                status:
                    label: Status
                    modelClass: October\Test\Models\Attribute
                    conditions: status_id in (:filtered)
                    nameFrom: name
```

![Peek 2019-03-20 11-29](https://user-images.githubusercontent.com/2057062/54678052-9861a800-4b04-11e9-99e1-15de09005a73.gif)



It does work, however there are some issues that need to be fixed. These are mostly interface/javascript based:
- [x]  The `date` and `daterange` pickers appear to open behind the modal
- [x] Clicking apply/clear on a filter popup triggers a JS error
- [x] Figure out why the positioning of the popups is a bit off when using a container element

I debugged the JS errors a bit and they do happen if the modal is opened a second time without a har refresh of the page. It appears, in this case the filter is not correctly re-initialized. Here are the errors I am getting in the console once I clear the Apply/Clear buttons on a filter widget popover:

```
storm-min.js?v447:31699 Uncaught TypeError: Cannot read property 'find' of null
    at FilterWidget.updateScopeDateSetting (storm-min.js?v447:31699)
    at FilterWidget.filterByDate (storm-min.js?v447:31765)
    at HTMLButtonElement.<anonymous> (storm-min.js?v447:31498)
    at HTMLDocument.dispatch (jquery.min.js?v447:5201)
    at HTMLDocument.elemData.handle (jquery.min.js?v447:5009)
FilterWidget.updateScopeDateSetting @ storm-min.js?v447:31699
FilterWidget.filterByDate @ storm-min.js?v447:31765
(anonymous) @ storm-min.js?v447:31498
dispatch @ jquery.min.js?v447:5201
elemData.handle @ jquery.min.js?v447:5009
3storm-min.js?v447:31699 Uncaught TypeError: Cannot read property 'find' of null
    at FilterWidget.updateScopeDateSetting (storm-min.js?v447:31699)
    at FilterWidget.filterByDate (storm-min.js?v447:31765)
    at HTMLButtonElement.<anonymous> (storm-min.js?v447:31505)
    at HTMLDocument.dispatch (jquery.min.js?v447:5201)
    at HTMLDocument.elemData.handle (jquery.min.js?v447:5009)
FilterWidget.updateScopeDateSetting @ storm-min.js?v447:31699
FilterWidget.filterByDate @ storm-min.js?v447:31765
(anonymous) @ storm-min.js?v447:31505
dispatch @ jquery.min.js?v447:5201
elemData.handle @ jquery.min.js?v447:5009
storm-min.js?v447:31347 Uncaught TypeError: Cannot read property 'data' of null
    at FilterWidget.filterScope (storm-min.js?v447:31347)
    at HTMLButtonElement.<anonymous> (storm-min.js?v447:31052)
    at HTMLDocument.dispatch (jquery.min.js?v447:5201)
    at HTMLDocument.elemData.handle (jquery.min.js?v447:5009)
```