### PR TITLE
Include CSRF token in uploads to richeditor

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/js/build-min.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/build-min.js
@@ -2330,7 +2330,7 @@ froalaOptions.lineBreakerTags=this.options.lineBreakerTags?this.options.lineBrea
 froalaOptions.shortcutsEnabled=['show','bold','italic','underline','indent','outdent','undo','redo']
 froalaOptions.imageUploadURL=froalaOptions.fileUploadURL=window.location
 froalaOptions.imageUploadParam=froalaOptions.fileUploadParam='file_data'
-froalaOptions.imageUploadParams=froalaOptions.fileUploadParams={X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD:1}
+froalaOptions.imageUploadParams=froalaOptions.fileUploadParams={X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD:1,_token:$('meta[name="csrf-token"]').attr('content')}
 var placeholder=this.$textarea.attr('placeholder')
 froalaOptions.placeholderText=placeholder?placeholder:''
 froalaOptions.height=this.$el.hasClass('stretch')?Infinity:$('.height-indicator',this.$el).height()

--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -155,7 +155,10 @@
         // File upload
         froalaOptions.imageUploadURL = froalaOptions.fileUploadURL = window.location
         froalaOptions.imageUploadParam = froalaOptions.fileUploadParam = 'file_data'
-        froalaOptions.imageUploadParams = froalaOptions.fileUploadParams = { X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD: 1 }
+        froalaOptions.imageUploadParams = froalaOptions.fileUploadParams = {
+            X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD: 1,
+            _token: $('meta[name="csrf-token"]').attr('content')
+        }
 
         var placeholder = this.$textarea.attr('placeholder')
         froalaOptions.placeholderText = placeholder ? placeholder : ''
@@ -222,7 +225,7 @@
 
         $(window).on('resize', this.proxy(this.updateLayout))
         $(window).on('oc.updateUi', this.proxy(this.updateLayout))
-        
+
         // Bind the keydown listener here to ensure it gets handled before the Froala handlers
         editor.events.on('keydown', this.proxy(this.onKeydown), true)
 


### PR DESCRIPTION
Includes CSRF token in request when uploading an image or file to a richeditor widget.

Fixes #4264.