### PR TITLE
Add validator for navigation in backend

### DIFF
--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -5,6 +5,8 @@ use BackendAuth;
 use System\Classes\PluginManager;
 use Validator;
 use SystemException;
+use Log;
+use Config;
 
 /**
  * Manages the backend navigation.
@@ -207,7 +209,12 @@ class NavigationManager
         ]);
 
         if ($validator->fails()) {
-            throw new SystemException('Invalid menu item detected in ' . $owner . '. Contact the plugin author to fix (' . $validator->errors()->first() . ')');
+            $errorMessage = 'Invalid menu item detected in ' . $owner . '. Contact the plugin author to fix (' . $validator->errors()->first() . ')';
+            if (Config::get('app.debug', false)) {
+                throw new SystemException($errorMessage);
+            } else {
+                Log::error($errorMessage);
+            }
         }
 
         $this->addMainMenuItems($owner, $definitions);

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -3,6 +3,8 @@
 use Event;
 use BackendAuth;
 use System\Classes\PluginManager;
+use Validator;
+use SystemException;
 
 /**
  * Manages the backend navigation.
@@ -193,6 +195,19 @@ class NavigationManager
     {
         if (!$this->items) {
             $this->items = [];
+        }
+
+        $validator = Validator::make($definitions, [
+            '*.label' => 'required',
+            '*.icon' => 'required',
+            '*.url' => 'required',
+            '*.sideMenu.*.label' => 'nullable|required',
+            '*.sideMenu.*.icon' => 'nullable|required',
+            '*.sideMenu.*.url' => 'nullable|required',
+        ]);
+
+        if ($validator->fails()) {
+            throw new SystemException('Error parsing navigation menu in plugin ' . $owner . ' (' . $validator->errors()->first() . ')');
         }
 
         $this->addMainMenuItems($owner, $definitions);

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -201,10 +201,12 @@ class NavigationManager
 
         $validator = Validator::make($definitions, [
             '*.label' => 'required',
-            '*.icon' => 'required',
+            '*.icon' => 'required_without:*.iconSvg',
+            '*.iconSvg' => 'required_without:*.icon',
             '*.url' => 'required',
             '*.sideMenu.*.label' => 'nullable|required',
-            '*.sideMenu.*.icon' => 'nullable|required',
+            '*.sideMenu.*.icon' => 'nullable|required_without:*.sideMenu.*.iconSvg',
+            '*.sideMenu.*.iconSvg' => 'nullable|required_without:*.sideMenu.*.icon',
             '*.sideMenu.*.url' => 'nullable|required',
         ]);
 

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -207,7 +207,7 @@ class NavigationManager
         ]);
 
         if ($validator->fails()) {
-            throw new SystemException('Error parsing navigation menu in plugin ' . $owner . ' (' . $validator->errors()->first() . ')');
+            throw new SystemException('Invalid menu item detected in ' . $owner . '. Contact the plugin author to fix (' . $validator->errors()->first() . ')');
         }
 
         $this->addMainMenuItems($owner, $definitions);

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -202,11 +202,9 @@ class NavigationManager
         $validator = Validator::make($definitions, [
             '*.label' => 'required',
             '*.icon' => 'required_without:*.iconSvg',
-            '*.iconSvg' => 'required_without:*.icon',
             '*.url' => 'required',
             '*.sideMenu.*.label' => 'nullable|required',
             '*.sideMenu.*.icon' => 'nullable|required_without:*.sideMenu.*.iconSvg',
-            '*.sideMenu.*.iconSvg' => 'nullable|required_without:*.sideMenu.*.icon',
             '*.sideMenu.*.url' => 'nullable|required',
         ]);
 


### PR DESCRIPTION
Resolves #4491

Tested with RainLab.Blog plugin

Main navigation:
![obrázok](https://user-images.githubusercontent.com/3110002/62077338-28012b00-b24a-11e9-9518-416bb5ad9b3a.png)

Nested sideMenu:
![obrázok](https://user-images.githubusercontent.com/3110002/62077360-32bbc000-b24a-11e9-85ee-6a80c563793b.png)
