### PR TITLE
add methods to allow extending/viewing layoutPath

### DIFF
--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -44,6 +44,32 @@ trait ViewMaker
     public $suppressLayout = false;
 
     /**
+     * Prepends a path on the available layout path locations.
+     * @param string|array $path
+     * @return void
+     */
+    public function addLayoutPath($path)
+    {
+        $this->layoutPath = (array) $this->layoutPath;
+
+        if (is_array($path)) {
+            $this->layoutPath = array_merge($path, $this->layoutPath);
+        }
+        else {
+            array_unshift($this->layoutPath, $path);
+        }
+    }
+
+    /**
+     * Returns the active layout path locations.
+     * @return array
+     */
+    public function getLayoutPaths()
+    {
+        return (array) $this->layoutPath;
+    }
+
+    /**
      * Prepends a path on the available view path locations.
      * @param string|array $path
      * @return void


### PR DESCRIPTION
With this, it is now possible to do the following in a plugin definition file:

```
\Backend\Classes\Controller::extend(function($controller) {
     list($author, $plugin) = explode('\\', strtolower(get_class()));
     $controller->addLayoutPath(sprintf('$/%s/%s/layouts', $author, $plugin));
});
```

And creating a layout view/partial file in the plugin's layouts folder, thus, overriding the backend layout.