### PR TITLE
Fix theme cache key null value

### DIFF
--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -222,7 +222,7 @@ class Theme
      */
     public static function setActiveTheme($code)
     {
-        self::resetCache();
+        self::resetCache($code);
 
         Parameter::set(self::ACTIVE_KEY, $code);
 
@@ -466,7 +466,7 @@ class Theme
         File::put($path, $contents);
         $this->configCache = $values;
 
-        $this->resetCache();
+        self::resetCache();
     }
 
     /**
@@ -484,6 +484,7 @@ class Theme
 
         return Url::asset('modules/cms/assets/images/default-theme-preview.png');
     }
+
     /**
      * Returns theme config cache key
      * @return string
@@ -497,14 +498,14 @@ class Theme
      * Resets any memory or cache involved with the active or edit theme.
      * @return void
      */
-    public function resetCache()
+    public static function resetCache($dirName = null)
     {
         self::$activeThemeCache = false;
         self::$editThemeCache = false;
 
         Cache::forget(self::ACTIVE_KEY);
         Cache::forget(self::EDIT_KEY);
-        Cache::forget($this->getConfigCacheKey());
+        Cache::forget(self::CONFIG_KEY.'::'.$dirName);
     }
 
     /**

--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -222,7 +222,7 @@ class Theme
      */
     public static function setActiveTheme($code)
     {
-        $this->resetCache();
+        self::resetCache();
 
         Parameter::set(self::ACTIVE_KEY, $code);
 

--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -220,9 +220,9 @@ class Theme
      * The active theme code is stored in the database and overrides the configuration cms.activeTheme parameter.
      * @param string $code Specifies the  active theme code.
      */
-    public static function setActiveTheme($code)
+    public function setActiveTheme($code)
     {
-        self::resetCache($code);
+        $this->resetCache();
 
         Parameter::set(self::ACTIVE_KEY, $code);
 
@@ -466,7 +466,7 @@ class Theme
         File::put($path, $contents);
         $this->configCache = $values;
 
-        self::resetCache();
+        $this->resetCache();
     }
 
     /**
@@ -498,14 +498,14 @@ class Theme
      * Resets any memory or cache involved with the active or edit theme.
      * @return void
      */
-    public static function resetCache($dirName = null)
+    public function resetCache()
     {
         self::$activeThemeCache = false;
         self::$editThemeCache = false;
 
         Cache::forget(self::ACTIVE_KEY);
         Cache::forget(self::EDIT_KEY);
-        Cache::forget(self::CONFIG_KEY.'::'.$dirName);
+        Cache::forget($this->getConfigCacheKey());
     }
 
     /**

--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -338,8 +338,7 @@ class Theme
         }
 
         try {
-            $cacheKey = self::CONFIG_KEY.'::'.$this->getDirName();
-            $config = Cache::rememberForever($cacheKey, function() use ($path) {
+            $config = Cache::rememberForever($this->getConfigCacheKey(), function() use ($path) {
                 return Yaml::parseFile($path);
             });
         }
@@ -485,19 +484,27 @@ class Theme
 
         return Url::asset('modules/cms/assets/images/default-theme-preview.png');
     }
+    /**
+     * Returns theme config cache key
+     * @return string
+     */
+    public function getConfigCacheKey()
+    {
+        return self::CONFIG_KEY.'::'.$this->getDirName();
+    }
 
     /**
      * Resets any memory or cache involved with the active or edit theme.
      * @return void
      */
-    public static function resetCache()
+    public function resetCache()
     {
         self::$activeThemeCache = false;
         self::$editThemeCache = false;
 
         Cache::forget(self::ACTIVE_KEY);
         Cache::forget(self::EDIT_KEY);
-        Cache::forget(self::CONFIG_KEY.'::'.(new self)->getDirName());
+        Cache::forget($this->getConfigCacheKey());
     }
 
     /**

--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -222,7 +222,7 @@ class Theme
      */
     public static function setActiveTheme($code)
     {
-        self::resetCache();
+        $this->resetCache();
 
         Parameter::set(self::ACTIVE_KEY, $code);
 
@@ -466,7 +466,7 @@ class Theme
         File::put($path, $contents);
         $this->configCache = $values;
 
-        self::resetCache();
+        $this->resetCache();
     }
 
     /**


### PR DESCRIPTION
Fix issue when config cache key is null.

One thing iam not sure how i should change is in tests: https://github.com/octobercms/october/blob/master/tests/unit/cms/classes/ThemeTest.php#L13

Second issue is that there are functions that are static and other are not static than i cant use `$this->resetCache()`