### PR TITLE
Fix JS error when calling getDropdownOptions handler in DataTable widget

### DIFF
--- a/modules/backend/formwidgets/DataTable.php
+++ b/modules/backend/formwidgets/DataTable.php
@@ -150,7 +150,7 @@ class DataTable extends FormWidgetBase
 
         $config->dataSource = 'client';
         if (isset($this->getParentForm()->arrayName)) {
-            $config->alias = $this->getParentForm()->arrayName . '[' . studly_case(HtmlHelper::nameToId($this->fieldName)) . 'datatable' . ']';
+            $config->alias = studly_case(HtmlHelper::nameToId($this->getParentForm()->arrayName . '[' . $this->fieldName . ']')) . 'datatable';
             $config->fieldName = $this->getParentForm()->arrayName . '[' . $this->fieldName . ']';
         } else {
             $config->alias = studly_case(HtmlHelper::nameToId($this->fieldName)) . 'datatable';


### PR DESCRIPTION
Hat tip @Samuell1.

The change to the DataTable widget alias to make it work in repeaters (https://github.com/octobercms/october/pull/4102) caused the onGetDropdownOptions handler to fail. This handler appears to be used if a dropdown column is specified without options.

The issue results from the table alias containing square brackets, which will not work with AJAX framework handler as it throws the following error:
```
Error: Invalid handler name. The correct handler name format is: "onEvent".
```

This fix should prevent that error. I have tested this fix with the repeating datatables and they still appear to work with this change in place.