### PR TITLE
Alternate method to pass CSRF token

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -8,6 +8,7 @@ use Lang;
 use Flash;
 use Config;
 use Session;
+use Cookie;
 use Request;
 use Response;
 use Exception;
@@ -256,7 +257,13 @@ class Controller
             return $result;
         }
 
-        return Response::make($result, $this->statusCode);
+        $response = Response::make($result, $this->statusCode);
+
+        if (Config::get('cms.enableCsrfProtection')) {
+            $this->addCsrfCookie($response);
+        }
+
+        return $response;
     }
 
     /**
@@ -1582,6 +1589,28 @@ class Controller
     //
     // Security
     //
+
+    /**
+     * Adds anti-CSRF cookie.
+     *
+     * Adds a cookie with a token for CSRF checks to the response.
+     *
+     * @return void
+     */
+    protected function addCsrfCookie(\Illuminate\Http\Response $response)
+    {
+        $response->withCookie(Cookie::make(
+            'csrfToken',
+            Session::token(),
+            60,
+            null,
+            null,
+            false,
+            false,
+            false,
+            'strict'
+        ));
+    }
 
     /**
      * Checks the request data / headers for a valid CSRF token.

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -15,6 +15,7 @@ if (window.jQuery.request !== undefined) {
 +function ($) { "use strict";
 
     var Request = function (element, handler, options) {
+        var csrfToken;
         var $el = this.$el = $(element);
         this.options = options || {};
 
@@ -27,6 +28,14 @@ if (window.jQuery.request !== undefined) {
 
         if (!handler.match(/^(?:\w+\:{2})?on*/)) {
             throw new Error('Invalid handler name. The correct handler name format is: "onEvent".')
+        }
+
+        if (document.cookie) {
+            // Retrieve CSRF cookie
+            var exists = new RegExp("(?:^|;\\s*)" + encodeURIComponent('csrfToken').replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=")
+            if (exists.test(document.cookie)) {
+                csrfToken = decodeURIComponent(document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*" + encodeURIComponent('csrfToken').replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=\\s*([^;]*).*$)|^.*$"), "$1")) || null
+            }
         }
 
         /*
@@ -66,6 +75,10 @@ if (window.jQuery.request !== undefined) {
 
         if (useFlash) {
             requestHeaders['X-OCTOBER-REQUEST-FLASH'] = 1
+        }
+
+        if (csrfToken) {
+            requestHeaders['X-CSRF-TOKEN'] = csrfToken
         }
 
         /*


### PR DESCRIPTION
Fixes #4699. Library PR: https://github.com/octobercms/library/pull/435

Adds another workflow for sending CSRF tokens, specifically in the case of pure JS AJAX requests from the CMS pages where the user has CSRF protection enabled but has not sent through a token. This PR adds a cookie-based CSRF token that is read in through the JS framework and added as a header in all AJAX requests.

As per the original CSRF token verification, if a token is provided through a `_token` input value, this will take precedence, allowing the CSRF cookie token to be overriden on a per-request basis.