### PR TITLE
Hide popup loading indicator if an error/flash is thrown from an AJAX handler

### DIFF
--- a/modules/system/assets/ui/js/popup.js
+++ b/modules/system/assets/ui/js/popup.js
@@ -86,10 +86,10 @@
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     this.error(jqXHR, textStatus, errorThrown).done(function(){
-                        self.hide()
                         if (self.isLoading) {
-                            self.setLoading(false)
-                            setTimeout(function(){ self.setBackdrop(false) }, 100)
+                            self.hideLoading();
+                        } else {
+                            self.hide()
                         }
                         self.triggerEvent('popupError') // Deprecated
                         self.triggerEvent('error.oc.popup')

--- a/modules/system/assets/ui/js/popup.js
+++ b/modules/system/assets/ui/js/popup.js
@@ -22,6 +22,7 @@
         this.$modal     = null
         this.$backdrop  = null
         this.isOpen     = false
+        this.isLoading  = false
         this.firstDiv   = null
         this.allowHide  = true
 
@@ -86,6 +87,10 @@
                 error: function(jqXHR, textStatus, errorThrown) {
                     this.error(jqXHR, textStatus, errorThrown).done(function(){
                         self.hide()
+                        if (self.isLoading) {
+                            self.setLoading(false)
+                            setTimeout(function(){ self.setBackdrop(false) }, 100)
+                        }
                         self.triggerEvent('popupError') // Deprecated
                         self.triggerEvent('error.oc.popup')
                     })
@@ -178,7 +183,7 @@
         this.$modal = null
         this.$el = null
 
-        // In some cases options could contain callbacks, 
+        // In some cases options could contain callbacks,
         // so it's better to clean them up too.
         this.options = null
 
@@ -248,6 +253,8 @@
     Popup.prototype.setLoading = function(val) {
         if (!this.$backdrop)
             return;
+
+        this.isLoading = val
 
         var self = this
         if (val) {

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3744,9 +3744,7 @@ if(!this.options.content){this.setLoading(true)}
 if(this.options.handler){this.$el.request(this.options.handler,{data:paramToObj('data-extra-data',this.options.extraData),success:function(data,textStatus,jqXHR){this.success(data,textStatus,jqXHR).done(function(){self.setContent(data.result)
 $(window).trigger('ajaxUpdateComplete',[this,data,textStatus,jqXHR])
 self.triggerEvent('popupComplete')
-self.triggerEvent('complete.oc.popup')})},error:function(jqXHR,textStatus,errorThrown){this.error(jqXHR,textStatus,errorThrown).done(function(){self.hide()
-if(self.isLoading){self.setLoading(false)
-setTimeout(function(){self.setBackdrop(false)},100)}
+self.triggerEvent('complete.oc.popup')})},error:function(jqXHR,textStatus,errorThrown){this.error(jqXHR,textStatus,errorThrown).done(function(){if(self.isLoading){self.hideLoading();}else{self.hide()}
 self.triggerEvent('popupError')
 self.triggerEvent('error.oc.popup')})}})}
 else if(this.options.ajax){$.ajax({url:this.options.ajax,data:paramToObj('data-extra-data',this.options.extraData),success:function(data){self.setContent(data)},cache:false})}

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3723,6 +3723,7 @@ this.$container=null
 this.$modal=null
 this.$backdrop=null
 this.isOpen=false
+this.isLoading=false
 this.firstDiv=null
 this.allowHide=true
 this.$container=this.createPopupContainer()
@@ -3744,6 +3745,8 @@ if(this.options.handler){this.$el.request(this.options.handler,{data:paramToObj(
 $(window).trigger('ajaxUpdateComplete',[this,data,textStatus,jqXHR])
 self.triggerEvent('popupComplete')
 self.triggerEvent('complete.oc.popup')})},error:function(jqXHR,textStatus,errorThrown){this.error(jqXHR,textStatus,errorThrown).done(function(){self.hide()
+if(self.isLoading){self.setLoading(false)
+setTimeout(function(){self.setBackdrop(false)},100)}
 self.triggerEvent('popupError')
 self.triggerEvent('error.oc.popup')})}})}
 else if(this.options.ajax){$.ajax({url:this.options.ajax,data:paramToObj('data-extra-data',this.options.extraData),success:function(data){self.setContent(data)},cache:false})}
@@ -3806,7 +3809,8 @@ this.$backdrop.append($('<div class="modal-content popup-loading-indicator" />')
 else if(!val&&this.$backdrop){this.$backdrop.remove()
 this.$backdrop=null}}
 Popup.prototype.setLoading=function(val){if(!this.$backdrop)
-return;var self=this
+return;this.isLoading=val
+var self=this
 if(val){setTimeout(function(){self.$backdrop.addClass('loading');},100)}
 else{setTimeout(function(){self.$backdrop.removeClass('loading');},100)}}
 Popup.prototype.setShake=function(){var self=this


### PR DESCRIPTION
Fixes https://github.com/rainlab/builder-plugin/issues/283

A popup widget using an AJAX handler will display a loading indicator whilst waiting for a response. If an error or a flash message is returned by the AJAX handler, the error is displayed correctly to the user, but the loading indicator and modal backdrop are not removed as the modal is technically not "open" at this stage.

This fix resolves this by tracking the loading state of the popup and removing the loading indicator and backdrop if an error occurs during load.