### PR TITLE
Fix error when $user is null

### DIFF
--- a/modules/system/classes/SettingsManager.php
+++ b/modules/system/classes/SettingsManager.php
@@ -365,6 +365,10 @@ class SettingsManager
      */
     protected function filterItemPermissions($user, array $items)
     {
+        if (!$user) {
+            return $items;
+        }
+        
         $items = array_filter($items, function ($item) use ($user) {
             if (!$item->permissions || !count($item->permissions)) {
                 return true;


### PR DESCRIPTION
I have no idea why the $user variable can ever be null in the first place, but for me it happens if I remove all main menu items (including the settings). The same check is already in place at the navigation manager: https://github.com/octobercms/october/blob/master/modules/backend/classes/NavigationManager.php#L509-L511
The change shouldn't break anything.

To reproduce the error, you can use this code:
```php
protected function removeMainMenuItems()
    {
        $navigationManager = NavigationManager::instance();
        foreach ($navigationManager->listMainMenuItems() as $mainMenuItem) {
            $navigationManager->removeMainMenuItem($mainMenuItem->owner, $mainMenuItem->code);
        }
    }
```