### PR TITLE
Fail CSRF token checks if the session expires.

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -786,7 +786,7 @@ class Controller extends ControllerBase
 
         $token = Request::input('_token') ?: Request::header('X-CSRF-TOKEN');
 
-        if (!strlen($token)) {
+        if (!strlen($token) || !strlen(Session::token())) {
             return false;
         }
 

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1596,7 +1596,7 @@ class Controller
 
         $token = Request::input('_token') ?: Request::header('X-CSRF-TOKEN');
 
-        if (!strlen($token)) {
+        if (!strlen($token) || !strlen(Session::token())) {
             return false;
         }
 


### PR DESCRIPTION
Fixes #4595.

If the session expires, we cannot do a valid CSRF token check, so this accounts for that possibility. I'm pretty certain this fix should work, but I've made it a PR in case there's some fringe case I'm not aware of.