### PR TITLE
Do not reset groupMap indexes

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -237,8 +237,8 @@ class Repeater extends FormWidgetBase
         }
 
         if (is_array($currentValue) && count($currentValue)) {
-            foreach ($currentValue as $value) {
-                $groupMap[] = array_get($value, '_group');
+            foreach ($currentValue as $index => $value) {
+                $groupMap[$index] = array_get($value, '_group');
             }
         }
 

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -233,9 +233,12 @@ class Repeater extends FormWidgetBase
                 }
             }
         }
-        
+       
         collect($currentValue)->each(function ($value, $index) {
-            $this->makeItemFormWidget($index, array_get($value, '_group'));
+            $groupCode = array_get($value, '_group', false);                    
+            if (!$groupCode) return;
+
+            $this->makeItemFormWidget($index, $groupCode);
         });
         
         $this->indexCount = max(count($currentValue), $this->indexCount);

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -234,7 +234,9 @@ class Repeater extends FormWidgetBase
             }
         }
         
-        if (!is_array($currentValue)) return;
+        if (!is_array($currentValue)) {
+            return;
+        }
        
         collect($currentValue)->each(function ($value, $index) {
             $this->makeItemFormWidget($index, array_get($value, '_group', false));

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -233,6 +233,8 @@ class Repeater extends FormWidgetBase
                 }
             }
         }
+        
+        if (!is_array($currentValue)) return;
        
         collect($currentValue)->each(function ($value, $index) {
             $groupCode = array_get($value, '_group', false);                    

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -239,7 +239,7 @@ class Repeater extends FormWidgetBase
         }
        
         collect($currentValue)->each(function ($value, $index) {
-            $this->makeItemFormWidget($index, array_get($value, '_group', false));
+            $this->makeItemFormWidget($index, array_get($value, '_group', null));
         });
         
         $this->indexCount = max(count($currentValue), $this->indexCount);

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -234,7 +234,7 @@ class Repeater extends FormWidgetBase
             }
         }
         
-        collect($currentValue)->each(function($value, $index) {
+        collect($currentValue)->each(function ($value, $index) {
             $this->makeItemFormWidget($index, array_get($value, '_group'));
         });
         

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -217,9 +217,7 @@ class Repeater extends FormWidgetBase
             $this->indexCount = 0;
             $this->formWidgets = [];
             return;
-        }
-
-        $groupMap = [];
+        }       
 
         // Ensure that the minimum number of items are preinitialized
         // ONLY DONE WHEN NOT IN GROUP MODE
@@ -235,20 +233,11 @@ class Repeater extends FormWidgetBase
                 }
             }
         }
-
-        if (is_array($currentValue) && count($currentValue)) {
-            foreach ($currentValue as $index => $value) {
-                $groupMap[$index] = array_get($value, '_group');
-            }
-        }
-
-        if (!count($groupMap)) {
-            return;
-        }
-
-        foreach ($groupMap as $index => $groupCode) {
-            $this->makeItemFormWidget($index, $groupCode);
-        }
+        
+        collect($currentValue)->each(function($value, $index) {
+            $this->makeItemFormWidget($index, array_get($value, '_group'));
+        });
+        
         $this->indexCount = max(count($currentValue), $this->indexCount);
     }
 

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -237,10 +237,7 @@ class Repeater extends FormWidgetBase
         if (!is_array($currentValue)) return;
        
         collect($currentValue)->each(function ($value, $index) {
-            $groupCode = array_get($value, '_group', false);                    
-            if (!$groupCode) return;
-
-            $this->makeItemFormWidget($index, $groupCode);
+            $this->makeItemFormWidget($index, array_get($value, '_group', false));
         });
         
         $this->indexCount = max(count($currentValue), $this->indexCount);


### PR DESCRIPTION
The change introduced in https://github.com/octobercms/october/commit/9b5bd83f10a73e92e5b88a9b9f23230d8bf374eb?diff=split causes grouped repeater widgets to lose the correct "index to widget" correlation once they have been sorted.

Can easily be reproduced:
- Create a grouped repeater config, add two widgets of your choosing
- Create a page and add two widgets, save
- Change the order of the widgets and save
- Reload the backend page and both widgets will now appear to have lost it's content

Before sorting:
blocks[0][textarea_content] = "Textarea 1 Content"
blocks[0][_group] = "textarea"
blocks[1][textarea_content] = "Textarea 2 Content"
blocks[1][_group] = "textarea"

After sorting:
blocks[1][textarea_content] = "Textarea 2 Content"
blocks[1][_group] = "textarea"
blocks[0][textarea_content] = "Textarea 1 Content"
blocks[0][_group] = "textarea"

@bennothommo Is there a particular reason why you opted to reset the indexes when creating the groupMap? I certainly don't mean to introduce a breaking change, but my proposed change seems to fix the problem and seems to not break anything. Perhaps you could have a look too?