### PR TITLE
max url field length is 191 bytes

### DIFF
--- a/modules/system/models/RequestLog.php
+++ b/modules/system/models/RequestLog.php
@@ -42,7 +42,7 @@ class RequestLog extends Model
         }
 
         $record = static::firstOrNew([
-            'url' => substr(Request::fullUrl(), 0, 255),
+            'url' => substr(Request::fullUrl(), 0, 191),
             'status_code' => $statusCode,
         ]);
 


### PR DESCRIPTION
the url field in table is 191:
```
mysql> describe system_request_logs;
+-------------+------------------+------+-----+---------+----------------+
| Field       | Type             | Null | Key | Default | Extra          |
+-------------+------------------+------+-----+---------+----------------+
| id          | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
| status_code | int(11)          | YES  |     | NULL    |                |
| url         | varchar(191)     | YES  |     | NULL    |                |
| referer     | text             | YES  |     | NULL    |                |
| count       | int(11)          | NO   |     | 0       |                |
| created_at  | timestamp        | YES  |     | NULL    |                |
| updated_at  | timestamp        | YES  |     | NULL    |                |
+-------------+------------------+------+-----+---------+----------------+
```