### PR TITLE
Remove logging of ApplicationException

### DIFF
--- a/modules/system/classes/ErrorHandler.php
+++ b/modules/system/classes/ErrorHandler.php
@@ -35,18 +35,6 @@ class ErrorHandler extends ErrorHandlerBase
     // }
 
     /**
-     * We are about to display an error page to the user,
-     * if it is an ApplicationException, this event should be logged.
-     * @return void
-     */
-    public function beforeHandleError($exception)
-    {
-        if ($exception instanceof ApplicationException) {
-            Log::error($exception);
-        }
-    }
-
-    /**
      * Looks up an error page using the CMS route "/error". If the route does not
      * exist, this function will use the error view found in the Cms module.
      * @return mixed Error page contents.


### PR DESCRIPTION
This fix resolves #4568 .

Even though logging is suppressed by [this dontReport list](https://github.com/octobercms/library/blob/master/src/Foundation/Exception/Handler.php#L23), `ApplicationException` is logged by [ErrorHandler](https://github.com/octobercms/october/blob/master/modules/system/classes/ErrorHandler.php#L45).
`ErrorHandler::beforeHandleError` is the one that logging `ApplicationException`.
It is called by `ErrorHandler::handleException`, which is called in the listener of `exception.beforeRender` event registered by [ServiceProvider::registerErrorHandler](https://github.com/octobercms/october/blob/master/modules/system/ServiceProvider.php#L262)

