### PR TITLE
Support additional file name and path characters in media manager

### DIFF
--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -486,6 +486,8 @@ class MediaLibrary
             preg_quote(']', '/'),
             preg_quote(',', '/'),
             preg_quote('=', '/'),
+            preg_quote("'", '/'),
+            preg_quote('&', '/'),
         ];
 
         if (!preg_match('/^[' . implode('', $regexWhitelist) . ']+$/iu', $path)) {

--- a/tests/unit/system/classes/MediaLibraryTest.php
+++ b/tests/unit/system/classes/MediaLibraryTest.php
@@ -37,6 +37,11 @@ class MediaLibraryTest extends TestCase // @codingStandardsIgnoreLine
             ['one(two)[].ext'],
             ['one=(two)[].ext'],
             ['one_(two)[].ext'],
+            /*
+            Example of a unicode-based filename with a single quote
+            @see: https://github.com/octobercms/october/pull/4564
+            */
+            ['BG中国通讯期刊(Blend\'r)创刊号.pdf'],
         ];
     }
 


### PR DESCRIPTION
When working with abstract file names that may contain additional characters, such as quotes or ampersands, the media manager would throw an error. This PR adds two additional characters to the character whitelist.

This will help support complex file names and paths, especially those that may contain international characters or file naming conventions.