### PR TITLE
Fix group index mapping in Repeater widget (#4334)

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -217,9 +217,7 @@ class Repeater extends FormWidgetBase
             $this->indexCount = 0;
             $this->formWidgets = [];
             return;
-        }
-
-        $groupMap = [];
+        }       
 
         // Ensure that the minimum number of items are preinitialized
         // ONLY DONE WHEN NOT IN GROUP MODE
@@ -235,20 +233,15 @@ class Repeater extends FormWidgetBase
                 }
             }
         }
-
-        if (is_array($currentValue) && count($currentValue)) {
-            foreach ($currentValue as $value) {
-                $groupMap[] = array_get($value, '_group');
-            }
-        }
-
-        if (!count($groupMap)) {
+        
+        if (!is_array($currentValue)) {
             return;
         }
-
-        foreach ($groupMap as $index => $groupCode) {
-            $this->makeItemFormWidget($index, $groupCode);
-        }
+       
+        collect($currentValue)->each(function ($value, $index) {
+            $this->makeItemFormWidget($index, array_get($value, '_group', null));
+        });
+        
         $this->indexCount = max(count($currentValue), $this->indexCount);
     }
 


### PR DESCRIPTION
Fixes a bug which causes grouped repeaters to lose data when repeater items are re-ordered and saved, due to the data indexes not being correctly mapped to the corresponding form widget.

Credit to @datune.