### PR TITLE
Fix #3415, #4672

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -220,6 +220,21 @@ class Repeater extends FormWidgetBase
             ? post($this->formField->getName())
             : $this->getLoadValue();
 
+        // Detect when a child widget is trying to run an AJAX handler
+        // outside of the form element that contains all the repeater
+        // fields that would normally be used to identify that case
+        $handler = $this->controller->getAjaxHandler();
+        if (!$this->loaded && starts_with($handler, $this->alias . 'Form')) {
+            // Attempt to get the index of the repeater
+            $handler = str_after($handler, $this->alias . 'Form');
+            preg_match("~^(\d+)~", $handler, $matches);
+
+            if (isset($matches[1])) {
+                $index = $matches[1];
+                $this->makeItemFormWidget($index);
+            }
+        }
+
         if (!$this->childAddItemCalled && $currentValue === null) {
             $this->formWidgets = [];
             return;
@@ -269,7 +284,7 @@ class Repeater extends FormWidgetBase
         $config = $this->makeConfig($configDefinition);
         $config->model = $this->model;
         $config->data = $this->getValueFromIndex($index);
-        $config->alias = $this->alias . 'Form'.$index;
+        $config->alias = $this->alias . 'Form' . $index;
         $config->arrayName = $this->getFieldName().'['.$index.']';
         $config->isNested = true;
         if (self::$onAddItemCalled || $this->minItems > 0) {


### PR DESCRIPTION
Handle child FormWidgets making AJAX requests outside of the repeater's form container. Note that this won't pass on the state of the repeater item as it exists on the webpage because that information won't be sent to the server in an AJAX request sent from outside of the repeater's form container unless the FormWidget sending the orphaned request specifically includes that data in their request, in which case the regular handling will kick in and initialize the widget properly. A discussion should be had whether this fix makes sense to be done in the Repeater FormWidget or if we should force FormWidgets to have the responsibility of initializing their parent repeaters if they're going to be making orphaned AJAX requests.

Should fix #3415, #4672.
Related: https://github.com/octoberrain/test-plugin/pull/78