### PR TITLE
Clean up index functionality in Repeater widget

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -293,7 +293,6 @@ class Repeater extends FormWidgetBase
 
         $groupCode = post('_repeater_group');
 
-        // Gets the next available index number
         $index = $this->getNextIndex();
 
         $this->prepareVars();
@@ -322,6 +321,11 @@ class Repeater extends FormWidgetBase
         return $widget->onRefresh();
     }
 
+    /**
+     * Determines the next available index number for assigning to a new repeater item.
+     *
+     * @return int
+     */
     protected function getNextIndex()
     {
         if ($this->loaded === true) {

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -3,7 +3,6 @@
 use Lang;
 use ApplicationException;
 use Backend\Classes\FormWidgetBase;
-use October\Rain\Html\Helper as HtmlHelper;
 
 /**
  * Repeater Form Widget
@@ -54,11 +53,6 @@ class Repeater extends FormWidgetBase
     protected $defaultAlias = 'repeater';
 
     /**
-     * @var int Count of repeated items.
-     */
-    protected $indexCount = 0;
-
-    /**
      * @var array Meta data associated to each field, organised by index
      */
     protected $indexMeta = [];
@@ -106,8 +100,6 @@ class Repeater extends FormWidgetBase
         if ((bool) post($this->alias . '_loaded') === true) {
             $this->loaded = true;
         }
-
-        $fieldName = $this->formField->getName(false);
 
         $this->processGroupMode();
 
@@ -214,10 +206,9 @@ class Repeater extends FormWidgetBase
             : $this->getLoadValue();
 
         if ($currentValue === null) {
-            $this->indexCount = 0;
             $this->formWidgets = [];
             return;
-        }       
+        }
 
         // Ensure that the minimum number of items are preinitialized
         // ONLY DONE WHEN NOT IN GROUP MODE
@@ -233,16 +224,14 @@ class Repeater extends FormWidgetBase
                 }
             }
         }
-        
+
         if (!is_array($currentValue)) {
             return;
         }
-       
+
         collect($currentValue)->each(function ($value, $index) {
             $this->makeItemFormWidget($index, array_get($value, '_group', null));
         });
-        
-        $this->indexCount = max(count($currentValue), $this->indexCount);
     }
 
     /**
@@ -304,14 +293,14 @@ class Repeater extends FormWidgetBase
 
         $groupCode = post('_repeater_group');
 
+        // Gets the next available index number
+        $index = $this->getNextIndex();
+
         $this->prepareVars();
-        $this->vars['widget'] = $this->makeItemFormWidget($this->indexCount, $groupCode);
-        $this->vars['indexValue'] = $this->indexCount;
+        $this->vars['widget'] = $this->makeItemFormWidget($index, $groupCode);
+        $this->vars['indexValue'] = $index;
 
         $itemContainer = '@#' . $this->getId('items');
-
-        // Increase index count after item is created
-        ++$this->indexCount;
 
         return [
             $itemContainer => $this->makePartial('repeater_item')
@@ -331,6 +320,25 @@ class Repeater extends FormWidgetBase
         $widget = $this->makeItemFormWidget($index, $group);
 
         return $widget->onRefresh();
+    }
+
+    protected function getNextIndex()
+    {
+        if ($this->loaded === true) {
+            $data = post($this->formField->getName());
+
+            if (is_array($data) && count($data)) {
+                return (max(array_keys($data)) + 1);
+            }
+        } else {
+            $data = $this->getLoadValue();
+
+            if (is_array($data)) {
+                return count($data);
+            }
+        }
+
+        return 0;
     }
 
     //


### PR DESCRIPTION
- Remove `$indexCount` property, as it is no longer needed with this fix in place.
- Determine highest key number in data, and increment when adding another item in the repeater.
- Remove some old code and dependencies.

Fixes #4402.