### PR TITLE
Remove Theme Data on Theme Deletion

### DIFF
--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -525,6 +525,17 @@ class Theme
     }
 
     /**
+     * Remove data specific to this theme
+     * @return bool
+     */
+    public function removeCustomData()
+    {
+        if ($this->hasCustomData()) {
+            return $this->getCustomData()->delete();
+        }
+    }
+
+    /**
      * Checks to see if the database layer has been enabled
      *
      * @return boolean

--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -533,6 +533,8 @@ class Theme
         if ($this->hasCustomData()) {
             return $this->getCustomData()->delete();
         }
+
+        return true;
     }
 
     /**

--- a/modules/cms/classes/ThemeManager.php
+++ b/modules/cms/classes/ThemeManager.php
@@ -107,6 +107,8 @@ class ThemeManager
             throw new ApplicationException(trans('cms::lang.theme.delete_active_theme_failed'));
         }
 
+        $theme->removeCustomData();
+
         /*
          * Delete from file system
          */


### PR DESCRIPTION
Fixes #1292, the second oldest issue on this repo 😄

For reference, custom theme data that lives in `cms_theme_data` is deleted with the theme.