### PR TITLE
Replaced depcreated Twig calls

### DIFF
--- a/modules/cms/classes/CmsCompoundObject.php
+++ b/modules/cms/classes/CmsCompoundObject.php
@@ -9,8 +9,8 @@ use Cms\Twig\Extension as CmsTwigExtension;
 use Cms\Components\ViewBag;
 use System\Twig\Extension as SystemTwigExtension;
 use October\Rain\Halcyon\Processors\SectionParser;
-use Twig_Source;
-use Twig_Environment;
+use Twig\Environment;
+use Twig\Source;
 use ApplicationException;
 
 /**
@@ -410,11 +410,11 @@ class CmsCompoundObject extends CmsObject
     public function getTwigNodeTree($markup = false)
     {
         $loader = new TwigLoader();
-        $twig = new Twig_Environment($loader, []);
+        $twig = new Environment($loader, []);
         $twig->addExtension(new CmsTwigExtension());
         $twig->addExtension(new SystemTwigExtension);
 
-        $stream = $twig->tokenize(new Twig_Source($markup === false ? $this->markup : $markup, 'getTwigNodeTree'));
+        $stream = $twig->tokenize(new Source($markup === false ? $this->markup : $markup, 'getTwigNodeTree'));
         return $twig->parse($stream);
     }
 

--- a/modules/cms/twig/Loader.php
+++ b/modules/cms/twig/Loader.php
@@ -1,7 +1,7 @@
 <?php namespace Cms\Twig;
 
 use Event;
-use Twig_Source;
+use Twig\Source;
 use Twig_LoaderInterface;
 use Cms\Contracts\CmsObject;
 use System\Twig\Loader as LoaderBase;
@@ -60,7 +60,7 @@ class Loader extends LoaderBase implements Twig_LoaderInterface
         $dataHolder = (object) ['content' => $content];
         Event::fire('cms.template.processTwigContent', [$this->obj, $dataHolder]);
 
-        return new Twig_Source($dataHolder->content, $name);
+        return new Source((string)$dataHolder->content, $name);
     }
 
     /**

--- a/modules/system/twig/Loader.php
+++ b/modules/system/twig/Loader.php
@@ -2,7 +2,7 @@
 
 use App;
 use File;
-use Twig_Source;
+use Twig\Source;
 use Twig_LoaderInterface;
 use Exception;
 
@@ -52,7 +52,7 @@ class Loader implements Twig_LoaderInterface
 
     public function getSourceContext($name)
     {
-        return new Twig_Source(File::get($this->findTemplate($name)), $name);
+        return new Source(File::get($this->findTemplate($name)), $name);
     }
 
     public function getCacheKey($name)


### PR DESCRIPTION
This PR fixes https://github.com/octobercms/october/issues/4209 by replacing deprectaed twig calls and casting `$dataHolder->content` to a string. This prevents the passing of a `null` value that isn't allowed by the receiving method.