### PR TITLE
Added getConfig helper method to get config values

### DIFF
--- a/modules/backend/classes/ListColumn.php
+++ b/modules/backend/classes/ListColumn.php
@@ -220,6 +220,17 @@ class ListColumn
     }
 
     /**
+     * Returns a raw config item value.
+     * @param  string $value
+     * @param  string $default
+     * @return mixed
+     */
+    public function getConfig($value, $default = null)
+    {
+        return array_get($this->config, $value, $default);
+    }
+
+    /**
      * Returns this columns value from a supplied data set, which can be
      * an array or a model or another generic collection.
      * @param mixed $data


### PR DESCRIPTION
Added getConfig to make it easier for developers to fetch the config data from a list column while overriding the list items through extension. This also makes the class more compatible with [FormField](https://github.com/octobercms/october/blob/master/modules/backend/classes/FormField.php) which already has the same helper function.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->