### PR TITLE
Fix text filter scope

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -261,15 +261,7 @@ class Filter extends WidgetBase
                 break;
 
             case 'text':
-                $values = post('options.value');
-
-                if ($values !== null && $values !== '') {
-                    list($value) = $values;
-                }
-                else {
-                    $value = null;
-                }
-
+                $value = post('options.value.' . $scope->scopeName) ?: null;
                 $this->setScopeValue($scope, $value);
                 break;
         }

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -116,7 +116,7 @@ class Filter extends WidgetBase
                     $after = $scope->value[0]->format('Y-m-d H:i:s');
                     $before = $scope->value[1]->format('Y-m-d H:i:s');
 
-                    if(strcasecmp($after, '0000-00-00 00:00:00') > 0) {
+                    if (strcasecmp($after, '0000-00-00 00:00:00') > 0) {
                         $params['afterStr'] = Backend::dateTime($scope->value[0], ['formatAlias' => 'dateMin']);
                         $params['after']    = $after;
                     }
@@ -125,7 +125,7 @@ class Filter extends WidgetBase
                         $params['after']    = null;
                     }
 
-                    if(strcasecmp($before, '2999-12-31 23:59:59') < 0) {
+                    if (strcasecmp($before, '2999-12-31 23:59:59') < 0) {
                         $params['beforeStr'] = Backend::dateTime($scope->value[1], ['formatAlias' => 'dateMin']);
                         $params['before']    = $before;
                     }
@@ -559,7 +559,6 @@ class Filter extends WidgetBase
     public function addScopes(array $scopes)
     {
         foreach ($scopes as $name => $config) {
-
             $scopeObj = $this->makeFilterScope($name, $config);
 
             /*
@@ -707,7 +706,6 @@ class Filter extends WidgetBase
                     list($after, $before) = array_values($scope->value);
 
                     if ($after && $after instanceof Carbon && $before && $before instanceof Carbon) {
-
                         /*
                          * Condition
                          */
@@ -755,7 +753,6 @@ class Filter extends WidgetBase
                     list($min, $max) = array_values($scope->value);
 
                     if ($min && $max) {
-
                         /*
                          * Condition
                          *
@@ -803,7 +800,6 @@ class Filter extends WidgetBase
                  * Condition
                  */
                 if ($scopeConditions = $scope->conditions) {
-
                     /*
                      * Switch scope: multiple conditions, value either 1 or 2
                      */
@@ -968,7 +964,7 @@ class Filter extends WidgetBase
 
         if (null !== $ajaxDates) {
             if (!is_array($ajaxDates)) {
-                if(preg_match($dateRegex, $ajaxDates)) {
+                if (preg_match($dateRegex, $ajaxDates)) {
                     $dates = [$ajaxDates];
                 }
             } else {
@@ -976,7 +972,7 @@ class Filter extends WidgetBase
                     if (preg_match($dateRegex, $date)) {
                         $dates[] = Carbon::createFromFormat('Y-m-d H:i:s', $date);
                     } elseif (empty($date)) {
-                        if($i == 0) {
+                        if ($i == 0) {
                             $dates[] = Carbon::createFromFormat('Y-m-d H:i:s', '0000-00-00 00:00:00');
                         } else {
                             $dates[] = Carbon::createFromFormat('Y-m-d H:i:s', '2999-12-31 23:59:59');

--- a/modules/backend/widgets/filter/partials/_scope_text.htm
+++ b/modules/backend/widgets/filter/partials/_scope_text.htm
@@ -2,7 +2,7 @@
     <label class="filter-label">
         <?= e(trans($scope->label)) ?>:
         <input type="text"
-               name="options[value][]"
+               name="options[value][<?= $scope->scopeName ?>]"
                data-request="<?= $this->getEventHandler('onFilterUpdate') ?>"
                data-request-data="'scopeName':'<?= $scope->scopeName ?>'"
                data-track-input


### PR DESCRIPTION
This tries to fix the behavior described here, which happens when more than one text filter scope is present: https://github.com/octobercms/october/pull/4241#issuecomment-510140574

The problem is that once the filter executes (i.e. new data is entered into the text input), it adds data to the `options.value` POST array. On regular lists, this array only contains the value of the field beeing edited/the filter beeing used. However, in the relation controller the POST data looks like this:
```
options[value][]: asd
options[value][]: have
```
The system will thus always use the first value in that array for each of the following text filters, meaning all fields will be filtered by the value of the first scope.

This PR adds the scope name to the POST data to make things expicit. I am, however, a bit concerned about side effects, as I do not understand why this comply array setup for the POST data is used in the first place.