### PR TITLE
Disable in-memory cache repository when running in CLI by default

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -99,9 +99,18 @@ return [
     |
     | The request cache stores cache retrievals from the cache store
     | in memory to speed up consecutive retrievals within the same request.
-    | Set to true to disable this in-memory request cache.
+    |
+    | true  - always disable this in-memory request cache
+    |
+    | false - always enable; be aware that long-running console commands
+    |         (including queue workers) may retain cache entries in memory that
+    |         have been changed in other processes or would have otherwise
+    |         expired, causing issues with the `queue:restart` command, for
+    |         example
+    |
+    | null  - enable for HTTP requests, disable when running in CLI
     |
     */
 
-    'disableRequestCache' => false,
+    'disableRequestCache' => null,
 ];


### PR DESCRIPTION
This implements the config change discussed in #4057, adding a `null` setting for `cache. disableRequestCache` that enables the request-level memory cache for HTTP requests but disables it from the console, and makes `null` the default setting.

Reference octobercms/library#401 for the other side of this.