### PR TITLE
added mailgun endpoint to services config, fixes issue #3846

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,7 @@ return [
     'mailgun' => [
         'domain' => '',
         'secret' => '',
+        'endpoint' => 'api.mailgun.net', // api.eu.mailgun.net for EU
     ],
 
     'mandrill' => [


### PR DESCRIPTION
Added missing endpoint configuration setting for the mailgun; thus, left the [sole alternative](https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions), EU option, as comment.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->