### PR TITLE
Added overflow rules to preview form-control

### DIFF
--- a/modules/system/assets/ui/less/form.less
+++ b/modules/system/assets/ui/less/form.less
@@ -216,6 +216,8 @@
         height: auto;
         min-height: 38px;
         border-color: #eee;
+        overflow: hidden;
+        text-overflow: ellipsis;
         .box-shadow(none);
     }
 

--- a/modules/system/assets/ui/less/form.less
+++ b/modules/system/assets/ui/less/form.less
@@ -216,8 +216,7 @@
         height: auto;
         min-height: 38px;
         border-color: #eee;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        word-break: break-word;
         .box-shadow(none);
     }
 

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4209,7 +4209,7 @@ html.cssanimations .cursor-loading-indicator.hide {display:none}
 .form-group.input-sidebar-control .sidebar-control {position:absolute;right:8px;top:34px;font-size:16px;color:#c4c4c4}
 .form-group.input-sidebar-control .sidebar-control:hover,
 .form-group.input-sidebar-control .sidebar-control:focus {text-decoration:none;color:#0181b9;outline:none}
-.form-group-preview .form-control {background-color:#f6f6f6;color:#555;height:auto;min-height:38px;border-color:#eee;overflow:hidden;text-overflow:ellipsis;-webkit-box-shadow:none;box-shadow:none}
+.form-group-preview .form-control {background-color:#f6f6f6;color:#555;height:auto;min-height:38px;border-color:#eee;word-break:break-word;-webkit-box-shadow:none;box-shadow:none}
 .form-group-preview .custom-checkbox label,
 .form-group-preview .custom-radio label {cursor:default}
 .help-block {font-size:13px;margin-bottom:0}

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4209,7 +4209,7 @@ html.cssanimations .cursor-loading-indicator.hide {display:none}
 .form-group.input-sidebar-control .sidebar-control {position:absolute;right:8px;top:34px;font-size:16px;color:#c4c4c4}
 .form-group.input-sidebar-control .sidebar-control:hover,
 .form-group.input-sidebar-control .sidebar-control:focus {text-decoration:none;color:#0181b9;outline:none}
-.form-group-preview .form-control {background-color:#f6f6f6;color:#555;height:auto;min-height:38px;border-color:#eee;-webkit-box-shadow:none;box-shadow:none}
+.form-group-preview .form-control {background-color:#f6f6f6;color:#555;height:auto;min-height:38px;border-color:#eee;overflow:hidden;text-overflow:ellipsis;-webkit-box-shadow:none;box-shadow:none}
 .form-group-preview .custom-checkbox label,
 .form-group-preview .custom-radio label {cursor:default}
 .help-block {font-size:13px;margin-bottom:0}


### PR DESCRIPTION
Minor UI fix for long `.form-control` values in preview mode.

Before:

![image](https://user-images.githubusercontent.com/8600029/55614709-ebd32780-578d-11e9-9bd8-4f48681c24b4.png)


After:

![image](https://user-images.githubusercontent.com/8600029/55614701-e2e25600-578d-11e9-9323-6db1be83812f.png)
