### PR TITLE
This fixes the issue with menus not being displayed in pages plugin

### DIFF
--- a/modules/cms/classes/Meta.php
+++ b/modules/cms/classes/Meta.php
@@ -42,7 +42,7 @@ class Meta extends CmsObject
             $this->content = $this->renderContent();
         });
         $this->bindEvent('model.afterFetch', function () {
-            $this->attributes = array_merge($this->parseContent(), $this->attributes);
+            $this->attributes = array_merge($this->attributes, $this->parseContent());
         });
     }
 


### PR DESCRIPTION
@LukeTowers requested this pull request in [this](https://github.com/rainlab/pages-plugin/issues/396#issuecomment-498092719) conversation.

I don't know why, but this change is solving the issue of menus from the pages plugin not being displayed on my websites. Maybe it has something to do with my PHP version. I'm using PHP 7.3.4.