### PR TITLE
Mention the lang dependency

### DIFF
--- a/modules/backend/assets/js/october.alert.js
+++ b/modules/backend/assets/js/october.alert.js
@@ -9,6 +9,7 @@
  *
  * Dependences:
  * - Sweet Alert
+ * - Translations (october.lang.js)
  */
 (function($){
 


### PR DESCRIPTION
Was re-using some of these classes on a non-OctoberCMS-based project and found that it was failing because it failed to copy this missing dependency. Best is to specify it.