### PR TITLE
Fix for the Object list editor report widget property type

### DIFF
--- a/modules/backend/widgets/ReportContainer.php
+++ b/modules/backend/widgets/ReportContainer.php
@@ -450,7 +450,11 @@ class ReportContainer extends WidgetBase
 
         $properties = $widget->defineProperties();
         foreach ($properties as $name => $params) {
-            $result[$name] = Lang::get($widget->property($name));
+            if (is_array($widget->property($name))) {
+                $result[$name] = $widget->property($name);
+            } else {
+                $result[$name] = Lang::get($widget->property($name));
+            }
         }
 
         $result['ocWidgetWidth'] = $widget->property('ocWidgetWidth');


### PR DESCRIPTION
Fixes the ErrorException: substr() expects parameter 1 to be string, array given. PR for issue #4398.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->