### PR TITLE
Added strip_tags to exportFromList

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -636,7 +636,7 @@ class ImportExportController extends ControllerBehavior
                 if (is_array($value)) {
                     $value = implode('|', $value);
                 }
-                $record[] = $value;
+                $record[] = strip_tags($value);
             }
             $csv->insertOne($record);
         }


### PR DESCRIPTION
When using date/time column types October creates date/time html tags around the column values, these are not wanted during export as it will generate invalid csv.