### PR TITLE
Include file extension in combiner

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -400,7 +400,7 @@ class CombineAssets
             $this->putCache($cacheKey, $cacheInfo);
         }
 
-        return $this->getCombinedUrl($cacheInfo['version']);
+        return $this->getCombinedUrl($cacheInfo['version'] . '.' . $extension);
     }
 
     /**


### PR DESCRIPTION
This PR let's asset combiner to generate final URLs that includes file extension.

It will help services that depent on file extension (like CloudFlare) to recognize what kind of file it is.
It will also help CDNs to cache those files.

Looks like no docs needed be updated.  