### PR TITLE
Fix FormData initialization in framework.js

### DIFF
--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -19,7 +19,7 @@ $.each($el.parents('[data-request-data]').toArray().reverse(),function extendReq
 if($el.is(':input')&&!$form.length){inputName=$el.attr('name')
 if(inputName!==undefined&&options.data[inputName]===undefined){options.data[inputName]=$el.val()}}
 if(options.data!==undefined&&!$.isEmptyObject(options.data)){$.extend(data,options.data)}
-if(useFiles){requestData=new FormData($form.length?$form.get(0):null)
+if(useFiles){requestData=new FormData($form.length?$form.get(0):undefined)
 if($el.is(':file')&&inputName){$.each($el.prop('files'),function(){requestData.append(inputName,this)})
 delete data[inputName]}
 $.each(data,function(key){requestData.append(key,this)})}

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -19,7 +19,7 @@ $.each($el.parents('[data-request-data]').toArray().reverse(),function extendReq
 if($el.is(':input')&&!$form.length){inputName=$el.attr('name')
 if(inputName!==undefined&&options.data[inputName]===undefined){options.data[inputName]=$el.val()}}
 if(options.data!==undefined&&!$.isEmptyObject(options.data)){$.extend(data,options.data)}
-if(useFiles){requestData=new FormData($form.length?$form.get(0):null)
+if(useFiles){requestData=new FormData($form.length?$form.get(0):undefined)
 if($el.is(':file')&&inputName){$.each($el.prop('files'),function(){requestData.append(inputName,this)})
 delete data[inputName]}
 $.each(data,function(key){requestData.append(key,this)})}

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -91,7 +91,7 @@ if (window.jQuery.request !== undefined) {
         }
 
         if (useFiles) {
-            requestData = new FormData($form.length ? $form.get(0) : null)
+            requestData = $form.length ? new FormData($form.get(0)) : new FormData()
 
             if ($el.is(':file') && inputName) {
                 $.each($el.prop('files'), function() {

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -91,7 +91,7 @@ if (window.jQuery.request !== undefined) {
         }
 
         if (useFiles) {
-            requestData = $form.length ? new FormData($form.get(0)) : new FormData()
+            requestData = new FormData($form.length ? $form.get(0) : undefined)
 
             if ($el.is(':file') && inputName) {
                 $.each($el.prop('files'), function() {


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->
### Problem
When `$.request()` is tried to run with `files: true` option, there's an error in console. In the FireFox (FF DE 68.0b10 (64-bit)) it is
`TypeError: Argument 1 of FormData.constructor is not an object.`. In Chrome (75.0.3770.90 (64-bit)) it is `Uncaught TypeError: Failed to construct 'FormData': parameter 1 is not of type 'HTMLFormElement'.`. 
A fix seems to be easy.
### How to test
- Enable Demo theme
- Put into `layouts/default.htm` (after all scripts) this code:
```
        <script>
            setTimeout(function() {
                $.request('onAddItem', {
                    files: true,
                    success: function(data) {
                        console.log(data);
                    },
                });
            }, 2000);
        </script>
```
- Open in the browser `/demo/plugins` page
- Look at the Console tab in the DevTools
### Even if you can't catch this error
It seems that the `FormData` object shouldn't be initiated by `null` value. See [here](https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData) and [here](https://xhr.spec.whatwg.org/#interface-formdata). I think there will be nothing wrong if we change code a little.