### PR TITLE
Fix backend same filename check bug

### DIFF
--- a/modules/cms/widgets/templatelist/partials/_items.htm
+++ b/modules/cms/widgets/templatelist/partials/_items.htm
@@ -36,7 +36,7 @@
 
                     <input type="hidden" name="template[<?= e($item->fileName) ?>]" value="0" />
                     <div class="checkbox custom-checkbox nolabel">
-                        <?php $cbId = 'cb'.md5($this->itemType . '/' . $item->fileName) ?>
+                        <?php $cbId = 'cb' . md5($this->itemType . '/' . $item->fileName) ?>
                         <input
                             id="<?= $cbId ?>"
                             type="checkbox"

--- a/modules/cms/widgets/templatelist/partials/_items.htm
+++ b/modules/cms/widgets/templatelist/partials/_items.htm
@@ -36,7 +36,7 @@
 
                     <input type="hidden" name="template[<?= e($item->fileName) ?>]" value="0" />
                     <div class="checkbox custom-checkbox nolabel">
-                        <?php $cbId = 'cb'.md5($item->fileName) ?>
+                        <?php $cbId = 'cb'.md5($this->itemType . '/' . $item->fileName) ?>
                         <input
                             id="<?= $cbId ?>"
                             type="checkbox"


### PR DESCRIPTION
**Summary:**
 In October backend cms module,when you have same filename in Pages and Partials, and you select the Partials's file, unfortunately, it can't be checked.

**Reproduce steps:**
 1. In October backend cms module, create a page name's index, create a partial name's index 
2. select the partial's index file

**Expected behavior:** The partial's index file will be selected.

**Actual behavior:** The page's index file will be selected and the partial's index file will not be selected

**Bug show:**
![oc_file_checkbox_bug](https://user-images.githubusercontent.com/20298832/60692742-23c34580-9f0a-11e9-873f-cdd53933debf.gif)