### PR TITLE
Optionally copy files instead of symlinking them while mirroring the public directory

### DIFF
--- a/modules/system/console/OctoberMirror.php
+++ b/modules/system/console/OctoberMirror.php
@@ -183,9 +183,9 @@ class OctoberMirror extends Command
         }
 
         if ($this->option('copy')) {
-            if(File::isFile($src)) {
+            if (File::isFile($src)) {
                 File::copy($src, $dest);
-            } else if(File::isDirectory($src)) {
+            } else if (File::isDirectory($src)) {
                 File::copyDirectory($src, $dest);
             }
         } else {


### PR DESCRIPTION
As discussed with @LukeTowers 

This pull request adds a `--copy` switch to the `october:mirror` command and copies the files and directories instead of symlinking them into the new public directory.

The functionality is completely optional. It works by creating a copy of all specified asset files and directories and then updates the mirrored `index.php` file with the updated paths to the `app.php` and `autoload.php` files.

### Why?

The `--copy` switch makes it possible to use the public folder deployment configuration on web hosts that do not support symbolic links.

Effectively, this change also allows shared hosting deployments to utilize the public folder configuration (although such use cases may be impractical because the `october:mirror` command would have to be run on the developer's machine).

The downsides of this approach is that it creates a copy of all published assets in the new public directory. However, I see this as a non-issue because the additional storage space required is an extremely minor inconvenience when compared with the advantage of broader web host support.

Moreover, in terms of file management copying is as good as symlinking in this case because the `october:mirror` command still needs to be run [after each system update](https://github.com/octobercms/docs/blob/f22b49c86bde81457a74c630a9636a966793189b/setup-configuration.md#using-a-public-folder).

I've tested these changes in my local development environment but they still need more testing to make sure everything works as expected. Any ideas on possible test cases?