### PR TITLE
add $options param to formRenderField

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -531,11 +531,12 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderField('field_name') ?>
      *
      * @param string $name Field name
+     * @param array $options (e.g. ['useContainer'=>false])
      * @return string HTML markup
      */
-    public function formRenderField($name)
+    public function formRenderField($name, $options = [])
     {
-        return $this->formWidget->renderField($name);
+        return $this->formWidget->renderField($name, $options);
     }
 
     /**


### PR DESCRIPTION
Allow passing options argument to Form widget's renderField() method

For example, if you need to replace the partial container markup with the rendered field content, you can pass ['useContainer'=>false] as an option.