### PR TITLE
Make RecordFinder's SearchWidget work when RecordFinder is in a Repeater

### DIFF
--- a/modules/backend/formwidgets/recordfinder/partials/_recordfinder_form.htm
+++ b/modules/backend/formwidgets/recordfinder/partials/_recordfinder_form.htm
@@ -1,5 +1,8 @@
 <div id="<?= $this->getId('popup') ?>" class="recordfinder-popup">
     <?= Form::open() ?>
+    <?php foreach ($preservePosts as $key => $value) { ?>
+        <input type="hidden" name="<?= $key ?>" value="<?= $value ?>" />
+    <?php } ?>
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
             <h4 class="modal-title"><?= e(trans($title)) ?></h4>


### PR DESCRIPTION
RecordFinder's SearchWidget doesn't work if the RecordFinder is inside a Repeater. The problem is that the widgets are not initialized and not bound to controller.

This change preserves the relevant POST keys from the sent from the Repeater and adds them to the SearchWidget form as hidden fields. When the SearchWidget's onSubmit is activated, those keys are sent and the Controller will initialize all related widgets, including the Repeater, it's child RecordFinder and it's child SearchWidget. Works with nested Repeaters too.

There might be a better way to achieve this but after reverse-engineer the widget code, I only came up with this. Suggestions are welcome, but I will be using this for my project, so wanted to also share.