### PR TITLE
Fix the S3 temporaryUrl generating issue

### DIFF
--- a/modules/backend/controllers/Files.php
+++ b/modules/backend/controllers/Files.php
@@ -77,10 +77,15 @@ class Files extends Controller
             if (empty($path)) {
                 $path = $file->getDiskPath();
             }
+
+            // Check to see if the URL has already been generated
+            $pathKey = 'backend.file:' . $path;
+            $url = Cache::get($pathKey);
+
             // The AWS S3 storage drivers will return a valid temporary URL even if the file does not exist
-            if ($disk->exists($path)) {
+            if (is_null($url) && $disk->exists($path)) {
                 $expires = now()->addSeconds(Config::get('cms.storage.uploads.temporaryUrlTTL', 3600));
-                $url = Cache::remember('backend.file:' . $path, $expires, function () use ($disk, $path, $expires) {
+                $url = Cache::remember($pathKey, $expires, function () use ($disk, $path, $expires) {
                     return $disk->temporaryUrl($path, $expires);
                 });
             }

--- a/modules/backend/controllers/Files.php
+++ b/modules/backend/controllers/Files.php
@@ -77,6 +77,9 @@ class Files extends Controller
             if (empty($path)) {
                 $path = $file->getDiskPath();
             }
+            if (!$disk->exists($path)) {
+                return '';
+            }
             $expires = now()->addSeconds(Config::get('cms.storage.uploads.temporaryUrlTTL', 3600));
 
             $url = Cache::remember('backend.file:' . $path, $expires, function () use ($disk, $path, $expires) {


### PR DESCRIPTION
Need to check whether the key exists before generating the S3 Pre-Signed URL.

With S3 Disk, the $disk->temporaryUrl($path, $expires) method can create the Temp url even if the $path not exists.