### PR TITLE
Update __isset function to comply with the same checks as __get 

### DIFF
--- a/modules/cms/classes/CodeBase.php
+++ b/modules/cms/classes/CodeBase.php
@@ -155,6 +155,14 @@ class CodeBase extends Extendable implements ArrayAccess
      */
     public function __isset($name)
     {
-        return isset($this->page->{$name});
+        if (isset($this->page->components[$name]) || isset($this->layout->components[$name])) {
+            return true;
+        }
+
+        if (isset($this->page->{$name})) {
+            return $value;
+        }
+
+        return array_key_exists($name, $this->controller->vars);
     }
 }

--- a/modules/cms/classes/CodeBase.php
+++ b/modules/cms/classes/CodeBase.php
@@ -160,7 +160,7 @@ class CodeBase extends Extendable implements ArrayAccess
         }
 
         if (isset($this->page->{$name})) {
-            return $value;
+            return true;
         }
 
         return array_key_exists($name, $this->controller->vars);

--- a/modules/cms/classes/CodeBase.php
+++ b/modules/cms/classes/CodeBase.php
@@ -149,9 +149,9 @@ class CodeBase extends Extendable implements ArrayAccess
     }
 
     /**
-     * This will check if a property isset on the CMS Page object.
-     * @param  string  $name
-     * @return void
+     * This will check if a property is set on the CMS Page object.
+     * @param string $name
+     * @return bool
      */
     public function __isset($name)
     {


### PR DESCRIPTION
The __isset function doesn't gives back the excepted result because the the __get function has different checks.

If you currently have a component that sets the variable you will be able to get this in the onEnd() function in the layout file. If you try to do isset upon the variable when calling it with the object operator it will return false.

Compoment:
```php
public function onRun()
{
    $this->page['var'] = 'Hello World';
}
```

Layout code:
```php
function onEnd() {
    var_dump(isset($this->var)); // FALSE
    var_dump(isset($this['var'])); // TRUE
    var_dump($this->var); // Hello World
    var_dump($this['var']); // Hello World
}
```

After the changes both isset methods will return TRUE.