### PR TITLE
Do not hardcode handler name

### DIFF
--- a/modules/backend/widgets/filter/partials/_scope_text.htm
+++ b/modules/backend/widgets/filter/partials/_scope_text.htm
@@ -3,7 +3,7 @@
         <?= e(trans($scope->label)) ?>:
         <input type="text"
                name="options[value][]"
-               data-request="listFilter::onFilterUpdate"
+               data-request="<?= $this->getEventHandler('onFilterUpdate') ?>"
                data-request-data="'scopeName':'<?= $scope->scopeName ?>'"
                data-track-input
                data-load-indicator


### PR DESCRIPTION
This enables us to reuse the widget with a different alias name. Also, this is the octoberish way of referring to handlers. Tested on the Test plugin.

