### PR TITLE
Fix CloudFlare's Rocket Loader break the script loading

### DIFF
--- a/modules/backend/layouts/_head.htm
+++ b/modules/backend/layouts/_head.htm
@@ -30,7 +30,7 @@
 ?>
 
 <?php foreach ($styles as $style) : ?>
-    <link href="<?= $style . '?v=' . $coreBuild; ?>" rel="stylesheet" importance="high">
+    <link data-cfasync="false" href="<?= $style . '?v=' . $coreBuild; ?>" rel="stylesheet" importance="high">
     <link href="<?= $style . '?v=' . $coreBuild; ?>" rel="preload" as="style" importance="high">
 <?php endforeach; ?>
 
@@ -49,11 +49,11 @@
              // Unregister all service workers before signing in to prevent cache issues, see github issue: #3707
              navigator.serviceWorker.getRegistrations().then(
                  function(registrations) {
-                     for (let registration of registrations) {  
+                     for (let registration of registrations) {
                          registration.unregister();
                      }
                  });
-         }		
+         }
     </script>
 <?php endif; ?>
 


### PR DESCRIPTION
Cloudflare Rocket Loader break the script loading, so many plugins (as RTE, Media Manager) are nor working. **data-cfasync** option set **false** applied for backend plugins.

It also used on #4092 , #3841, and #3839

I have expanded it to other plugins.