### PR TITLE
Fix "widget not bound to controller" error for nested repeaters

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -115,7 +115,7 @@ class Repeater extends FormWidgetBase
             $this->loaded = true;
         }
 
-        $this->checkAjaxRequest();
+        $this->checkAddItemRequest();
         $this->processGroupMode();
 
         if (!self::$onAddItemCalled) {
@@ -364,17 +364,24 @@ class Repeater extends FormWidgetBase
     }
 
     /**
-     * Determines the repeater that has triggered an AJAX request.
+     * Determines the repeater that has triggered an AJAX request to add an item.
      *
      * @return void
      */
-    protected function checkAjaxRequest()
+    protected function checkAddItemRequest()
     {
         $handler = $this->getParentForm()
             ->getController()
             ->getAjaxHandler();
 
-        list($widgetName) = explode('::', $handler);
+        if ($handler === null || strpos($handler, '::') === false) {
+            return;
+        }
+
+        list($widgetName, $handlerName) = explode('::', $handler);
+        if ($handlerName !== 'onAddItem') {
+            return;
+        }
 
         if ($this->alias === $widgetName) {
             // This repeater has made the AJAX request


### PR DESCRIPTION
Since repeaters have no value by themselves, a repeater that contains only a child repeater was throwing a "widget not bound to controller" exception when adding a new item. This is due to the repeater `processItems()` method not creating a form widget for the inner repeater as it contained no value.

This fix specifically checks if a child repeater has called for a new item - if this is the case, and the current repeater has no value for this particular item, it will add a "stub" form widget to correctly bind the inner repeater widget.

Fixes #4344, ~~and quite possibly #3415 as well.~~