### PR TITLE
Allow relation widget to be ordered by author

### DIFF
--- a/modules/backend/formwidgets/Relation.php
+++ b/modules/backend/formwidgets/Relation.php
@@ -40,6 +40,11 @@ class Relation extends FormWidgetBase
      */
     public $scope;
 
+    /**
+     * @var string Define the order of the list query.
+     */
+    public $order;
+
     //
     // Object properties
     //
@@ -63,6 +68,7 @@ class Relation extends FormWidgetBase
             'nameFrom',
             'emptyOption',
             'scope',
+            'order',
         ]);
 
         if (isset($this->config->select)) {
@@ -107,6 +113,12 @@ class Relation extends FormWidgetBase
             }
             elseif (in_array($relationType, ['belongsTo', 'hasOne'])) {
                 $field->type = 'dropdown';
+            }
+
+            // Order query by the configured option.
+            if ($this->order) {
+                // Using "raw" to allow authors to use a string to define the order clause.
+                $query->orderByRaw($this->order);
             }
 
             // It is safe to assume that if the model and related model are of


### PR DESCRIPTION
This allows the option "order" to be configured for a relation widget. 
Developers can ensure a logical order for administrators, so they can find what they're looking for quickly.

Example configuration:

```
productCategories:
    type: relation
    label: Category
    nameFrom: name
    span: auto
    order: name
```

To order descending the yaml config would look like this:

```
    order: "name desc"
```

I will do a PR to the docs if this is accepted.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->