### PR TITLE
Prefetch Dashboard assets at Signin Stage to speed up loading

### DIFF
--- a/modules/backend/layouts/auth.htm
+++ b/modules/backend/layouts/auth.htm
@@ -10,6 +10,17 @@
         <link rel="icon" type="image/png" href="<?= e(Backend\Models\BrandSetting::getFavicon()) ?>">
         <title><?= e(trans('backend::lang.auth.title')) ?></title>
 
+        <!-- Prefecth the Dashboard Resources to speed up loading -->
+        <meta http-equiv="x-dns-prefetch-control" content="on">
+
+        <link rel="prefetch" href="<?= Backend::skinAsset('widgets/mediamanager/assets/css/mediamanager.css') ?>?v<?= $coreBuild ?>" as="style">
+        <link rel="prefetch" href="<?= Backend::skinAsset('assets/css/dashboard/dashboard.css') ?>?v<?= $coreBuild ?>" as="style">
+        <link rel="prefetch" href="<?= Backend::skinAsset('widgets/reportcontainer/assets/css/reportcontainer.css') ?>?v<?= $coreBuild ?>" as="style">
+
+        <link rel="prefetch" href="<?= Backend::skinAsset('widgets/mediamanager/assets/js/mediamanager-browser-min.js') ?>?v<?= $coreBuild ?>" as="script">
+        <link rel="prefetch" href="<?= Backend::skinAsset('widgets/reportcontainer/assets/vendor/isotope/jquery.isotope.min.js') ?>?v<?= $coreBuild ?>" as="script">
+        <link rel="prefetch" href="<?= Backend::skinAsset('widgets/reportcontainer/assets/js/reportcontainer.js') ?>?v<?= $coreBuild ?>" as="script">       
+
         <?php
             $coreBuild = System\Models\Parameter::get('system::core.build', 1);
             $styles = [


### PR DESCRIPTION
When a User opens the Backend Signin screen their next web page that will open is (99.9% of the time) the Dashboard web page. This is a perfect use case, where we can prefecth the Dashboard assets ahead of time to make the loading faster and on the road to instant loading. See comment here for further details: https://github.com/octobercms/october/issues/4379#issuecomment-501806678

Before Luke asks me for more information about this I have drawn a flow chart picture for you:

![1](https://user-images.githubusercontent.com/17784082/59458694-e429a200-8e12-11e9-9f40-2908eeda5c0f.png)
