### PR TITLE
Hide Active Theme's Delete Button

### DIFF
--- a/modules/cms/controllers/themes/_theme_list_item.htm
+++ b/modules/cms/controllers/themes/_theme_list_item.htm
@@ -100,19 +100,21 @@
                         <?= e(trans('cms::lang.theme.export_button')) ?>
                     </a>
                 </li>
-                <li role="presentation" class="divider"></li>
-                <li role="presentation">
-                    <a
-                        role="menuitem"
-                        tabindex="-1"
-                        data-request="onDelete"
-                        data-request-confirm="<?= e(trans('cms::lang.theme.delete_confirm')) ?>"
-                        data-request-data="theme: '<?= e($theme->getDirName()) ?>'"
-                        href="javascript:;"
-                        class="oc-icon-trash">
-                        <?= e(trans('cms::lang.theme.delete_button')) ?>
-                    </a>
-                </li>
+                <?php if (! $theme->isActiveTheme()): ?>
+                    <li role="presentation" class="divider"></li>
+                    <li role="presentation">
+                        <a
+                            role="menuitem"
+                            tabindex="-1"
+                            data-request="onDelete"
+                            data-request-confirm="<?= e(trans('cms::lang.theme.delete_confirm')) ?>"
+                            data-request-data="theme: '<?= e($theme->getDirName()) ?>'"
+                            href="javascript:;"
+                            class="oc-icon-trash">
+                            <?= e(trans('cms::lang.theme.delete_button')) ?>
+                        </a>
+                    </li>
+                <?php endif ?>
             </ul>
         </div>
     </div>

--- a/modules/cms/controllers/themes/_theme_list_item.htm
+++ b/modules/cms/controllers/themes/_theme_list_item.htm
@@ -100,7 +100,7 @@
                         <?= e(trans('cms::lang.theme.export_button')) ?>
                     </a>
                 </li>
-                <?php if (! $theme->isActiveTheme()): ?>
+                <?php if (!$theme->isActiveTheme()): ?>
                     <li role="presentation" class="divider"></li>
                     <li role="presentation">
                         <a


### PR DESCRIPTION
This PR hides the active theme's delete button from its "Manage" dropdown menu.

At the moment, the button is still clickable and warns you that the action "can't be undone". When the user proceeds, it informs you that you can't delete an active theme! This is not very intuitive in my opinion.