### PR TITLE
Add event before invite email is sent

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,21 @@
+name: Archive
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 30
+        days-before-close: 3
+        stale-issue-message: 'This issue will be closed and archived in 3 days, as there has been no activity in the last 30 days. If this issue is still relevant or you would like to see action on it, please respond and we will get the ball rolling.'
+        stale-pr-message: 'This pull request will be closed and archived in 3 days, as there has been no activity in the last 30 days. If this is still being worked on, please respond and we will re-open this pull request.'
+        stale-issue-label: 'Status: Archived'
+        stale-pr-label: 'Status: Archived'
+        exempt-issue-label: 'Status: In Progress'
+        exempt-pr-label: 'Status: In Progress'

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -151,6 +151,8 @@ class User extends UserBase
             'password' => $this->getOriginalHashValue('password'),
             'link' => Backend::url('backend'),
         ];
+        
+        Event::fire('backend.user.beforeSendInvite', [$this, &$data]);
 
         Mail::send('backend::mail.invite', $data, function ($message) {
             $message->to($this->email, $this->full_name);


### PR DESCRIPTION
Required so the data can be extended when sending the backend invite email.