### PR TITLE
Improve Travis CI build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,20 +31,20 @@ jobs:
     - stage: linting
       script:
         - echo $TRAVIS_COMMIT_RANGE
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: 7.1
     - stage: linting
       script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: 7.2
     - stage: linting
       script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: 7.3
     - stage: linting
       script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: nightly
     - stage: code quality
       php: 7.1
-      script: sh -c "./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE)"
+      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ stages:
 jobs:
   include:
     - stage: "Linting"
-      script: ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r HEAD | grep ".php")
+      script: ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r develop..HEAD | grep ".php")
     - stage: "Tests"
       script: ./vendor/bin/phpunit
     - stage: "Code Quality"
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r HEAD)
+      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r develop..HEAD)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,27 +18,19 @@ cache:
     - $HOME/.composer/cache/files
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction --no-progress --no-suggest
 
 before_script: git reset --hard HEAD
 
 stages:
   - "Linting"
-  - "Tests"
+  - test
   - "Code Quality"
 
 jobs:
   include:
     - stage: "Linting"
-      php:
-        - 7.0
-        - 7.1
-        - 7.2
-        - 7.3
-        - nightly
-      allow_failures:
-        - php: nightly
-      script: ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+      script: sh -c "./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep \".php\")"
     - stage: "Code Quality"
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE)
+      script: sh -c "./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,53 +24,16 @@ install:
 before_script: git reset --hard HEAD
 
 stages:
-  - linting
   - test
   - code quality
   - code coverage
 
+script:
+  - ./vendor/bin/parallel-lint --exclude vendor --exclude storage --exclude tests/fixtures/plugins/testvendor/goto/Plugin.php .
+  - ./vendor/bin/phpunit
+
 jobs:
   include:
-    - stage: linting
-      if: type = pull_request
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
-      php: 7.1
-    - stage: linting
-      if: type = pull_request
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
-      php: 7.2
-    - stage: linting
-      if: type = pull_request
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
-      php: 7.3
-    - stage: linting
-      if: type = pull_request
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
-      php: nightly
-    - stage: linting
-      if: type = push AND (branch = develop OR branch = master)
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
-      php: 7.1
-    - stage: linting
-      if: type = push AND (branch = develop OR branch = master)
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
-      php: 7.2
-    - stage: linting
-      if: type = push AND (branch = develop OR branch = master)
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
-      php: 7.3
-    - stage: linting
-      if: type = push AND (branch = develop OR branch = master)
-      script:
-        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
-      php: nightly
     - stage: code coverage
       if: type = push AND (branch = develop OR branch = master)
       php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
 
 sudo: false
 
+if: type = pull_request OR (type = push AND (branch = develop OR branch = master))
+
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -50,35 +52,36 @@ jobs:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: nightly
     - stage: linting
-      if: type = push
+      if: type = push AND (branch = develop OR branch = master)
       script:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
       php: 7.1
     - stage: linting
-      if: type = push
+      if: type = push AND (branch = develop OR branch = master)
       script:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
       php: 7.2
     - stage: linting
-      if: type = push
+      if: type = push AND (branch = develop OR branch = master)
       script:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
       php: 7.3
     - stage: linting
-      if: type = push
+      if: type = push AND (branch = develop OR branch = master)
       script:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
       php: nightly
-    - stage: code quality
-      if: type = pull_request
-      php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})
     - stage: code coverage
+      if: type = push AND (branch = develop OR branch = master)
       php: 7.1
       script:
         - ./vendor/bin/phpunit --testsuite "October CMS Test Suite" --coverage-clover=coverage.xml
         - bash <(curl -s https://codecov.io/bash)
     - stage: code quality
-      if: type = push
+      if: type = pull_request
+      php: 7.1
+      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})
+    - stage: code quality
+      if: type = push AND (branch = develop OR branch = master)
       php: 7.1
       script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ matrix:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 install:
-  - composer self-update
   - travis_retry composer install --no-interaction --prefer-source
 
 before_script: git reset --hard HEAD
@@ -27,9 +30,15 @@ stages:
 jobs:
   include:
     - stage: "Linting"
-      script: ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r develop..HEAD | grep ".php")
-    - stage: "Tests"
-      script: ./vendor/bin/phpunit
+      php:
+        - 7.0
+        - 7.1
+        - 7.2
+        - 7.3
+        - nightly
+      allow_failures:
+        - php: nightly
+      script: ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
     - stage: "Code Quality"
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r develop..HEAD)
+      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,17 @@ install:
 
 before_script: git reset --hard HEAD
 
-script: vendor/bin/phpunit
+stages:
+  - "Linting"
+  - "Tests"
+  - "Code Quality"
+
+jobs:
+  include:
+    - stage: "Linting"
+      script: ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r HEAD | grep ".php")
+    - stage: "Tests"
+      script: ./vendor/bin/phpunit
+    - stage: "Code Quality"
+      php: 7.1
+      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r HEAD)

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ jobs:
     - stage: code quality
       if: type = pull_request
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})
+      script: ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})
     - stage: code quality
       if: type = push AND (branch = develop OR branch = master)
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT)
+      script: ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -23,14 +22,29 @@ install:
 before_script: git reset --hard HEAD
 
 stages:
-  - "Linting"
+  - linting
   - test
-  - "Code Quality"
+  - code quality
 
 jobs:
   include:
-    - stage: "Linting"
-      script: sh -c "./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep \".php\")"
-    - stage: "Code Quality"
+    - stage: linting
+      script:
+        - echo $TRAVIS_COMMIT_RANGE
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+      php: 7.1
+    - stage: linting
+      script:
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+      php: 7.2
+    - stage: linting
+      script:
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+      php: 7.3
+    - stage: linting
+      script:
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE | grep ".php")
+      php: nightly
+    - stage: code quality
       php: 7.1
       script: sh -c "./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT_RANGE)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,22 +29,50 @@ stages:
 jobs:
   include:
     - stage: linting
+      if: type = pull_request
       script:
-        - echo $TRAVIS_COMMIT_RANGE
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: 7.1
     - stage: linting
+      if: type = pull_request
       script:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: 7.2
     - stage: linting
+      if: type = pull_request
       script:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: 7.3
     - stage: linting
+      if: type = pull_request
       script:
         - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..} | grep ".php")
       php: nightly
+    - stage: linting
+      if: type = push
+      script:
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
+      php: 7.1
+    - stage: linting
+      if: type = push
+      script:
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
+      php: 7.2
+    - stage: linting
+      if: type = push
+      script:
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
+      php: 7.3
+    - stage: linting
+      if: type = push
+      script:
+        - ./vendor/bin/parallel-lint $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT | grep ".php")
+      php: nightly
     - stage: code quality
+      if: type = pull_request
       php: 7.1
       script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})
+    - stage: code quality
+      if: type = push
+      php: 7.1
+      script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ stages:
   - linting
   - test
   - code quality
+  - code coverage
 
 jobs:
   include:
@@ -72,6 +73,11 @@ jobs:
       if: type = pull_request
       php: 7.1
       script: ./vendor/bin/phpcs --colors -nq --report="full" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})
+    - stage: code coverage
+      php: 7.1
+      script:
+        - ./vendor/bin/phpunit --testsuite "October CMS Test Suite" --coverage-clover=coverage.xml
+        - bash <(curl -s https://codecov.io/bash)
     - stage: code quality
       if: type = push
       php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require-dev": {
         "fzaninotto/faker": "~1.7",
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "~6.5",
         "phpunit/phpunit-selenium": "~1.2",
         "meyfa/phpunit-assert-gd": "1.1.0",
         "squizlabs/php_codesniffer": "3.*",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,9 @@
         "fzaninotto/faker": "~1.7",
         "phpunit/phpunit": "~5.7",
         "phpunit/phpunit-selenium": "~1.2",
-        "meyfa/phpunit-assert-gd": "1.1.0"
+        "meyfa/phpunit-assert-gd": "1.1.0",
+        "squizlabs/php_codesniffer": "3.*",
+        "jakub-onderka/php-parallel-lint": "^1.0"
     },
     "autoload-dev": {
         "classmap": [

--- a/modules/backend/controllers/Index.php
+++ b/modules/backend/controllers/Index.php
@@ -14,7 +14,7 @@ use Backend\Widgets\ReportContainer;
  */
 class Index extends Controller
 {
-    use \Backend\Traits\InspectableContainer; 
+    use \Backend\Traits\InspectableContainer;
 
     /**
      * @var array Permissions required to view this page.
@@ -71,7 +71,9 @@ class Index extends Controller
     protected function checkPermissionRedirect()
     {
         if (!$this->user->hasAccess('backend.access_dashboard')) {
-            $true = function () { return true; };
+            $true = function () {
+                return true;
+            };
             if ($first = array_first(BackendMenu::listMainMenuItems(), $true)) {
                 return Redirect::intended($first->url);
             }

--- a/modules/backend/controllers/Index.php
+++ b/modules/backend/controllers/Index.php
@@ -14,7 +14,7 @@ use Backend\Widgets\ReportContainer;
  */
 class Index extends Controller
 {
-    use \Backend\Traits\InspectableContainer;
+    use \Backend\Traits\InspectableContainer; 
 
     /**
      * @var array Permissions required to view this page.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="PSR2">
+    <description>The PSR2 coding standard.</description>
+    <rule ref="PSR2" />
+    <file>bootstrap/</file>
+    <file>config/</file>
+    <file>modules/</file>
+    <file>tests</file>
+
+    <exclude-pattern>vendor/</exclude-pattern>
+    <exclude-pattern>storage/</exclude-pattern>
+    <exclude-pattern>plugins/</exclude-pattern>
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
-<ruleset name="PSR2">
-    <description>The PSR2 coding standard.</description>
-    <rule ref="PSR2" />
+<ruleset name="October CMS">
+    <description>The coding standard for October CMS.</description>
+    <rule ref="PSR2">
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+    </rule>
+
     <file>bootstrap/</file>
     <file>config/</file>
     <file>modules/</file>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,23 @@
             <directory>./vendor/october/rain/tests</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./modules/</directory>
+
+            <exclude>
+                <file>./modules/backend/routes.php</file>
+                <file>./modules/cms/routes.php</file>
+                <file>./modules/system/routes.php</file>
+
+                <directory suffix=".php">./modules/backend/database</directory>
+                <directory suffix=".php">./modules/cms/database</directory>
+                <directory suffix=".php">./modules/system/database</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
     <php>
         <env name="APP_ENV" value="testing" />
         <env name="CACHE_DRIVER" value="array" />


### PR DESCRIPTION
Originally, this change was done to allow us to check pull requests for code smells and any PHP errors that may have occurred since the last commit to develop.

It has been extended to add the following to the Travis CI build process:
- Builds are cached where possible to speed up tasks
- Builds are run either on pull requests OR when a push is made to the `develop` or `master` branch - previously, a push to a PR ran the tasks twice, once for the push and once for the PR.
- ~~Removed PHP 7.0 tests - 7.0 is no longer supported (happy to add them back in though)~~ Re-added back in
- Added code coverage on pushes to `develop` or `master` only