### PR TITLE
Fix: Not reflecting "defaultMask" when uploading file@CMS

### DIFF
--- a/modules/cms/widgets/AssetList.php
+++ b/modules/cms/widgets/AssetList.php
@@ -17,7 +17,6 @@ use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use DirectoryIterator;
 use Exception;
-use Config;
 
 /**
  * CMS asset list widget.

--- a/modules/cms/widgets/AssetList.php
+++ b/modules/cms/widgets/AssetList.php
@@ -665,7 +665,9 @@ class AssetList extends WidgetBase
              */
             $uploadedFile = $uploadedFile->move($this->getCurrentPath(), $uploadedFile->getClientOriginalName());
 
-            @chmod($uploadedFile, octdec(Config::get('cms.defaultMask.file')));
+            if (Config::get('cms.defaultMask.file')) {
+                @chmod($uploadedFile->getRealPath(), octdec(Config::get('cms.defaultMask.file')));
+            }
 
             $response = Response::make('success');
         }

--- a/modules/cms/widgets/AssetList.php
+++ b/modules/cms/widgets/AssetList.php
@@ -17,6 +17,7 @@ use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use DirectoryIterator;
 use Exception;
+use Config;
 
 /**
  * CMS asset list widget.
@@ -663,6 +664,8 @@ class AssetList extends WidgetBase
              * Accept the uploaded file
              */
             $uploadedFile->move($this->getCurrentPath(), $uploadedFile->getClientOriginalName());
+
+            @chmod($this->getCurrentPath().'/'.$uploadedFile->getClientOriginalName(), octdec(Config::get('cms.defaultMask.file')));
 
             $response = Response::make('success');
         }

--- a/modules/cms/widgets/AssetList.php
+++ b/modules/cms/widgets/AssetList.php
@@ -663,9 +663,9 @@ class AssetList extends WidgetBase
             /*
              * Accept the uploaded file
              */
-            $uploadedFile->move($this->getCurrentPath(), $uploadedFile->getClientOriginalName());
+            $uploadedFile = $uploadedFile->move($this->getCurrentPath(), $uploadedFile->getClientOriginalName());
 
-            @chmod($this->getCurrentPath().'/'.$uploadedFile->getClientOriginalName(), octdec(Config::get('cms.defaultMask.file')));
+            @chmod($uploadedFile, octdec(Config::get('cms.defaultMask.file')));
 
             $response = Response::make('success');
         }

--- a/modules/cms/widgets/AssetList.php
+++ b/modules/cms/widgets/AssetList.php
@@ -665,9 +665,7 @@ class AssetList extends WidgetBase
              */
             $uploadedFile = $uploadedFile->move($this->getCurrentPath(), $uploadedFile->getClientOriginalName());
 
-            if (Config::get('cms.defaultMask.file')) {
-                @chmod($uploadedFile->getRealPath(), octdec(Config::get('cms.defaultMask.file')));
-            }
+            File::chmod($uploadedFile->getRealPath());
 
             $response = Response::make('success');
         }


### PR DESCRIPTION
When uploading file through "CMS"->"Files"->"Add" -> "Upload file(s)", uploaded file doesn't have set file permissions according to "cms.defaultMask.file" from Config.

This patch fixes it so "defaultMask" can be different from umask and file has correctly set its permissions (usefull when required permissions are other than "644") as well as it has files/directories directly created in CMS section.