### PR TITLE
Filterfields is now called before save and update of forms

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -247,6 +247,10 @@ class FormController extends ControllerBehavior
         $this->controller->formBeforeSave($model);
         $this->controller->formBeforeCreate($model);
 
+        if (method_exists($model, 'filterFields')) {
+            $model->filterFields((object) $this->formWidget->getFields(), $this->context);
+        }
+
         $modelsToSave = $this->prepareModelsToSave($model, $this->formWidget->getSaveData());
         Db::transaction(function () use ($modelsToSave) {
             foreach ($modelsToSave as $modelToSave) {
@@ -313,6 +317,10 @@ class FormController extends ControllerBehavior
 
         $this->controller->formBeforeSave($model);
         $this->controller->formBeforeUpdate($model);
+
+        if (method_exists($model, 'filterFields')) {
+            $model->filterFields((object) $this->formWidget->getFields(), $this->context);
+        }
 
         $modelsToSave = $this->prepareModelsToSave($model, $this->formWidget->getSaveData());
         Db::transaction(function () use ($modelsToSave) {


### PR DESCRIPTION
The filterfields method is called before the save or update of the form field's model is made so that any changes made by the user to the field using filterFields method is also reflected in the saved model data. This PR closes octobercms/october#4144.