### PR TITLE
Allow partial overrides in subfolders

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -24,6 +24,7 @@ use System\Classes\CombineAssets;
 use System\Twig\Extension as SystemTwigExtension;
 use October\Rain\Exception\AjaxException;
 use October\Rain\Exception\ValidationException;
+use October\Rain\Exception\ApplicationException;
 use October\Rain\Parse\Bracket as TextParser;
 use Illuminate\Http\RedirectResponse;
 
@@ -1004,7 +1005,14 @@ class Controller
              * Check the component partial
              */
             if ($partial === null) {
-                $partial = ComponentPartial::loadCached($componentObj, $partialName);
+                try {
+                    $partial = ComponentPartial::loadCached($componentObj, $partialName);
+                } catch (ApplicationException $e) {
+                    if ($throwException) {
+                        throw new CmsException(Lang::get('cms::lang.partial.not_found_name', ['name' => $name]));
+                    }
+                    return false;
+                }
             }
 
             if ($partial === null) {

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -998,9 +998,7 @@ class Controller
             /*
              * Check if the theme has an override
              */
-            if (strpos($partialName, '/') === false) {
-                $partial = ComponentPartial::loadOverrideCached($this->theme, $componentObj, $partialName);
-            }
+            $partial = ComponentPartial::loadOverrideCached($this->theme, $componentObj, $partialName);
 
             /*
              * Check the component partial

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1009,7 +1009,7 @@ class Controller
                     $partial = ComponentPartial::loadCached($componentObj, $partialName);
                 } catch (ApplicationException $e) {
                     if ($throwException) {
-                        throw new CmsException(Lang::get('cms::lang.partial.not_found_name', ['name' => $name]));
+                        throw $e;
                     }
                     return false;
                 }

--- a/modules/cms/helpers/File.php
+++ b/modules/cms/helpers/File.php
@@ -1,5 +1,8 @@
 <?php namespace Cms\Helpers;
 
+use October\Rain\Filesystem\Filesystem;
+use Config;
+
 /**
  * Defines some file-system helpers for the CMS system.
  *
@@ -64,6 +67,26 @@ class File
             if (!self::validateName($segment)) {
                 return false;
             }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates a CMS object path is inside the application's base directory.
+     * @param string $filePath Specifies a path to validate
+     * @return boolean Returns true if the file path is local. Otherwise returns false.
+     */
+    public static function validateIsLocalFile($filePath)
+    {
+        $restrictBaseDir = Config::get('cms.restrictBaseDir', true);
+
+        if ($restrictBaseDir && !app(Filesystem::class)->isLocalPath($filePath)) {
+            return false;
+        }
+
+        if (!$restrictBaseDir && realpath($filePath) === false) {
+            return false;
         }
 
         return true;

--- a/modules/cms/helpers/File.php
+++ b/modules/cms/helpers/File.php
@@ -1,7 +1,7 @@
 <?php namespace Cms\Helpers;
 
-use October\Rain\Filesystem\Filesystem;
 use Config;
+use File as Filesystem;
 
 /**
  * Defines some file-system helpers for the CMS system.
@@ -81,7 +81,7 @@ class File
     {
         $restrictBaseDir = Config::get('cms.restrictBaseDir', true);
 
-        if ($restrictBaseDir && !app(Filesystem::class)->isLocalPath($filePath)) {
+        if ($restrictBaseDir && !Filesystem::isLocalPath($filePath)) {
             return false;
         }
 


### PR DESCRIPTION
This PR is my proposal to fix #4347. 

Changed behaviour:

* Component partials in subfolders can now be overridden
* Including partials from outside the base path results in a ApplicationException now (if `cms.restrictBaseDir` is true)

Adding the local file check to the `File::validatePath` method turned out to be not a good solution. Passing the absolute path to this method would break the "max nesting" check. My solution is to introduce a new `File::validateIsLocalFile` method that does this check depending on the `cms.restrictBaseDir` setting.
