### PR TITLE
Prevent subject and password from being HTML encoded in the invite email

### DIFF
--- a/modules/backend/views/mail/invite.htm
+++ b/modules/backend/views/mail/invite.htm
@@ -1,4 +1,4 @@
-subject = "Welcome to {{ appName|raw }}"
+subject = "Welcome to {{ appName | raw }}"
 layout = "system"
 description = "Invite new admin to the site"
 ==

--- a/modules/backend/views/mail/invite.htm
+++ b/modules/backend/views/mail/invite.htm
@@ -1,4 +1,4 @@
-subject = "Welcome to {{ appName }}"
+subject = "Welcome to {{ appName|raw }}"
 layout = "system"
 description = "Invite new admin to the site"
 ==
@@ -8,7 +8,7 @@ A user account has been created for you on **{{ appName }}**.
 
 {% partial 'panel' body %}
 - Login: `{{ login ?: 'sample' }}`
-- Password: `{{ password ?: '********' | raw }}`
+- Password: `{{ (password ?: '********') | raw }}`
 {% endpartial %}
 
 You can use the following link to sign in:


### PR DESCRIPTION
This prevents that the subject and/or password are being HTML encoded in the invite email.

https://github.com/octobercms/october/commit/ac5bc866ff8f0e7dea3ed7f667b99848723eb268 should have fixed this for the password, but didn't. A fix for this is included in this request.