### PR TITLE
Fix #4251: improved email client support for branded mails

### DIFF
--- a/modules/system/models/mailbrandsetting/custom.less
+++ b/modules/system/models/mailbrandsetting/custom.less
@@ -87,7 +87,7 @@ img {
     max-width: 100%;
 }
 
-.break-all, .break-all *{
+.break-all, .break-all * {
     -ms-word-break: break-all;
     word-break: break-word;
     word-break: break-all;

--- a/modules/system/models/mailbrandsetting/custom.less
+++ b/modules/system/models/mailbrandsetting/custom.less
@@ -74,8 +74,6 @@ code {
     color: @text-color;
     font-size: 16px;
     line-height: 1.5em;
-    -ms-word-break: break-all;
-    word-break: break-word;
     word-break: break-all;
 }
 
@@ -88,8 +86,6 @@ img {
 }
 
 .break-all, .break-all * {
-    -ms-word-break: break-all;
-    word-break: break-word;
     word-break: break-all;
 }
 

--- a/modules/system/models/mailbrandsetting/custom.less
+++ b/modules/system/models/mailbrandsetting/custom.less
@@ -13,11 +13,10 @@ body {
     line-height: 1.4;
     margin: 0;
     -moz-hyphens: auto;
-    -ms-word-break: break-all;
+    -ms-word-break: break-word;
     width: 100% !important;
     -webkit-hyphens: auto;
     -webkit-text-size-adjust: none;
-    word-break: break-all;
     word-break: break-word;
 }
 
@@ -75,6 +74,9 @@ code {
     color: @text-color;
     font-size: 16px;
     line-height: 1.5em;
+    -ms-word-break: break-all;
+    word-break: break-word;
+    word-break: break-all;
 }
 
 p.sub {
@@ -83,6 +85,12 @@ p.sub {
 
 img {
     max-width: 100%;
+}
+
+.break-all, .break-all *{
+    -ms-word-break: break-all;
+    word-break: break-word;
+    word-break: break-all;
 }
 
 /* Layout */

--- a/modules/system/views/mail/partial-panel.htm
+++ b/modules/system/views/mail/partial-panel.htm
@@ -2,7 +2,7 @@ name = "Panel"
 ==
 {{ body|trim }}
 ==
-<table class="panel" width="100%" cellpadding="0" cellspacing="0">
+<table class="panel break-all" width="100%" cellpadding="0" cellspacing="0">
     <tr>
         <td class="panel-content">
             <table width="100%" cellpadding="0" cellspacing="0">

--- a/modules/system/views/mail/partial-promotion.htm
+++ b/modules/system/views/mail/partial-promotion.htm
@@ -2,7 +2,7 @@ name = "Promotion"
 ==
 {{ body|trim }}
 ==
-<table class="promotion" align="center" width="100%" cellpadding="0" cellspacing="0">
+<table class="promotion break-all" align="center" width="100%" cellpadding="0" cellspacing="0">
     <tr>
         <td align="center">
             {{ body|md_safe }}


### PR DESCRIPTION
Fixed issue #4251 where word-break issues in Outlook clients (9.1% market share) were causing major readability issues.

- Updated word-break style settings.
- Added .break-all class, which can be used to make sure content does not expand beyond its container.
- Updated panel and promotion panel to use break-all class by default (in case long strings like coupon codes are used).
- Tested in all major email clients for compatibility using Litmus.

**Before**: https://litmus.com/checklist/emails/public/24587be
**After**: https://litmus.com/checklist/emails/public/d80507b

Note: this does not fix the Android 6.0 layout issue. 
