### PR TITLE
Code Editor Buttons Brightened

### DIFF
--- a/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
+++ b/modules/backend/formwidgets/codeeditor/assets/less/codeeditor.less
@@ -48,7 +48,7 @@
             display: block;
             height: 25px;
             width: 25px;
-            color: #666;
+            color: @color_2;
             font-size: 20px;
             text-align: center;
             text-decoration: none;


### PR DESCRIPTION
Code Editor Buttons are not visible easily as you can see in the picture
![50541966-220a7500-0ba9-11e9-928c-017ef82ac58c](https://user-images.githubusercontent.com/40098832/60214561-a50d3f00-985d-11e9-967e-5bffe07cb9e3.png)

This PR solves this issue
![solved](https://user-images.githubusercontent.com/40098832/60214680-d84fce00-985d-11e9-8a8b-99e1faeb3532.PNG)

**How to test**
- Checkout to this branch
- run `php artisan october:util compile assets` in root
- clear cache and browser cookies