### PR TITLE
Allow List Widget configs to add CSS classes to head column cell

### DIFF
--- a/modules/backend/classes/ListColumn.php
+++ b/modules/backend/classes/ListColumn.php
@@ -82,6 +82,11 @@ class ListColumn
     public $cssClass;
 
     /**
+     * @var string Specify a CSS class to attach to the list header cell element.
+     */
+    public $headCssClass;
+
+    /**
      * @var string Specify a format or style for the column value, such as a Date.
      */
     public $format;
@@ -137,6 +142,9 @@ class ListColumn
         }
         if (isset($config['cssClass'])) {
             $this->cssClass = $config['cssClass'];
+        }
+        if (isset($config['headCssClass'])) {
+            $this->headCssClass = $config['headCssClass'];
         }
         if (isset($config['searchable'])) {
             $this->searchable = $config['searchable'];

--- a/modules/backend/widgets/lists/partials/_list_head_row.htm
+++ b/modules/backend/widgets/lists/partials/_list_head_row.htm
@@ -18,7 +18,7 @@
         <?php if ($showSorting && $column->sortable): ?>
             <th
                 <?php if ($column->width): ?>style="width: <?= $column->width ?>"<?php endif ?>
-                class="<?= $this->sortColumn==$column->columnName?'sort-'.$this->sortDirection.' active':'sort-desc' ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->getAlignClass() ?>"
+                class="<?= $this->sortColumn==$column->columnName?'sort-'.$this->sortDirection.' active':'sort-desc' ?> list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->getAlignClass() ?> <?= $column->headCssClass ?>"
                 >
                 <a
                     href="javascript:;"
@@ -31,7 +31,7 @@
         <?php else: ?>
             <th
                 <?php if ($column->width): ?>style="width: <?= $column->width ?>"<?php endif ?>
-                class="list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->getAlignClass() ?>"
+                class="list-cell-name-<?= $column->getName() ?> list-cell-type-<?= $column->type ?> <?= $column->getAlignClass() ?> <?= $column->headCssClass ?>"
                 >
                 <span><?= $this->getHeaderValue($column) ?></span>
             </th>


### PR DESCRIPTION
Allows for the definition of custom CSS classes for the header cell of a column in a list widget. There is currently a way to specify custom CSS classes for the body cell of a column through the `cssClass` property, but this allows developers to also specify a CSS class for the header cell via the `headCssClass` property.

As an example, with this in place, we can do responsive list tables by hiding a column on smaller devices:

```
    version:
        label: system::lang.updates.plugin_version
        sortable: false
        cssClass: visible-lg
        headCssClass: visible-lg
```

Happy to update the docs if this change is approved.