### PR TITLE
Fix CMS scrollbar issue

### DIFF
--- a/modules/backend/assets/css/october.css
+++ b/modules/backend/assets/css/october.css
@@ -119,7 +119,7 @@
 .control-scrollbar >div {-webkit-transform:translateZ(0);-ms-transform:translateZ(0);transform:translateZ(0)}
 .control-scrollbar >.scrollbar-scrollbar {position:absolute;z-index:100}
 .control-scrollbar >.scrollbar-scrollbar .scrollbar-track {background-color:transparent;position:relative;-webkit-border-radius:5px;-moz-border-radius:5px;border-radius:5px}
-.control-scrollbar >.scrollbar-scrollbar .scrollbar-track .scrollbar-thumb {background-color:rgba(0,0,0,0.35);-webkit-border-radius:5px;-moz-border-radius:5px;border-radius:5px;cursor:pointer;overflow:hidden;position:absolute}
+.control-scrollbar >.scrollbar-scrollbar .scrollbar-track .scrollbar-thumb {background-color:rgba(0,0,0,0.35);-webkit-border-radius:5px;-moz-border-radius:5px;border-radius:5px;cursor:pointer;overflow:hidden;position:sticky}
 .control-scrollbar >.scrollbar-scrollbar.disabled {display:none !important}
 .control-scrollbar.vertical >.scrollbar-scrollbar {right:0;margin-right:5px;width:6px}
 .control-scrollbar.vertical >.scrollbar-scrollbar .scrollbar-track {height:100%;width:6px}

--- a/modules/backend/assets/less/controls/scrollbar.less
+++ b/modules/backend/assets/less/controls/scrollbar.less
@@ -31,7 +31,7 @@
                 .border-radius(5px);
                 cursor: pointer;
                 overflow: hidden;
-                position: absolute;
+                position: sticky;
             }
         }
 


### PR DESCRIPTION
## Tested on two locations

### CMS web page issue

1. This Pull request relates to github issue: https://github.com/octobercms/october/issues/4621

See results:

![1](https://user-images.githubusercontent.com/55155131/65392299-2a27c780-dd6b-11e9-87c1-e469c417d2a3.gif)

Notes: Seems fine and no more problems now.

### Media managert web page issue

2. Also tested this pull request with regards to github issue: https://github.com/octobercms/october/issues/4601

See results:

![2](https://user-images.githubusercontent.com/55155131/65392332-a02c2e80-dd6b-11e9-9e03-557adea97b42.gif)

Notes: Even though the issue is fixed with this pull request, the scrolling is not smooth there is some major JANK issues going on with the scrolling. This maybe fixed when my other issue has been fixed, see here: https://github.com/jquery/jquery-mousewheel/issues/202

Here is a working example of setting the mousewheel vendor file to using passive event listeners: https://jsbin.com/bupesajoza/edit?html,js,output

(As you can see the scrolling is very smooth and not like the media manager scrolling right now with non-passive event listeners).

---

Conclusion: This should keep most people happy in the mean time.