### PR TITLE
Move prompt to lang

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,5 @@
 # These are supported funding model platforms
 custom: ['https://octobercms.com/fundraising']
 open_collective: octobercms
+github: LukeTowers
 patreon: LukeTowers

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -21,7 +21,7 @@ class Repeater extends FormWidgetBase
     /**
      * @var string Prompt text for adding new items.
      */
-    public $prompt = 'Add new item';
+    public $prompt;
 
     /**
      * @var bool Items can be sorted.
@@ -97,6 +97,8 @@ class Repeater extends FormWidgetBase
      */
     public function init()
     {
+        $this->prompt = Lang::get('backend::lang.repeater.add_new_item');
+        
         $this->fillFromConfig([
             'form',
             'prompt',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -239,6 +239,7 @@ return [
         'remove_file' => 'Remove file'
     ],
     'repeater' => [
+        'add_new_item' => 'Add new item',
         'min_items_failed' => ':name requires a minimum of :min items, only :items were provided',
         'max_items_failed' => ':name only allows up to :max items, :items were provided',
     ],


### PR DESCRIPTION
Move default prompt text to i18n file.

By default there is no way of overriding Repeater prompt in whole back-end admin site - only exclusively using config. 
This change do not break any existing code. 
Default prompt text will be loaded from overridable translation file.