### PR TITLE
Add check to make sure event result is an array in Form widget

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -449,6 +449,10 @@ class Form extends WidgetBase
         $eventResults = $this->fireSystemEvent('backend.form.refresh', [$result], false);
 
         foreach ($eventResults as $eventResult) {
+            if (!is_array($eventResult)) {
+                continue;
+            }
+            
             $result = $eventResult + $result;
         }
 


### PR DESCRIPTION
Wildcard listeners will add null responses to the event result array and causes an error when they are merged into the result. This PR adds a check to see if each event result is an array before adding it to the result array. This should fix https://github.com/OFFLINE-GmbH/oc-clockwork-plugin/issues/1 and not introduce any backward compatability issues.