### PR TITLE
Accessibility enhancement for code editor icons

### DIFF
--- a/modules/backend/formwidgets/codeeditor/assets/css/codeeditor.css
+++ b/modules/backend/formwidgets/codeeditor/assets/css/codeeditor.css
@@ -25,3 +25,4 @@
 .field-codeeditor.editor-fullscreen .editor-toolbar >ul >li >a {color:#666}
 .field-codeeditor.editor-fullscreen .ace_search {z-index:303}
 .field-codeeditor .secondary-tabs .editor-toolbar >ul >li >a {color:#fff}
+#cms-master-tabs .field-codeeditor .editor-toolbar >ul >li >a {color: #919898}

--- a/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
+++ b/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
@@ -122,4 +122,6 @@
 
 }
 
-#cms-master-tabs { .field-codeeditor { .editor-toolbar { >ul { >li { >a { color: @color_3; } } } } } }
+#cms-master-tabs .field-codeeditor .editor-toolbar > ul  > li  > a { 
+    color: @color_3; 
+} 

--- a/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
+++ b/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
@@ -122,16 +122,4 @@
 
 }
 
-#cms-master-tabs {
-	.field-codeeditor {
-		.editor-toolbar {
-			>ul {
-				>li {
-					>a {
-						color: @color_3;
-					}
-				}
-			}
-		}
-	}
-}
+#cms-master-tabs { .field-codeeditor { .editor-toolbar { >ul { >li { >a { color: @color_3; } } } } } }

--- a/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
+++ b/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
@@ -2,6 +2,7 @@
 
 @color_1: #666;
 @color_2: #fff;
+@color_3: #919898;
 @background_color_1: #ddd;
 @border_right_color_1: #cbcbcb;
 
@@ -119,4 +120,18 @@
         }
     }
 
+}
+
+#cms-master-tabs {
+	.field-codeeditor {
+		.editor-toolbar {
+			>ul {
+				>li {
+					>a {
+						color: @color_3;
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes the issue of the code editor icons being hard to see, they now match the other icons and this PR only works in the `CMS` web page section and not the rest of the cms which when testing is ok.

See test results on a live test server:

![Untitled](https://user-images.githubusercontent.com/17784082/59786633-994ed500-92bf-11e9-8e29-1353f1a780fa.png)

@w20k ready for you to test and check, shouldn't take up too much of your time, as I've double checked this for you.

Fixes Github issue: https://github.com/octobercms/october/issues/4392

