### PR TITLE
Updated documentation for AJAX search (Select2)

### DIFF
--- a/modules/system/assets/ui/docs/select.md
+++ b/modules/system/assets/ui/docs/select.md
@@ -77,7 +77,10 @@ The AJAX handler should return results as an array.
 public function onGetOptions()
 {
     $results = [
-        'key' => 'value',
+        [
+            'id'   => 'key',
+            'text' => 'value',
+        ],
         ...
     ];
 


### PR DESCRIPTION
Current documentation is incorrect, because Most likely the type of answer for Select2 has been changed, you can see the documentation here: https://select2.org/data-sources/ajax