### PR TITLE
Add some "clear" classes for fields

### DIFF
--- a/modules/system/assets/ui/less/form.less
+++ b/modules/system/assets/ui/less/form.less
@@ -155,6 +155,18 @@
         clear: right;
     }
 
+    &.clear-full {
+        clear: both;
+    }
+
+    &.clear-left {
+        clear: left;
+    }
+
+    &.clear-right {
+        clear: right;
+    }
+
     &.layout-relative {
         padding-bottom: 0;
     }

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4200,6 +4200,9 @@ html.cssanimations .cursor-loading-indicator.hide {display:none}
 .form-group.span-full {width:100%;float:left}
 .form-group.span-left {float:left;width:48.5%;clear:left}
 .form-group.span-right {float:right;width:48.5%;clear:right}
+.form-group.clear-full {clear:both}
+.form-group.clear-left {clear:left}
+.form-group.clear-right {clear:right}
 .form-group.layout-relative {padding-bottom:0}
 .form-group.checkbox-field {padding-bottom:5px}
 .form-group.number-field >.form-control {text-align:right}


### PR DESCRIPTION
Adds a couple of "clear" classes for fields to take advantage of. This is mainly for fields using the "storm" span option, allowing them to uses the CSS classes to specify column widths.

I had a particular example where I wanted six media finders in a row, followed by six text fields underneath. I used a combination of the "storm" span option and the "col-sm-2" CSS class to make this possible. However, with media finders, when an image is uploaded, they grow in height, which causes the columns (which float left) to go out of alignment.

Observe:
![image](https://user-images.githubusercontent.com/15900351/67162182-4895d880-f394-11e9-83f2-af4fa97c730d.png)

With this new clear class added to the first text field in the second row, I can have it clear the floats and start a new row with the correct alignment:

![image](https://user-images.githubusercontent.com/15900351/67162226-9579af00-f394-11e9-8781-4dcf20186b7c.png)
