### PR TITLE
Escape widgets values

### DIFF
--- a/modules/backend/formwidgets/colorpicker/partials/_colorpicker.htm
+++ b/modules/backend/formwidgets/colorpicker/partials/_colorpicker.htm
@@ -1,5 +1,5 @@
 <?php if ($this->previewMode): ?>
-    <div class="form-control"><?= $value ?></div>
+    <div class="form-control"><?= e($value) ?></div>
 <?php else: ?>
     <div
         id="<?= $this->getId() ?>"
@@ -20,9 +20,9 @@
 
             <li
                 class="custom-color <?= $isCustomColor == $value ? 'active' : null ?>"
-                data-hex-color="<?= $isCustomColor ? $value : '#ffffff' ?>"
+                data-hex-color="<?= $isCustomColor ? e($value) : '#ffffff' ?>"
                 data-custom-color>
-                <span style="background: <?= $isCustomColor ? $value : '#ffffff' ?>"></span>
+                <span style="background: <?= $isCustomColor ? e($value) : '#ffffff' ?>"></span>
             </li>
         </ul>
 
@@ -30,7 +30,7 @@
             type="hidden"
             id="<?= $this->getId('input') ?>"
             name="<?= $name ?>"
-            value="<?= $value ?>" />
+            value="<?= e($value) ?>" />
     </div>
 
 <?php endif ?>

--- a/modules/backend/formwidgets/mediafinder/partials/_file_single.htm
+++ b/modules/backend/formwidgets/mediafinder/partials/_file_single.htm
@@ -16,7 +16,7 @@
         </div>
         <div class="info">
             <h4 class="filename">
-                <span data-find-file-name><?= ltrim($value, '/') ?></span>
+                <span data-find-file-name><?= e(ltrim($value, '/')) ?></span>
             </h4>
         </div>
         <div class="meta">

--- a/modules/backend/formwidgets/mediafinder/partials/_image_single.htm
+++ b/modules/backend/formwidgets/mediafinder/partials/_image_single.htm
@@ -25,7 +25,7 @@
 
         <div class="info">
             <h4 class="filename">
-                <span data-find-file-name><?= ltrim($value, '/') ?></span>
+                <span data-find-file-name><?= e(ltrim($value, '/')) ?></span>
                 <a href="javascript:;" class="find-remove-button">
                     <i class="icon-times"></i>
                 </a>

--- a/modules/backend/widgets/filter/partials/_scope_text.htm
+++ b/modules/backend/widgets/filter/partials/_scope_text.htm
@@ -9,7 +9,7 @@
                data-load-indicator
                data-load-indicator-opaque
                size="<?= $size ?>"
-               value="<?= isset($value) ? $value:''; ?>"
+               value="<?= isset($value) ? e($value):''; ?>"
                class="form-control"/>
     </label>
 </div>

--- a/modules/backend/widgets/form/partials/_field_checkboxlist.htm
+++ b/modules/backend/widgets/form/partials/_field_checkboxlist.htm
@@ -21,7 +21,7 @@
                     type="checkbox"
                     id="<?= $checkboxId ?>"
                     name="<?= $field->getName() ?>[]"
-                    value="<?= $value ?>"
+                    value="<?= e($value) ?>"
                     disabled="disabled"
                     checked="checked">
 
@@ -68,7 +68,7 @@
                     type="checkbox"
                     id="<?= $checkboxId ?>"
                     name="<?= $field->getName() ?>[]"
-                    value="<?= $value ?>"
+                    value="<?= e($value) ?>"
                     <?= in_array($value, $checkedValues) ? 'checked="checked"' : '' ?>>
 
                 <label for="<?= $checkboxId ?>">

--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -32,7 +32,7 @@
             <option
                 <?= $field->isSelected($value) ? 'selected="selected"' : '' ?>
                 <?php if (isset($option[1])): ?>data-<?=strpos($option[1],'.')?'image':'icon'?>="<?= $option[1] ?>"<?php endif ?>
-                value="<?= $value ?>"
+                value="<?= e($value) ?>"
             ><?= e(trans($option[0])) ?></option>
         <?php endforeach ?>
     </select>

--- a/modules/backend/widgets/form/partials/_field_radio.htm
+++ b/modules/backend/widgets/form/partials/_field_radio.htm
@@ -17,7 +17,7 @@
             <input
                 id="<?= $fieldId ?>"
                 name="<?= $field->getName() ?>"
-                value="<?= $value ?>"
+                value="<?= e($value) ?>"
                 type="radio"
                 <?= $field->isSelected($value) ? 'checked="checked"' : '' ?>
                 <?= $this->previewMode ? 'disabled="disabled"' : '' ?>


### PR DESCRIPTION
Escape values of modules widgets to prevent XSS injection from another low-permission administrators or users directly from plugins which use colorpicker field.