### PR TITLE
Fix Travis CI file scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ jobs:
     - stage: code quality
       if: type = pull_request
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff-tree --no-commit-id --name-only -r ${TRAVIS_COMMIT_RANGE/.../..})
+      script: ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff --name-only origin/$TRAVIS_BRANCH..HEAD)
     - stage: code quality
       if: type = push AND (branch = develop OR branch = master)
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff-tree --no-commit-id --name-only -r $TRAVIS_COMMIT)
+      script: ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff --name-only $TRAVIS_COMMIT)

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ jobs:
     - stage: code quality
       if: type = pull_request
       php: 7.1
-      script: ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff --name-only origin/$TRAVIS_BRANCH..HEAD)
+      script:
+        - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch
+        - ./vendor/bin/phpcs --colors -nq --report="full" --extensions="php" $(git diff --name-only HEAD origin/$TRAVIS_BRANCH)
     - stage: code quality
       if: type = push AND (branch = develop OR branch = master)
       php: 7.1

--- a/modules/backend/models/ExportModel.php
+++ b/modules/backend/models/ExportModel.php
@@ -96,7 +96,7 @@ abstract class ExportModel extends Model
          * Prepare CSV
          */
         $csv = CsvWriter::createFromFileObject(new SplTempFileObject);
-        
+
         $csv->setOutputBOM(CsvWriter::BOM_UTF8);
 
         if ($options['delimiter'] !== null) {
@@ -192,7 +192,7 @@ abstract class ExportModel extends Model
         $newData = [];
         foreach ($data as $value) {
             if (is_array($value)) {
-                $newData[] = 'Array';
+                $newData[] = 'Array'; 
             }
             else {
                 $newData[] = str_replace($delimeter, '\\'.$delimeter, $value);

--- a/modules/backend/models/ExportModel.php
+++ b/modules/backend/models/ExportModel.php
@@ -192,9 +192,8 @@ abstract class ExportModel extends Model
         $newData = [];
         foreach ($data as $value) {
             if (is_array($value)) {
-                $newData[] = 'Array'; 
-            }
-            else {
+                $newData[] = 'Array';
+            } else {
                 $newData[] = str_replace($delimeter, '\\'.$delimeter, $value);
             }
         }


### PR DESCRIPTION
The original Travis CI fixes in #4394 were picking up file changes in other PR branches and not just the current branch. This fix should restrict the file diff to just the current branch's changes.