### PR TITLE
Make contributions easier by having an online IDE (Gitpod) for October

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-mysql:latest
+
+ENV APACHE_DOCROOT_IN_REPO=""

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,15 @@
+image:
+  file: .gitpod.dockerfile
+ports:
+  - port: 8001
+    onOpen: open-preview
+  - port: 3306
+    onOpen: ignore
+tasks:
+- init: composer install
+  command: >
+    php artisan october:env;
+    sed -i "/APP_URL=/c APP_URL=$(gp url 8001)" .env;
+    sed -i "/APP_KEY=/c APP_KEY=$(php artisan key:generate --show)" .env;
+    sed -i "/LINK_POLICY=/c LINK_POLICY=secure" .env;
+    apachectl start;

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ The OctoberCMS platform is open-sourced software licensed under the [MIT license
 
 Before sending a Pull Request, be sure to review the [Contributing Guidelines](.github/CONTRIBUTING.md) first.
 
+A quick and easy way to open, modify and run source code from this repo is to open it in Gitpod, an online IDE with full PHP and Laravel support.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/octobercms/october)
+
+
 ### Coding standards
 
 Please follow the following guides and code standards:


### PR DESCRIPTION
hi there 👋!

I got inspired by your statement 
> October is [...] whose sole purpose is to make your development workflow simple again.

and I thought I can contribute to that mission: Eliminate the setup effort for first-time visitors, contributors and developers. I believe this can make it much easier for contributors to get the source up-and-running and make their first contribution. 

The core idea here is to specify the dev-environment as code and store it in git, so that it's available to everybody who wants to work with the code. This PR contributes a dev-environment-as-code, namely the files `.gitpod.yml` and `.gitpod.dockerfile`. The IDE of [Gitpod](https://www.gitpod.io) has full language support for PHP.

To try, click on 
https://gitpod.io/#https://github.com/meysholdt/october

and see
1. a new dev environment (a docker container) launches on gitpod.io
2. git-clone checks out this repo. (GitHub OAuth required)
3. `composer install` runs
4. `apachectl start` runs
5. a preview opens to show the October Demo.

this is how it looks like:

![image](https://user-images.githubusercontent.com/239422/58037007-b3fd2500-7b2c-11e9-9eb9-f422407e7805.png)

Disclosure: I work on Gitpod.

I noticed that `composer install` takes several minutes to run... but we can avoid that people have to wait for it. Gitpod can run it on git-push, just like Travis/Jenkins would do it, when you configure the [Gitpod App](https://github.com/apps/gitpod-io/) on this repo. Then, when you open a workspace, `composer install` will already have completed and all dependencies are available so that the demo can launch instantaneously. 

Let me know what you think. 





