### PR TITLE
Use temporaryUrls for protected files if the storage driver supports them

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -252,14 +252,20 @@ return [
     | folder - a folder prefix for storing all generated files inside.
     | path   - the public path relative to the application base URL,
     |          or you can specify a full URL path.
+    |
+    | Optionally, you can specify how long temporary URLs to protected files
+    | in cloud storage (ex. AWS, RackSpace) are valid for by setting
+    | temporaryUrlTTL to a value in seconds to define a validity period. This
+    | is only used for the 'uploads' config when using a supported cloud disk
     */
 
     'storage' => [
 
         'uploads' => [
-            'disk'   => 'local',
-            'folder' => 'uploads',
-            'path'   => '/storage/app/uploads',
+            'disk'            => 'local',
+            'folder'          => 'uploads',
+            'path'            => '/storage/app/uploads',
+            'temporaryUrlTTL' => 3600,
         ],
 
         'media' => [

--- a/modules/backend/controllers/Files.php
+++ b/modules/backend/controllers/Files.php
@@ -66,12 +66,12 @@ class Files extends Controller
         $url = null;
         $disk = $file->getDisk();
         $adapter = $disk->getAdapter();
-        if ($adapter instanceof \League\Flysystem\Cached\CachedAdapter) {
+        if (class_exists('\League\Flysystem\Cached\CachedAdapter') && $adapter instanceof \League\Flysystem\Cached\CachedAdapter) {
             $adapter = $adapter->getAdapter();
         }
 
-        if (($adapter instanceof \League\Flysystem\AwsS3v3\AwsS3Adapter) ||
-            ($adapter instanceof \League\Flysystem\Rackspace\RackspaceAdapter) ||
+        if ((class_exists('\League\Flysystem\AwsS3v3\AwsS3Adapter') && $adapter instanceof \League\Flysystem\AwsS3v3\AwsS3Adapter) ||
+            (class_exists('\League\Flysystem\Rackspace\RackspaceAdapter') && $adapter instanceof \League\Flysystem\Rackspace\RackspaceAdapter) ||
             method_exists($adapter, 'getTemporaryUrl')
         ) {
             if (empty($path)) {

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -42,13 +42,13 @@ class File extends FileBase
     /**
      * {@inheritDoc}
      */
-    public function getPath()
+    public function getPath($fileName = null)
     {
         $url = '';
         if (!$this->isPublic() && class_exists(Files::class)) {
             $url = Files::getDownloadUrl($this);
         } else {
-            $url = parent::getPath();
+            $url = parent::getPath($fileName);
         }
 
         return $url;
@@ -103,12 +103,11 @@ class File extends FileBase
     }
 
     /**
-     * Copy the local file to Storage
-     * @return bool True on success, false on failure.
+     * Returns the storage disk the file is stored on
+     * @return FilesystemAdapter
      */
-    protected function copyLocalToStorage($localPath, $storagePath)
+    public function getDisk()
     {
-        $disk = Storage::disk(Config::get('cms.storage.uploads.disk'));
-        return $disk->put($storagePath, FileHelper::get($localPath), $this->isPublic() ? 'public' : null);
+        return Storage::disk(Config::get('cms.storage.uploads.disk'));
     }
 }


### PR DESCRIPTION
Requires https://github.com/octobercms/library/pull/406. This vastly improves performance of interacting with protected files in the backend that are located on remote storage services (S3, Rackspace) that support the use of temporary URLs.

Should this behaviour be configurable? @bennothommo @w20k @daftspunk 