### PR TITLE
Default to full width dashboard widgets

### DIFF
--- a/modules/backend/widgets/reportcontainer/partials/_new_widget_popup.htm
+++ b/modules/backend/widgets/reportcontainer/partials/_new_widget_popup.htm
@@ -23,7 +23,7 @@
             <select class="form-control custom-select" name="size">
                 <option></option>
                 <?php foreach ($sizes as $size => $name):?>
-                    <option value="<?= e($size) ?>" <?= $size == 10 ? 'selected' : null ?>><?= e($name) ?></option>
+                    <option value="<?= e($size) ?>" <?= $size == 12 ? 'selected' : null ?>><?= e($name) ?></option>
                 <?php endforeach ?>
             </select>
         </div>


### PR DESCRIPTION
As of [build 449](https://github.com/octoberrain/meta/blob/master/release-notes/build-449.md), the dashboard now uses a 12 column layout. This PR restores the behavior of defaulting new widgets to full width.
