### PR TITLE
Make contributions easier by having an online IDE (Gitpod) for October (reuse Dockerfile)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,21 @@
+image:
+  file: .gitpod/Dockerfile
+  context: .gitpod
+ports:
+  - port: 8080
+    onOpen: open-preview
+tasks:
+- init: |
+    composer install --no-interaction --prefer-dist --no-scripts
+    composer clearcache
+    cp -R /home/gitpod/octobercms-config-docker config/docker
+    echo 'config/docker' >> .git/info/exclude
+    echo 'plugins/october/drivers' >> .git/info/exclude
+    echo "APP_ENV=docker" > .env
+    echo "OCTOBERCMS_DEVELOP_COMMIT=$(git rev-parse HEAD)" >> .env
+    touch storage/database.sqlite
+    chmod 666 storage/database.sqlite
+    php artisan october:up
+    php artisan plugin:install october.drivers
+  command: |
+    apachectl start

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,0 +1,75 @@
+FROM php:7.3-apache
+
+RUN apt-get update && apt-get install -y cron git-core jq unzip vim zip \
+  libjpeg-dev libpng-dev libpq-dev libsqlite3-dev libwebp-dev libzip-dev && \
+  rm -rf /var/lib/apt/lists/* && \
+  docker-php-ext-configure zip --with-libzip && \
+  docker-php-ext-configure gd --with-png-dir --with-jpeg-dir --with-webp-dir && \
+  docker-php-ext-install exif gd mysqli opcache pdo_pgsql pdo_mysql zip
+
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=2'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/docker-oc-opcache.ini
+
+RUN { \
+    echo 'log_errors=on'; \
+    echo 'display_errors=off'; \
+    echo 'upload_max_filesize=32M'; \
+    echo 'post_max_size=32M'; \
+    echo 'memory_limit=128M'; \
+  } > /usr/local/etc/php/conf.d/docker-oc-php.ini
+
+RUN pecl install xdebug
+
+RUN { \
+    echo "#zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" ; \
+    echo 'xdebug.remote_enable=on'; \
+    echo 'xdebug.remote_autostart=off'; \
+    echo 'xdebug.remote_host=host.docker.internal'; \
+  } > /usr/local/etc/php/conf.d/docker-xdebug-php.ini
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+  /usr/local/bin/composer global require hirak/prestissimo
+
+RUN a2enmod rewrite
+
+COPY config/docker /usr/src/octobercms-config-docker
+
+ENV OCTOBERCMS_TAG develop
+ENV OCTOBERCMS_DEVELOP_CHECKSUM e7ca6f6c6651cfb040f73c5a6dc3ea0633345e17
+ENV OCTOBERCMS_DEVELOP_COMMIT a9e198c8b4e4eaee2438cd89d2e3d6e3e6e93bd5
+
+RUN git clone https://github.com/octobercms/october.git -b $OCTOBERCMS_TAG . && \
+  composer install --no-interaction --prefer-dist --no-scripts && \
+  composer clearcache && \
+  git status && git reset --hard HEAD && \
+  echo 'APP_ENV=docker' > .env && \
+  mv /usr/src/octobercms-config-docker config/docker && \
+  echo 'config/docker' >> .git/info/exclude && \
+  touch storage/database.sqlite && \
+  chmod 666 storage/database.sqlite && \
+  php artisan october:up && \
+  php artisan plugin:install october.drivers && \
+  chown -R www-data:www-data /var/www/html && \
+  find . -type d \( -path './plugins' -or  -path './storage' -or  -path './themes' -or  -path './plugins/*' -or  -path './storage/*' -or  -path './themes/*' \) -exec chmod g+ws {} \;
+
+RUN echo "* * * * * /usr/local/bin/php /var/www/html/artisan schedule:run > /proc/1/fd/1 2>/proc/1/fd/2" > /etc/cron.d/october-cron && \
+  crontab /etc/cron.d/october-cron
+
+RUN echo 'exec php artisan "$@"' > /usr/local/bin/artisan && \
+  echo 'exec php artisan tinker' > /usr/local/bin/tinker && \
+  echo '[ $# -eq 0 ] && exec php artisan october || exec php artisan october:"$@"' > /usr/local/bin/october && \
+  sed -i '1s;^;#!/bin/bash\n[ "$PWD" != "/var/www/html" ] \&\& echo " - Helper must be run from /var/www/html" \&\& exit 1\n;' /usr/local/bin/artisan /usr/local/bin/tinker /usr/local/bin/october && \
+  chmod +x /usr/local/bin/artisan /usr/local/bin/tinker /usr/local/bin/october
+
+COPY docker-oc-entrypoint /usr/local/bin/
+
+ENTRYPOINT ["docker-oc-entrypoint"]
+CMD ["apache2-foreground"]

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y cron git-core jq unzip vim zip \
   docker-php-ext-configure gd --with-png-dir --with-jpeg-dir --with-webp-dir && \
   docker-php-ext-install exif gd mysqli opcache pdo_pgsql pdo_mysql zip
 
+# Recommended opcache settings - https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
     echo 'opcache.memory_consumption=128'; \
     echo 'opcache.interned_strings_buffer=8'; \
@@ -40,36 +41,29 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 
 RUN a2enmod rewrite
 
-COPY config/docker /usr/src/octobercms-config-docker
-
 ENV OCTOBERCMS_TAG develop
-ENV OCTOBERCMS_DEVELOP_CHECKSUM e7ca6f6c6651cfb040f73c5a6dc3ea0633345e17
-ENV OCTOBERCMS_DEVELOP_COMMIT a9e198c8b4e4eaee2438cd89d2e3d6e3e6e93bd5
 
-RUN git clone https://github.com/octobercms/october.git -b $OCTOBERCMS_TAG . && \
-  composer install --no-interaction --prefer-dist --no-scripts && \
-  composer clearcache && \
-  git status && git reset --hard HEAD && \
-  echo 'APP_ENV=docker' > .env && \
-  mv /usr/src/octobercms-config-docker config/docker && \
-  echo 'config/docker' >> .git/info/exclude && \
-  touch storage/database.sqlite && \
-  chmod 666 storage/database.sqlite && \
-  php artisan october:up && \
-  php artisan plugin:install october.drivers && \
-  chown -R www-data:www-data /var/www/html && \
-  find . -type d \( -path './plugins' -or  -path './storage' -or  -path './themes' -or  -path './plugins/*' -or  -path './storage/*' -or  -path './themes/*' \) -exec chmod g+ws {} \;
-
+# Initialize crontab for the October CMS scheduler
 RUN echo "* * * * * /usr/local/bin/php /var/www/html/artisan schedule:run > /proc/1/fd/1 2>/proc/1/fd/2" > /etc/cron.d/october-cron && \
   crontab /etc/cron.d/october-cron
 
+# Add helpers
 RUN echo 'exec php artisan "$@"' > /usr/local/bin/artisan && \
   echo 'exec php artisan tinker' > /usr/local/bin/tinker && \
   echo '[ $# -eq 0 ] && exec php artisan october || exec php artisan october:"$@"' > /usr/local/bin/october && \
   sed -i '1s;^;#!/bin/bash\n[ "$PWD" != "/var/www/html" ] \&\& echo " - Helper must be run from /var/www/html" \&\& exit 1\n;' /usr/local/bin/artisan /usr/local/bin/tinker /usr/local/bin/october && \
   chmod +x /usr/local/bin/artisan /usr/local/bin/tinker /usr/local/bin/october
 
-COPY docker-oc-entrypoint /usr/local/bin/
+# create 'gitpod' user: It is used for everything that runs inside Gitpod workspaces
+RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod
+ENV HOME=/home/gitpod
+WORKDIR $HOME
 
-ENTRYPOINT ["docker-oc-entrypoint"]
-CMD ["apache2-foreground"]
+# configure Apache webserver for October in Gitpod
+RUN echo "ServerName \${APACHE_SERVER_NAME}" >> /etc/apache2/apache2.conf && \
+    chown -R gitpod:gitpod /etc/apache2 /var/run/apache2 /var/lock/apache2 /var/log/apache2 && \
+    rm /var/log/apache2/*
+COPY --chown=gitpod:gitpod apache/ /etc/apache2/
+
+# make October config available in container
+COPY --chown=gitpod:gitpod config /home/gitpod/octobercms-config-docker

--- a/.gitpod/apache/envvars
+++ b/.gitpod/apache/envvars
@@ -1,0 +1,8 @@
+# these variables are used by the Apache Config and by Apache tools, e.g. apachectl.
+export APACHE_SERVER_NAME=$(gp url 8080 | sed -e s/https:\\/\\/// | sed -e s/\\///)
+export APACHE_RUN_USER="gitpod"
+export APACHE_RUN_GROUP="gitpod"
+export APACHE_RUN_DIR=/var/run/apache2
+export APACHE_PID_FILE="$APACHE_RUN_DIR/apache.pid"
+export APACHE_LOCK_DIR=/var/lock/apache2
+export APACHE_LOG_DIR=/var/log/apache2

--- a/.gitpod/apache/ports.conf
+++ b/.gitpod/apache/ports.conf
@@ -1,0 +1,2 @@
+# In Gitpod, we want tu run Apache on port 8080
+Listen 8080

--- a/.gitpod/apache/sites-available/000-default.conf
+++ b/.gitpod/apache/sites-available/000-default.conf
@@ -1,0 +1,17 @@
+# configure October's git-working-copy's root folder as Apache's document root.
+# In other words: make the root of the git repo the root of the webserver.
+<VirtualHost *:8080>
+	ServerAdmin webmaster@localhost
+    ServerName ${APACHE_SERVER_NAME}
+	DocumentRoot ${GITPOD_REPO_ROOT}
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+
+<Directory ${GITPOD_REPO_ROOT}>
+	Options Indexes FollowSymLinks
+	AllowOverride All
+	Require all granted
+</Directory>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/.gitpod/config/app.php
+++ b/.gitpod/config/app.php
@@ -1,0 +1,12 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/master/config/app.php
+*/
+
+return [
+    'debug' => env('APP_DEBUG', false),
+    'url' => env('APP_URL', 'http://localhost'),
+    'timezone' => env('TZ', 'UTC'),
+    'key' => env('APP_KEY', '0123456789ABCDEFGHIJKLMNOPQRSTUV'),
+];

--- a/.gitpod/config/cache.php
+++ b/.gitpod/config/cache.php
@@ -1,0 +1,9 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/master/config/cache.php
+*/
+
+return [
+    'default' => env('CACHE_STORE','file'), // file, redis, etc
+];

--- a/.gitpod/config/cms.php
+++ b/.gitpod/config/cms.php
@@ -1,0 +1,19 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/master/config/cms.php
+*/
+
+return [
+    'activeTheme' => env('CMS_ACTIVE_THEME', 'demo'),
+    'edgeUpdates' => env('CMS_EDGE_UPDATES', false),
+    'disableCoreUpdates' => env('CMS_DISABLE_CORE_UPDATES', true),
+    'backendTimezone' => env('TZ', 'UTC'),
+    'backendSkin' => env('CMS_BACKEND_SKIN', 'Backend\Skins\Standard'),
+    'linkPolicy' => env('CMS_LINK_POLICY', 'detect'),
+    'backendForceSecure' => env('CMS_BACKEND_FORCE_SECURE', false),
+    'defaultMask' => [
+        'file' => env('CMS_DEFAULT_MASK_FILE', '664'),
+        'folder' =>  env('CMS_DEFAULT_MASK_FOLDER', '775'),
+    ],
+];

--- a/.gitpod/config/cms.php
+++ b/.gitpod/config/cms.php
@@ -10,8 +10,8 @@ return [
     'disableCoreUpdates' => env('CMS_DISABLE_CORE_UPDATES', true),
     'backendTimezone' => env('TZ', 'UTC'),
     'backendSkin' => env('CMS_BACKEND_SKIN', 'Backend\Skins\Standard'),
-    'linkPolicy' => env('CMS_LINK_POLICY', 'detect'),
-    'backendForceSecure' => env('CMS_BACKEND_FORCE_SECURE', false),
+    'linkPolicy' => env('CMS_LINK_POLICY', 'secure'),
+    'backendForceSecure' => env('CMS_BACKEND_FORCE_SECURE', true),
     'defaultMask' => [
         'file' => env('CMS_DEFAULT_MASK_FILE', '664'),
         'folder' =>  env('CMS_DEFAULT_MASK_FOLDER', '775'),

--- a/.gitpod/config/database.php
+++ b/.gitpod/config/database.php
@@ -1,0 +1,38 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/master/config/database.php
+|
+| When using a container to serve a database, the host value will need to be
+|  set as the service name defined in your docker-compose.yml
+*/
+
+return [
+    'default' => env('DB_TYPE','sqlite'), // sqlite, mysql, etc
+    'connections' => [
+        'sqlite' => [
+            'database' => env('DB_PATH_SQLITE','storage/database.sqlite'),
+        ],
+        'mysql' => [
+            'host'      => env('DB_HOST','mysql'),
+            'port'      => env('DB_PORT'),
+            'database'  => env('DB_DATABASE'),
+            'username'  => env('DB_USERNAME'),
+            'password'  => env('DB_PASSWORD'),
+        ],
+        'pgsql' => [
+            'host'     => env('DB_HOST'),
+            'port'     => env('DB_PORT'),
+            'database' => env('DB_DATABASE'),
+            'username' => env('DB_USERNAME'),
+            'password' => env('DB_PASSWORD'),
+        ],
+    ],
+    'redis' => [
+        'default' => [
+            'host'     => env('DB_REDIS_HOST','redis'),
+            'password' => env('DB_REDIS_PASSWORD',null),
+            'port'     => env('DB_REDIS_PORT',6379),
+        ],
+    ],
+];

--- a/.gitpod/config/environment.php
+++ b/.gitpod/config/environment.php
@@ -1,0 +1,12 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/develop/config/environment.php
+*/
+
+return [
+    'default' => 'docker',
+    'hosts' => [
+        'localhost' => 'docker',
+    ],
+];

--- a/.gitpod/config/mail.php
+++ b/.gitpod/config/mail.php
@@ -1,0 +1,18 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/master/config/mail.php
+*/
+
+return [
+    'driver' => env('MAIL_DRIVER', 'log'), // smtp, log, etc
+    'host' => env('MAIL_SMTP_HOST'),
+    'port' => env('MAIL_SMTP_PORT', '587'),
+    'from' => [
+      'address' => env('MAIL_FROM_ADDRESS', 'no-reply@domain.tld'),
+      'name' => env('MAIL_FROM_NAME', 'OctoberCMS')
+    ],
+    'encryption' => env('MAIL_SMTP_ENCRYPTION', 'tls'),
+    'username' => env('MAIL_SMTP_USERNAME'),
+    'password' => env('MAIL_SMTP_PASSWORD'),
+];

--- a/.gitpod/config/queue.php
+++ b/.gitpod/config/queue.php
@@ -1,0 +1,12 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/master/config/queue.php
+*/
+
+return [
+    'default' => env('QUEUE_DRIVER', 'sync'),
+    'failed' => [
+        'database' => env('DB_TYPE','sqlite')
+    ],
+];

--- a/.gitpod/config/session.php
+++ b/.gitpod/config/session.php
@@ -1,0 +1,9 @@
+<?php
+/*
+| For additional options see
+| https://github.com/octobercms/october/blob/master/config/session.php
+*/
+
+return [
+    'driver' => env('SESSION_DRIVER','file'), // file, redis, etc
+];

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The OctoberCMS platform is open-sourced software licensed under the [MIT license
 
 Before sending a Pull Request, be sure to review the [Contributing Guidelines](.github/CONTRIBUTING.md) first.
 
+A quick and easy way to open, modify and run source code from this repo is to open it in Gitpod, an online IDE with full PHP and Laravel support.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/octobercms/october)
+
 ### Coding standards
 
 Please follow the following guides and code standards:


### PR DESCRIPTION
In https://github.com/octobercms/october/pull/4340 I proposed an online IDE ([gitpod.io](http://www.gitpod.io)) for October and @LukeTowers asked:

>  Does the docker file have to be the one you specified or could you use [aspendigital/octobercms](https://hub.docker.com/r/aspendigital/octobercms/)?

I would like to answer with this PR: 
yes, we can absolutely use your Dockerfile instead of using [Gitpod's workspace-full image](https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile).

Some small modifications make it usable in Gitpod:
* don't do the `git clone` in the Dockerfile, because we should not need a new docker-build for every commit/branch/tag. Gitpod runs `git clone` on a volume that mounted into the workspace-container that that's backed by an SSD drive.
* move the command that deal with the source code into `.gitpod.yaml`, so they are executed after `git clone`
* create a Linux user named `gitpod`
* configure Apache. 

See this PR's commits for details.

Gitpod builds the workspace-container on-demand, but only when the Dockerfile has changed. 

To try, click on this link. GitHub OAuth is needed for git-clone.
https://gitpod.io/#https://github.com/meysholdt/october/tree/docker

This is how it looks like:
<img width="1594" alt="image" src="https://user-images.githubusercontent.com/239422/58113030-030e8d00-7bf5-11e9-8e66-643ad8c27fb2.png">

Let me know what you think :)

