### PR TITLE
Relation Manager Customisation Improvements

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1465,7 +1465,7 @@ class RelationController extends ControllerBehavior
 
     /**
      * Determine the default buttons based on the model relationship type.
-     * @return array|string
+     * @return array|null
      */
     protected function evalToolbarButtons()
     {

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1583,7 +1583,7 @@ class RelationController extends ControllerBehavior
             case 'pivot':
                 if (array_key_exists('pivot', $customTitles)) {
                     return $customTitles['pivot'];
-                } elseif ($this->eventTarget == 'button-link') {
+                } elseif ($this->eventTarget === 'button-link') {
                     return 'backend::lang.relation.link_a_new';
                 }
 

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1465,7 +1465,7 @@ class RelationController extends ControllerBehavior
 
     /**
      * Determine the default buttons based on the model relationship type.
-     * @return string
+     * @return array|string
      */
     protected function evalToolbarButtons()
     {
@@ -1495,41 +1495,41 @@ class RelationController extends ControllerBehavior
             }
         }
 
-        $buttonText = array();
+        $buttonText = [];
 
         foreach ($buttons as $type => $text) {
-            if (is_numeric($type) || ! $text) {
+            if (is_numeric($type) || !$text) {
                 if (is_numeric($type) && $text) {
                     $type = $text;
                 }
 
                 switch ($type) {
-                    case 'add':
-                        $text = 'backend::lang.relation.add_name';
-                        break;
-
                     case 'create':
                         $text = 'backend::lang.relation.create_name';
+                        break;
+
+                    case 'update':
+                        $text = 'backend::lang.relation.update_name';
                         break;
 
                     case 'delete':
                         $text = 'backend::lang.relation.delete';
                         break;
 
-                    case 'link':
-                        $text = 'backend::lang.relation.link_name';
+                    case 'add':
+                        $text = 'backend::lang.relation.add_name';
                         break;
 
                     case 'remove':
                         $text = 'backend::lang.relation.remove';
                         break;
+
+                    case 'link':
+                        $text = 'backend::lang.relation.link_name';
+                        break;
                         
                     case 'unlink':
                         $text = 'backend::lang.relation.unlink';
-                        break;
-
-                    case 'update':
-                        $text = 'backend::lang.relation.update_name';
                         break;
                 }
             }
@@ -1577,7 +1577,7 @@ class RelationController extends ControllerBehavior
             return $customTitle;
         }
 
-        $customTitles = is_array($customTitle) ? $customTitle : array();
+        $customTitles = is_array($customTitle) ? $customTitle : [];
 
         switch ($this->manageMode) {
             case 'pivot':

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -896,12 +896,12 @@ class RelationController extends ControllerBehavior
             if (!$config = $this->makeConfigForMode('manage', 'form', false)) {
                 return null;
             }
-            
+
             $config->model = $this->relationModel;
             $config->arrayName = class_basename($this->relationModel);
             $config->context = $this->evalFormContext('manage', !!$this->manageId);
             $config->alias = $this->alias . 'ManageForm';
-            
+
             /*
              * Existing record
              */
@@ -916,14 +916,14 @@ class RelationController extends ControllerBehavior
                     ]));
                 }
             }
-            
+
             $widget = $this->makeWidget('Backend\Widgets\Form', $config);
         }
-        
+
         if (!$widget) {
             return null;
         }
-        
+
         /*
          * Exclude existing relationships
          */
@@ -938,10 +938,10 @@ class RelationController extends ControllerBehavior
                 }
             });
         }
-        
+
         return $widget;
     }
-    
+
     protected function makePivotWidget()
     {
         $config = $this->makeConfigForMode('pivot', 'form');
@@ -949,15 +949,15 @@ class RelationController extends ControllerBehavior
         $config->arrayName = class_basename($this->relationModel);
         $config->context = $this->evalFormContext('pivot', !!$this->manageId);
         $config->alias = $this->alias . 'ManagePivotForm';
-        
+
         $foreignKeyName = $this->relationModel->getQualifiedKeyName();
-        
+
         /*
          * Existing record
          */
         if ($this->manageId) {
             $hydratedModel = $this->relationObject->where($foreignKeyName, $this->manageId)->first();
-            
+
             if ($hydratedModel) {
                 $config->model = $hydratedModel;
             } else {
@@ -975,35 +975,35 @@ class RelationController extends ControllerBehavior
                 $foreignModel = $this->relationModel
                     ->whereIn($foreignKeyName, (array) $this->foreignId)
                     ->first();
-                
+
                 if ($foreignModel) {
                     $foreignModel->exists = false;
                     $config->model = $foreignModel;
                 }
             }
-            
+
             $pivotModel = $this->relationObject->newPivot();
             $config->model->setRelation('pivot', $pivotModel);
         }
-        
+
         return $this->makeWidget('Backend\Widgets\Form', $config);
     }
-    
+
     //
     // AJAX (Buttons)
     //
-    
+
     public function onRelationButtonAdd()
     {
         $this->eventTarget = 'button-add';
-        
+
         return $this->onRelationManageForm();
     }
-    
+
     public function onRelationButtonCreate()
     {
         $this->eventTarget = 'button-create';
-        
+
         return $this->onRelationManageForm();
     }
 

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1474,17 +1474,13 @@ class RelationController extends ControllerBehavior
         if (!is_array($buttons)) {
             if ($buttons === false) {
                 return null;
-            }
-            elseif (is_string($buttons)) {
+            } elseif (is_string($buttons)) {
                 $buttons = array_map('trim', explode('|', $buttons));
-            }
-            elseif (is_array($buttons)) {
+            } elseif (is_array($buttons)) {
                 $buttons = $buttons;
-            }
-            elseif ($this->manageMode == 'pivot') {
+            } elseif ($this->manageMode == 'pivot') {
                 $buttons = ['add', 'remove'];
-            }
-            else {
+            } else {
                 switch ($this->relationType) {
                     case 'hasMany':
                     case 'morphMany':

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -156,6 +156,11 @@ class RelationController extends ControllerBehavior
     protected $toolbarButtons;
 
     /**
+     * @var array The text used for the set of toolbar buttons.
+     */
+    protected $toolbarButtonText;
+
+    /**
      * @var Model Reference to the model used for viewing (form only).
      */
     protected $viewModel;
@@ -270,6 +275,7 @@ class RelationController extends ControllerBehavior
         $this->vars['relationManageMode'] = $this->manageMode;
         $this->vars['relationManageWidget'] = $this->manageWidget;
         $this->vars['relationToolbarButtons'] = $this->toolbarButtons;
+        $this->vars['relationToolbarButtonText'] = $this->toolbarButtonText;
         $this->vars['relationViewMode'] = $this->viewMode;
         $this->vars['relationViewWidget'] = $this->viewWidget;
         $this->vars['relationViewModel'] = $this->viewModel;
@@ -320,16 +326,17 @@ class RelationController extends ControllerBehavior
         }
 
         if (!$this->model) {
-            throw new ApplicationException(Lang::get('backend::lang.relation.missing_model', [
-                'class' => get_class($this->controller),
-            ]));
+            throw new ApplicationException(Lang::get(
+                'backend::lang.relation.missing_model',
+                ['class'=>get_class($this->controller)]
+            ));
         }
 
         if (!$this->model instanceof Model) {
-            throw new ApplicationException(Lang::get('backend::lang.model.invalid_class', [
-                'model' => get_class($this->model),
-                'class' => get_class($this->controller),
-            ]));
+            throw new ApplicationException(Lang::get(
+                'backend::lang.model.invalid_class',
+                ['model'=>get_class($this->model), 'class'=>get_class($this->controller)]
+            ));
         }
 
         if (!$this->getConfig($field)) {
@@ -360,6 +367,7 @@ class RelationController extends ControllerBehavior
         $this->manageMode = $this->evalManageMode();
         $this->manageTitle = $this->evalManageTitle();
         $this->toolbarButtons = $this->evalToolbarButtons();
+        $this->toolbarButtonText = $this->getConfig('view[toolbarButtonText]');
 
         /*
          * Toolbar widget
@@ -900,13 +908,10 @@ class RelationController extends ControllerBehavior
              * Existing record
              */
             if ($this->manageId) {
-                $model = $config->model->find($this->manageId);
-                if ($model) {
-                    $config->model = $model;
-                } else {
+                $config->model = $config->model->find($this->manageId);
+                if (!$config->model) {
                     throw new ApplicationException(Lang::get('backend::lang.model.not_found', [
-                        'class' => get_class($config->model),
-                        'id' => $this->manageId,
+                        'class' => get_class($config->model), 'id' => $this->manageId
                     ]));
                 }
             }
@@ -952,12 +957,10 @@ class RelationController extends ControllerBehavior
         if ($this->manageId) {
             $hydratedModel = $this->relationObject->where($foreignKeyName, $this->manageId)->first();
 
-            if ($hydratedModel) {
-                $config->model = $hydratedModel;
-            } else {
+            $config->model = $hydratedModel;
+            if (!$config->model) {
                 throw new ApplicationException(Lang::get('backend::lang.model.not_found', [
-                    'class' => get_class($config->model),
-                    'id' => $this->manageId,
+                    'class' => get_class($config->model), 'id' => $this->manageId
                 ]));
             }
         }

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -326,17 +326,16 @@ class RelationController extends ControllerBehavior
         }
 
         if (!$this->model) {
-            throw new ApplicationException(Lang::get(
-                'backend::lang.relation.missing_model',
-                ['class'=>get_class($this->controller)]
-            ));
+            throw new ApplicationException(Lang::get('backend::lang.relation.missing_model', [
+                'class' => get_class($this->controller),
+            ]));
         }
 
         if (!$this->model instanceof Model) {
-            throw new ApplicationException(Lang::get(
-                'backend::lang.model.invalid_class',
-                ['model'=>get_class($this->model), 'class'=>get_class($this->controller)]
-            ));
+            throw new ApplicationException(Lang::get('backend::lang.model.invalid_class', [
+                'model' => get_class($this->model),
+                'class' => get_class($this->controller),
+            ]));
         }
 
         if (!$this->getConfig($field)) {
@@ -894,35 +893,32 @@ class RelationController extends ControllerBehavior
          * Form
          */
         elseif ($this->manageMode == 'form') {
-
             if (!$config = $this->makeConfigForMode('manage', 'form', false)) {
                 return null;
             }
-
             $config->model = $this->relationModel;
             $config->arrayName = class_basename($this->relationModel);
             $config->context = $this->evalFormContext('manage', !!$this->manageId);
             $config->alias = $this->alias . 'ManageForm';
-
             /*
              * Existing record
              */
             if ($this->manageId) {
-                $config->model = $config->model->find($this->manageId);
-                if (!$config->model) {
+                $model = $config->model->find($this->manageId);
+                if ($model) {
+                    $config->model = $model;
+                } else {
                     throw new ApplicationException(Lang::get('backend::lang.model.not_found', [
-                        'class' => get_class($config->model), 'id' => $this->manageId
+                        'class' => get_class($config->model),
+                        'id' => $this->manageId,
                     ]));
                 }
             }
-
             $widget = $this->makeWidget('Backend\Widgets\Form', $config);
         }
-
         if (!$widget) {
             return null;
         }
-
         /*
          * Exclude existing relationships
          */
@@ -937,10 +933,8 @@ class RelationController extends ControllerBehavior
                 }
             });
         }
-
         return $widget;
     }
-
     protected function makePivotWidget()
     {
         $config = $this->makeConfigForMode('pivot', 'form');
@@ -948,19 +942,18 @@ class RelationController extends ControllerBehavior
         $config->arrayName = class_basename($this->relationModel);
         $config->context = $this->evalFormContext('pivot', !!$this->manageId);
         $config->alias = $this->alias . 'ManagePivotForm';
-
         $foreignKeyName = $this->relationModel->getQualifiedKeyName();
-
         /*
          * Existing record
          */
         if ($this->manageId) {
             $hydratedModel = $this->relationObject->where($foreignKeyName, $this->manageId)->first();
-
-            $config->model = $hydratedModel;
-            if (!$config->model) {
+            if ($hydratedModel) {
+                $config->model = $hydratedModel;
+            } else {
                 throw new ApplicationException(Lang::get('backend::lang.model.not_found', [
-                    'class' => get_class($config->model), 'id' => $this->manageId
+                    'class' => get_class($config->model),
+                    'id' => $this->manageId,
                 ]));
             }
         }
@@ -972,35 +965,27 @@ class RelationController extends ControllerBehavior
                 $foreignModel = $this->relationModel
                     ->whereIn($foreignKeyName, (array) $this->foreignId)
                     ->first();
-
                 if ($foreignModel) {
                     $foreignModel->exists = false;
                     $config->model = $foreignModel;
                 }
             }
-
             $pivotModel = $this->relationObject->newPivot();
             $config->model->setRelation('pivot', $pivotModel);
         }
-
         return $this->makeWidget('Backend\Widgets\Form', $config);
     }
-
     //
     // AJAX (Buttons)
     //
-
     public function onRelationButtonAdd()
     {
         $this->eventTarget = 'button-add';
-
         return $this->onRelationManageForm();
     }
-
     public function onRelationButtonCreate()
     {
         $this->eventTarget = 'button-create';
-
         return $this->onRelationManageForm();
     }
 

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1476,7 +1476,7 @@ class RelationController extends ControllerBehavior
                 return null;
             } elseif (is_string($buttons)) {
                 $buttons = array_map('trim', explode('|', $buttons));
-            } elseif ($this->manageMode == 'pivot') {
+            } elseif ($this->manageMode === 'pivot') {
                 $buttons = ['add', 'remove'];
             } else {
                 switch ($this->relationType) {

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1471,7 +1471,7 @@ class RelationController extends ControllerBehavior
     {
         $buttons = $this->getConfig('view[toolbarButtons]');
 
-        if (! is_array($buttons)) {
+        if (!is_array($buttons)) {
             if ($buttons === false) {
                 return null;
             }

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1476,8 +1476,6 @@ class RelationController extends ControllerBehavior
                 return null;
             } elseif (is_string($buttons)) {
                 $buttons = array_map('trim', explode('|', $buttons));
-            } elseif (is_array($buttons)) {
-                $buttons = $buttons;
             } elseif ($this->manageMode == 'pivot') {
                 $buttons = ['add', 'remove'];
             } else {

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -893,13 +893,16 @@ class RelationController extends ControllerBehavior
          * Form
          */
         elseif ($this->manageMode == 'form') {
+            
             if (!$config = $this->makeConfigForMode('manage', 'form', false)) {
                 return null;
             }
+            
             $config->model = $this->relationModel;
             $config->arrayName = class_basename($this->relationModel);
             $config->context = $this->evalFormContext('manage', !!$this->manageId);
             $config->alias = $this->alias . 'ManageForm';
+            
             /*
              * Existing record
              */
@@ -914,11 +917,14 @@ class RelationController extends ControllerBehavior
                     ]));
                 }
             }
+            
             $widget = $this->makeWidget('Backend\Widgets\Form', $config);
         }
+        
         if (!$widget) {
             return null;
         }
+        
         /*
          * Exclude existing relationships
          */
@@ -942,6 +948,7 @@ class RelationController extends ControllerBehavior
         $config->arrayName = class_basename($this->relationModel);
         $config->context = $this->evalFormContext('pivot', !!$this->manageId);
         $config->alias = $this->alias . 'ManagePivotForm';
+        
         $foreignKeyName = $this->relationModel->getQualifiedKeyName();
         /*
          * Existing record
@@ -965,27 +972,34 @@ class RelationController extends ControllerBehavior
                 $foreignModel = $this->relationModel
                     ->whereIn($foreignKeyName, (array) $this->foreignId)
                     ->first();
+                
                 if ($foreignModel) {
                     $foreignModel->exists = false;
                     $config->model = $foreignModel;
                 }
             }
+            
             $pivotModel = $this->relationObject->newPivot();
             $config->model->setRelation('pivot', $pivotModel);
         }
+        
         return $this->makeWidget('Backend\Widgets\Form', $config);
     }
+    
     //
     // AJAX (Buttons)
     //
     public function onRelationButtonAdd()
     {
         $this->eventTarget = 'button-add';
+        
         return $this->onRelationManageForm();
     }
+    
     public function onRelationButtonCreate()
     {
         $this->eventTarget = 'button-create';
+        
         return $this->onRelationManageForm();
     }
 
@@ -1193,7 +1207,6 @@ class RelationController extends ControllerBehavior
          * Add
          */
         if ($this->viewMode == 'multi') {
-
             $checkedIds = $recordId ? [$recordId] : post('checked');
 
             if (is_array($checkedIds)) {
@@ -1209,14 +1222,12 @@ class RelationController extends ControllerBehavior
                     $this->relationObject->add($model, $sessionKey);
                 }
             }
-
         }
         /*
          * Link
          */
         elseif ($this->viewMode == 'single') {
             if ($recordId && ($model = $this->relationModel->find($recordId))) {
-
                 $this->relationObject->add($model, $sessionKey);
                 $this->viewWidget->setFormValues($model->attributes);
 
@@ -1230,7 +1241,6 @@ class RelationController extends ControllerBehavior
                         $parentModel->save();
                     }
                 }
-
             }
         }
 
@@ -1252,7 +1262,6 @@ class RelationController extends ControllerBehavior
          * Remove
          */
         if ($this->viewMode == 'multi') {
-
             $checkedIds = $recordId ? [$recordId] : post('checked');
 
             if (is_array($checkedIds)) {
@@ -1695,7 +1704,8 @@ class RelationController extends ControllerBehavior
      *
      * @return \Backend\Classes\WidgetBase
      */
-    public function relationGetManageWidget() {
+    public function relationGetManageWidget()
+    {
         return $this->manageWidget;
     }
 
@@ -1704,7 +1714,8 @@ class RelationController extends ControllerBehavior
      *
      * @return \Backend\Classes\WidgetBase
      */
-    public function relationGetViewWidget() {
+    public function relationGetViewWidget()
+    {
         return $this->viewWidget;
     }
 }

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1591,7 +1591,7 @@ class RelationController extends ControllerBehavior
             case 'list':
                 if (array_key_exists('list', $customTitles)) {
                     return $customTitles['list'];
-                } elseif ($this->eventTarget == 'button-link') {
+                } elseif ($this->eventTarget === 'button-link') {
                     return 'backend::lang.relation.link_a_new';
                 }
 

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -939,8 +939,10 @@ class RelationController extends ControllerBehavior
                 }
             });
         }
+        
         return $widget;
     }
+    
     protected function makePivotWidget()
     {
         $config = $this->makeConfigForMode('pivot', 'form');
@@ -950,11 +952,13 @@ class RelationController extends ControllerBehavior
         $config->alias = $this->alias . 'ManagePivotForm';
         
         $foreignKeyName = $this->relationModel->getQualifiedKeyName();
+        
         /*
          * Existing record
          */
         if ($this->manageId) {
             $hydratedModel = $this->relationObject->where($foreignKeyName, $this->manageId)->first();
+            
             if ($hydratedModel) {
                 $config->model = $hydratedModel;
             } else {
@@ -989,6 +993,7 @@ class RelationController extends ControllerBehavior
     //
     // AJAX (Buttons)
     //
+    
     public function onRelationButtonAdd()
     {
         $this->eventTarget = 'button-add';

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1585,8 +1585,7 @@ class RelationController extends ControllerBehavior
             case 'pivot':
                 if (array_key_exists('pivot', $customTitles)) {
                     return $customTitles['pivot'];
-                }
-                elseif ($this->eventTarget == 'button-link') {
+                } elseif ($this->eventTarget == 'button-link') {
                     return 'backend::lang.relation.link_a_new';
                 }
 
@@ -1594,8 +1593,7 @@ class RelationController extends ControllerBehavior
             case 'list':
                 if (array_key_exists('list', $customTitles)) {
                     return $customTitles['list'];
-                }
-                elseif ($this->eventTarget == 'button-link') {
+                } elseif ($this->eventTarget == 'button-link') {
                     return 'backend::lang.relation.link_a_new';
                 }
 
@@ -1603,11 +1601,9 @@ class RelationController extends ControllerBehavior
             case 'form':
                 if (array_key_exists('form', $customTitles)) {
                     return $customTitles['form'];
-                }
-                elseif ($this->readOnly) {
+                } elseif ($this->readOnly) {
                     return 'backend::lang.relation.preview_name';
-                }
-                elseif ($this->manageId) {
+                } elseif ($this->manageId) {
                     return 'backend::lang.relation.update_name';
                 }
                 

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -893,7 +893,6 @@ class RelationController extends ControllerBehavior
          * Form
          */
         elseif ($this->manageMode == 'form') {
-            
             if (!$config = $this->makeConfigForMode('manage', 'form', false)) {
                 return null;
             }

--- a/modules/backend/behaviors/relationcontroller/partials/_button_add.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_add.htm
@@ -4,5 +4,5 @@
     data-handler="onRelationButtonAdd"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-plus">
-    <?= e(trans($relationToolbarButtonText && array_key_exists('add', $relationToolbarButtonText) ? $relationToolbarButtonText['add'] : 'backend::lang.relation.add_name', ['name' => trans($relationLabel)])) ?>
+    <?= e(trans($text, ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_add.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_add.htm
@@ -4,5 +4,5 @@
     data-handler="onRelationButtonAdd"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-plus">
-    <?= e(trans('backend::lang.relation.add_name', ['name'=>trans($relationLabel)])) ?>
+    <?= e(trans($relationToolbarButtonText && array_key_exists('add', $relationToolbarButtonText) ? $relationToolbarButtonText['add'] : 'backend::lang.relation.add_name', ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_create.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_create.htm
@@ -4,5 +4,5 @@
     data-handler="onRelationButtonCreate"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-file">
-    <?= e(trans('backend::lang.relation.create_name', ['name'=>trans($relationLabel)])) ?>
+    <?= e(trans($relationToolbarButtonText && array_key_exists('create', $relationToolbarButtonText) ? $relationToolbarButtonText['create'] : 'backend::lang.relation.create_name', ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_create.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_create.htm
@@ -4,5 +4,5 @@
     data-handler="onRelationButtonCreate"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-file">
-    <?= e(trans($relationToolbarButtonText && array_key_exists('create', $relationToolbarButtonText) ? $relationToolbarButtonText['create'] : 'backend::lang.relation.create_name', ['name' => trans($relationLabel)])) ?>
+    <?= e(trans($text, ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_delete.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_delete.htm
@@ -5,7 +5,7 @@
         data-request-confirm="<?= e(trans('backend::lang.relation.delete_confirm')) ?>"
         data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'deleted')"
         data-stripe-load-indicator>
-        <?= e(trans('backend::lang.relation.delete')) ?>
+        <?= e(trans($relationToolbarButtonText && array_key_exists('delete', $relationToolbarButtonText) ? $relationToolbarButtonText['delete'] : 'backend::lang.relation.delete')) ?>
     </button>
 <?php else: ?>
     <button
@@ -21,6 +21,6 @@
         data-trigger="#<?= $this->relationGetId('view') ?> .control-list input[type=checkbox]"
         data-trigger-condition="checked"
         data-stripe-load-indicator>
-        <?= e(trans('backend::lang.relation.delete')) ?>
+        <?= e(trans($relationToolbarButtonText && array_key_exists('delete', $relationToolbarButtonText) ? $relationToolbarButtonText['delete'] : 'backend::lang.relation.delete')) ?>
     </button>
 <?php endif ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_delete.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_delete.htm
@@ -5,7 +5,7 @@
         data-request-confirm="<?= e(trans('backend::lang.relation.delete_confirm')) ?>"
         data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'deleted')"
         data-stripe-load-indicator>
-        <?= e(trans($relationToolbarButtonText && array_key_exists('delete', $relationToolbarButtonText) ? $relationToolbarButtonText['delete'] : 'backend::lang.relation.delete')) ?>
+        <?= e(trans($text)) ?>
     </button>
 <?php else: ?>
     <button
@@ -21,6 +21,6 @@
         data-trigger="#<?= $this->relationGetId('view') ?> .control-list input[type=checkbox]"
         data-trigger-condition="checked"
         data-stripe-load-indicator>
-        <?= e(trans($relationToolbarButtonText && array_key_exists('delete', $relationToolbarButtonText) ? $relationToolbarButtonText['delete'] : 'backend::lang.relation.delete')) ?>
+        <?= e(trans($text)) ?>
     </button>
 <?php endif ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_link.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_link.htm
@@ -4,5 +4,5 @@
     data-handler="onRelationButtonLink"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-link">
-    <?= e(trans($relationToolbarButtonText && array_key_exists('link', $relationToolbarButtonText) ? $relationToolbarButtonText['link'] : 'backend::lang.relation.link_name', ['name' => trans($relationLabel)])) ?>
+    <?= e(trans($text, ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_link.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_link.htm
@@ -4,5 +4,5 @@
     data-handler="onRelationButtonLink"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-link">
-    <?= e(trans('backend::lang.relation.link_name', ['name'=>trans($relationLabel)])) ?>
+    <?= e(trans($relationToolbarButtonText && array_key_exists('link', $relationToolbarButtonText) ? $relationToolbarButtonText['link'] : 'backend::lang.relation.link_name', ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_remove.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_remove.htm
@@ -4,7 +4,7 @@
         data-request="onRelationButtonRemove"
         data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'removed')"
         data-stripe-load-indicator>
-        <?= e(trans('backend::lang.relation.remove')) ?>
+        <?= e(trans($relationToolbarButtonText && array_key_exists('remove', $relationToolbarButtonText) ? $relationToolbarButtonText['remove'] : 'backend::lang.relation.remove')) ?>
     </button>
 <?php else: ?>
     <button
@@ -19,6 +19,6 @@
         data-trigger="#<?= $this->relationGetId('view') ?> .control-list input[type=checkbox]"
         data-trigger-condition="checked"
         data-stripe-load-indicator>
-        <?= e(trans('backend::lang.relation.remove')) ?>
+        <?= e(trans($relationToolbarButtonText && array_key_exists('remove', $relationToolbarButtonText) ? $relationToolbarButtonText['remove'] : 'backend::lang.relation.remove')) ?>
     </button>
 <?php endif ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_remove.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_remove.htm
@@ -4,7 +4,7 @@
         data-request="onRelationButtonRemove"
         data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'removed')"
         data-stripe-load-indicator>
-        <?= e(trans($relationToolbarButtonText && array_key_exists('remove', $relationToolbarButtonText) ? $relationToolbarButtonText['remove'] : 'backend::lang.relation.remove')) ?>
+        <?= e(trans($text)) ?>
     </button>
 <?php else: ?>
     <button
@@ -19,6 +19,6 @@
         data-trigger="#<?= $this->relationGetId('view') ?> .control-list input[type=checkbox]"
         data-trigger-condition="checked"
         data-stripe-load-indicator>
-        <?= e(trans($relationToolbarButtonText && array_key_exists('remove', $relationToolbarButtonText) ? $relationToolbarButtonText['remove'] : 'backend::lang.relation.remove')) ?>
+        <?= e(trans($text)) ?>
     </button>
 <?php endif ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_unlink.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_unlink.htm
@@ -5,5 +5,5 @@
     data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'removed')"
     data-request-confirm="<?= e(trans('backend::lang.relation.unlink_confirm')) ?>"
     data-stripe-load-indicator>
-    <?= e(trans('backend::lang.relation.unlink')) ?>
+    <?= e(trans($relationToolbarButtonText && array_key_exists('unlink', $relationToolbarButtonText) ? $relationToolbarButtonText['unlink'] : 'backend::lang.relation.unlink')) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_unlink.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_unlink.htm
@@ -5,5 +5,5 @@
     data-request-success="$.oc.relationBehavior.changed('<?= e($this->vars['relationField']) ?>', 'removed')"
     data-request-confirm="<?= e(trans('backend::lang.relation.unlink_confirm')) ?>"
     data-stripe-load-indicator>
-    <?= e(trans($relationToolbarButtonText && array_key_exists('unlink', $relationToolbarButtonText) ? $relationToolbarButtonText['unlink'] : 'backend::lang.relation.unlink')) ?>
+    <?= e(trans($text)) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_update.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_update.htm
@@ -5,5 +5,5 @@
     data-request-data="manage_id: '<?= $relationManageId ?>'"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-pencil">
-    <?= e(trans('backend::lang.relation.update_name', ['name'=>trans($relationLabel)])) ?>
+    <?= e(trans($relationToolbarButtonText && array_key_exists('update', $relationToolbarButtonText) ? $relationToolbarButtonText['update'] : 'backend::lang.relation.update_name', ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_button_update.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_update.htm
@@ -5,5 +5,5 @@
     data-request-data="manage_id: '<?= $relationManageId ?>'"
     href="javascript:;"
     class="btn btn-sm btn-secondary oc-icon-pencil">
-    <?= e(trans($relationToolbarButtonText && array_key_exists('update', $relationToolbarButtonText) ? $relationToolbarButtonText['update'] : 'backend::lang.relation.update_name', ['name' => trans($relationLabel)])) ?>
+    <?= e(trans($text, ['name' => trans($relationLabel)])) ?>
 </a>

--- a/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
@@ -2,7 +2,7 @@
 
     <?php foreach ($relationToolbarButtons as $type => $text): ?>
 
-        <?php if ($type == 'update'): ?>
+        <?php if ($type === 'update'): ?>
             <?= $this->relationMakePartial('button_update', [
                 'relationManageId' => $relationViewModel->getKey(),
                 'text' => $text

--- a/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
@@ -8,7 +8,7 @@
                 'text' => $text
             ]) ?>
         <?php else: ?>
-            <?= $this->relationMakePartial('button_'.$type, [
+            <?= $this->relationMakePartial('button_' . $type, [
                 'text' => $text
             ]) ?>
         <?php endif ?>

--- a/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
@@ -1,13 +1,16 @@
 <div data-control="toolbar">
 
-    <?php foreach ($relationToolbarButtons as $button): ?>
+    <?php foreach ($relationToolbarButtons as $type => $text): ?>
 
-        <?php if ($button == 'update'): ?>
+        <?php if ($type == 'update'): ?>
             <?= $this->relationMakePartial('button_update', [
-                'relationManageId' => $relationViewModel->getKey()
+                'relationManageId' => $relationViewModel->getKey(),
+                'text' => $text
             ]) ?>
         <?php else: ?>
-            <?= $this->relationMakePartial('button_'.$button) ?>
+            <?= $this->relationMakePartial('button_'.$type, [
+                'text' => $text
+            ]) ?>
         <?php endif ?>
 
     <?php endforeach ?>


### PR DESCRIPTION
This change allows for easy customisation of the relation manager titles and toolbar buttons.

For buttons - define your custom strings directly in the standard `toolbarButtons` syntax...

```
toolbarButtons:
    create: acme.blog::lang.subcategory.CreateButtonText
    delete: # omit the string to fall back to the default button text
```

...and the old syntax still works...

```
toolbarButtons: create|delete
```

For titles - define different strings for each mode (form, list or pivot)...

```
title:
    form: acme.blog::lang.subcategory.FormTitle
    list: acme.blog::lang.subcategory.ListTitle
```

This feature provides developer convenience, for example in this situation where I have a relation manager that is used to assign user permissions to a project:
Before
![Screenshot 2019-07-10 at 09 28 22](https://user-images.githubusercontent.com/41773797/60953626-6bc0de80-a2f5-11e9-8001-04e816ad6967.png)
After
![Screenshot 2019-07-10 at 09 32 51](https://user-images.githubusercontent.com/41773797/60953773-b9d5e200-a2f5-11e9-93a9-69238ea696aa.png)

This PR contains no breaking changes.