### PR TITLE
Remove Author Name from Backend URLs (where possible)

### DIFF
--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -207,18 +207,23 @@ class BackendController extends ControllerBase
          * Look for a Plugin controller
          */
         if (count($params) >= 1) {
-            $pluginVersions = PluginVersion::applyEnabled()
-                ->where('code', ucfirst($params[0]) . '.' . ucfirst($params[1]))
-                ->orWhere('code', 'like', '%' . ucfirst($params[0]))
-                ->get();
+            $plugins = array();
 
-            $pluginVersion = count($pluginVersions) === 1 ? $pluginVersions->first() : null;
+            foreach (PluginManager::instance()->getPlugins() as $pluginCode => $plugin) {
+                if ($pluginCode === ucfirst($params[0]) . '.' . ucfirst($params[1])) {
+                    $plugins[] = $pluginCode;
+                } elseif (substr($pluginCode, -strlen($params[0])) === ucfirst($params[0])) {
+                    $plugins[] = $pluginCode;
+                }
+            }
 
-            if ($pluginVersion) {
-                $pluginVersionCode = explode('.', $pluginVersion->code, 2);
+            $plugin = count($plugins) === 1 ? $plugins[0] : null;
 
-                $author = strtolower($pluginVersionCode[0]);
-                $plugin = strtolower($pluginVersionCode[1]);
+            if ($plugin) {
+                $pluginCode = explode('.', $plugin, 2);
+
+                $author = strtolower($pluginCode[0]);
+                $plugin = strtolower($pluginCode[1]);
 
                 if ($params[0] != $author) {
                     array_unshift($params, $author);

--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -207,7 +207,7 @@ class BackendController extends ControllerBase
          * Look for a Plugin controller
          */
         if (count($params) >= 1) {
-            $plugins = array();
+            $plugins = [];
 
             foreach (PluginManager::instance()->getPlugins() as $pluginCode => $plugin) {
                 if ($pluginCode === ucfirst($params[0]) . '.' . ucfirst($params[1])) {

--- a/modules/backend/helpers/Backend.php
+++ b/modules/backend/helpers/Backend.php
@@ -8,6 +8,7 @@ use Redirect;
 use October\Rain\Router\Helper as RouterHelper;
 use System\Helpers\DateTime as DateTimeHelper;
 use Backend\Classes\Skin;
+use System\Models\PluginVersion;
 
 /**
  * Backend Helper
@@ -31,6 +32,27 @@ class Backend
      */
     public function url($path = null, $parameters = [], $secure = null)
     {
+        $path = explode('/', $path);
+
+        if (count($path) >= 2) {
+            $pluginVersions = PluginVersion::applyEnabled()
+                ->where('code', ucfirst($path[0]) . '.' . ucfirst($path[1]))
+                ->orWhere('code', 'like', '%' . ucfirst($path[0]))
+                ->get();
+
+            $pluginVersion = count($pluginVersions) === 1 ? $pluginVersions->first() : null;
+
+            if ($pluginVersion) {
+                $author = strtolower(explode('.', $pluginVersion->code, 2)[0]);
+
+                if ($path[0] == $author) {
+                    array_shift($path);
+                }
+            }
+        }
+
+        $path = implode('/', $path);
+
         return Url::to($this->uri() . '/' . $path, $parameters, $secure);
     }
 

--- a/modules/backend/helpers/Backend.php
+++ b/modules/backend/helpers/Backend.php
@@ -8,7 +8,7 @@ use Redirect;
 use October\Rain\Router\Helper as RouterHelper;
 use System\Helpers\DateTime as DateTimeHelper;
 use Backend\Classes\Skin;
-use System\Models\PluginVersion;
+use System\Classes\PluginManager;
 
 /**
  * Backend Helper
@@ -35,15 +35,20 @@ class Backend
         $path = explode('/', $path);
 
         if (count($path) >= 2) {
-            $pluginVersions = PluginVersion::applyEnabled()
-                ->where('code', ucfirst($path[0]) . '.' . ucfirst($path[1]))
-                ->orWhere('code', 'like', '%' . ucfirst($path[0]))
-                ->get();
+            $plugins = array();
 
-            $pluginVersion = count($pluginVersions) === 1 ? $pluginVersions->first() : null;
+            foreach (PluginManager::instance()->getPlugins() as $pluginCode => $plugin) {
+                if ($pluginCode === ucfirst($path[0]) . '.' . ucfirst($path[1])) {
+                    $plugins[] = $pluginCode;
+                } elseif (substr($pluginCode, -strlen($path[0])) === ucfirst($path[0])) {
+                    $plugins[] = $pluginCode;
+                }
+            }
 
-            if ($pluginVersion) {
-                $author = strtolower(explode('.', $pluginVersion->code, 2)[0]);
+            $plugin = count($plugins) === 1 ? $plugins[0] : null;
+
+            if ($plugin) {
+                $author = strtolower(explode('.', $plugin, 2)[0]);
 
                 if ($path[0] == $author) {
                     array_shift($path);


### PR DESCRIPTION
This PR contains some changes I have made whilst starting work on a solution for #1956.

I used some of the information given by @LukeTowers [here](https://github.com/octobercms/october/issues/1956#issuecomment-356510337).

There are a number of issues that I'm a little stuck on, so if someone could give me a few pointers, that would be great. Currently, these changes...
- provide resolution for URLs that don't include the author's name.
- generate URLs without the author's name where possible (broken since 213e425).

Some issues with this PR include...
- AJAX requests made through backend controllers, like `onSave`, still redirect to the author's name URL version.
- DB requests are made to check if there are any other installed plugins with the same name. This is probably not the most optimised way of performing this check.

As I noted beforehand, these changes are in no way production-ready and **require heavy revision before they are production ready**.