### PR TITLE
Abort old track input requests

### DIFF
--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -134,8 +134,8 @@ var interval=$(this).data('track-input')
 if(!interval)
 interval=300
 var self=this
-this.dataTrackInputTimer=window.setTimeout(function(){if(this.lastDataTrackInputRequest){this.lastDataTrackInputRequest.abort();}
-this.lastDataTrackInputRequest=$(self).request();},interval)})
+this.dataTrackInputTimer=window.setTimeout(function(){if(self.lastDataTrackInputRequest){self.lastDataTrackInputRequest.abort();}
+self.lastDataTrackInputRequest=$(self).request();},interval)})
 $(document).on('submit','[data-request]',function documentOnSubmit(){$(this).request()
 return false})
 $(window).on('beforeunload',function documentOnBeforeUnload(){window.ocUnloading=true})

--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -134,7 +134,8 @@ var interval=$(this).data('track-input')
 if(!interval)
 interval=300
 var self=this
-this.dataTrackInputTimer=window.setTimeout(function(){$(self).request()},interval)})
+this.dataTrackInputTimer=window.setTimeout(function(){if(this.lastDataTrackInputRequest){this.lastDataTrackInputRequest.abort();}
+this.lastDataTrackInputRequest=$(self).request();},interval)})
 $(document).on('submit','[data-request]',function documentOnSubmit(){$(this).request()
 return false})
 $(window).on('beforeunload',function documentOnBeforeUnload(){window.ocUnloading=true})

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -134,8 +134,8 @@ var interval=$(this).data('track-input')
 if(!interval)
 interval=300
 var self=this
-this.dataTrackInputTimer=window.setTimeout(function(){if(this.lastDataTrackInputRequest){this.lastDataTrackInputRequest.abort();}
-this.lastDataTrackInputRequest=$(self).request();},interval)})
+this.dataTrackInputTimer=window.setTimeout(function(){if(self.lastDataTrackInputRequest){self.lastDataTrackInputRequest.abort();}
+self.lastDataTrackInputRequest=$(self).request();},interval)})
 $(document).on('submit','[data-request]',function documentOnSubmit(){$(this).request()
 return false})
 $(window).on('beforeunload',function documentOnBeforeUnload(){window.ocUnloading=true})

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -134,7 +134,8 @@ var interval=$(this).data('track-input')
 if(!interval)
 interval=300
 var self=this
-this.dataTrackInputTimer=window.setTimeout(function(){$(self).request()},interval)})
+this.dataTrackInputTimer=window.setTimeout(function(){if(this.lastDataTrackInputRequest){this.lastDataTrackInputRequest.abort();}
+this.lastDataTrackInputRequest=$(self).request();},interval)})
 $(document).on('submit','[data-request]',function documentOnSubmit(){$(this).request()
 return false})
 $(window).on('beforeunload',function documentOnBeforeUnload(){window.ocUnloading=true})

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -507,7 +507,10 @@ if (window.jQuery.request !== undefined) {
 
         var self = this
         this.dataTrackInputTimer = window.setTimeout(function() {
-            $(self).request()
+            if (this.lastDataTrackInputRequest) {
+                this.lastDataTrackInputRequest.abort();
+            }
+            this.lastDataTrackInputRequest = $(self).request();
         }, interval)
     })
 

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -507,10 +507,10 @@ if (window.jQuery.request !== undefined) {
 
         var self = this
         this.dataTrackInputTimer = window.setTimeout(function() {
-            if (this.lastDataTrackInputRequest) {
-                this.lastDataTrackInputRequest.abort();
+            if (self.lastDataTrackInputRequest) {
+                self.lastDataTrackInputRequest.abort();
             }
-            this.lastDataTrackInputRequest = $(self).request();
+            self.lastDataTrackInputRequest = $(self).request();
         }, interval)
     })
 

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -4201,8 +4201,8 @@ if(prefix===undefined)
 prefix=''
 if($el.val().length&&$el.val()!=prefix)
 return
-this.$src=$(options.inputPreset,parent)
 $el.val(prefix).trigger('oc.inputPreset.afterUpdate')
+this.$src=$(options.inputPreset,parent)
 this.$src.on('input paste',function(event){if(self.cancelled)
 return
 var timeout=event.type==='paste'?100:0


### PR DESCRIPTION
This aborts old request triggered by the data-track-input feature. Without this older requests might overwrite the results of newer ones. See #4237 for more details.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->