### PR TITLE
Fix empty menu item counter

### DIFF
--- a/modules/backend/layouts/_mainmenu.htm
+++ b/modules/backend/layouts/_mainmenu.htm
@@ -34,7 +34,7 @@
                             </span>
                         </a>
                         <span
-                            class="counter <?= $item->counter === null ? 'empty' : null ?>"
+                            class="counter <?= !$item->counter ? 'empty' : null ?>"
                             data-menu-id="<?= e($item->code) ?>"
                             <?php if ($item->counterLabel): ?>title="<?= e(trans($item->counterLabel)) ?>"<?php endif ?>
                         >


### PR DESCRIPTION
Remove empty counter from main menu items when set to false. See [https://octobercms.com/docs/plugin/registration#navigation-menus](https://octobercms.com/docs/plugin/registration#navigation-menus) for documentation.

Fixes #4371