### PR TITLE
Use parseFile for caching and parsing

### DIFF
--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -50,7 +50,6 @@ class Theme
 
     const ACTIVE_KEY = 'cms::theme.active';
     const EDIT_KEY = 'cms::theme.edit';
-    const CONFIG_KEY = 'cms::theme.config';
 
     /**
      * Loads the theme.
@@ -339,21 +338,7 @@ class Theme
             return $this->configCache = [];
         }
 
-        try {
-            if (Config::get('app.debug', false)) {
-                $config = Yaml::parseFile($path);
-            } else {
-                $cacheKey = self::CONFIG_KEY.'::'.$this->getDirName();
-                $config = Cache::rememberForever($cacheKey, function () use ($path) {
-                    return Yaml::parseFile($path);
-                });
-            }
-        }
-        catch (Exception $ex) {
-            // Cache failed
-            $config = Yaml::parseFile($path);
-        }
-
+        $config = Yaml::parseFile($path);
 
         /**
          * @event cms.theme.extendConfig
@@ -503,7 +488,6 @@ class Theme
 
         Cache::forget(self::ACTIVE_KEY);
         Cache::forget(self::EDIT_KEY);
-        Cache::forget(self::CONFIG_KEY.'::'.(new self)->getDirName());
     }
 
     /**

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -7,6 +7,7 @@ use Event;
 use SystemException;
 use stdClass;
 use Config;
+use Cache;
 
 /**
  * Config Maker Trait
@@ -65,7 +66,14 @@ trait ConfigMaker
                 ));
             }
 
-            $config = Yaml::parse(File::get($configFile));
+            // Cache parsed yaml file if debug mode is disabled
+            if (!Config::get('app.debug', false)) {
+                $config = Cache::rememberForever('configmaker::' . $configFile, function () use ($configFile) {
+                    return Yaml::parse(File::get($configFile));
+                });
+            } else {
+                $config = Yaml::parse(File::get($configFile));
+            }
 
             /*
              * Extensibility

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -7,7 +7,6 @@ use Event;
 use SystemException;
 use stdClass;
 use Config;
-use Cache;
 
 /**
  * Config Maker Trait

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -66,14 +66,7 @@ trait ConfigMaker
                 ));
             }
 
-            // Cache parsed yaml file if debug mode is disabled
-            if (!Config::get('app.debug', false)) {
-                $config = Cache::rememberForever('configmaker::' . $configFile, function () use ($configFile) {
-                    return Yaml::parse(File::get($configFile));
-                });
-            } else {
-                $config = Yaml::parse(File::get($configFile));
-            }
+            $config = Yaml::parseFile($configFile);
 
             /*
              * Extensibility


### PR DESCRIPTION
This adds caching for backend parsing of configs when debug mode is disabled.

Tested with blog plugin on Post backend page:

**Before:**
![obrázok](https://user-images.githubusercontent.com/3110002/62520217-6770de00-b82d-11e9-89b0-55309b7f1119.png)

Green squares are yaml parsing calls
![obrázok](https://user-images.githubusercontent.com/3110002/62520450-e7974380-b82d-11e9-9062-ec376a4c42c5.png)


**After:** 0 yaml parsed files

![obrázok](https://user-images.githubusercontent.com/3110002/62520475-f5e55f80-b82d-11e9-889d-1005cb10f102.png)
