### PR TITLE
Restore support for Select2 data format in custom select control

### DIFF
--- a/modules/system/assets/ui/docs/select.md
+++ b/modules/system/assets/ui/docs/select.md
@@ -71,24 +71,47 @@ Use the `data-handler` attribute to source the select options from an AJAX handl
 ></select>
 ```
 
-The AJAX handler should return results as an array.
+The AJAX handler should return results in the [Select2 data format](https://select2.org/data-sources/formats).
 
 ```php
 public function onGetOptions()
 {
-    $results = [
-        [
-            'id' => 1,
-            'text' => 'Foobar',
+    return [
+        'results' => [
+            [
+                'id' => 1,
+                'text' => 'Foo',
+                'disabled' => true
+            ],
+            [
+                'id' => 2,
+                'text' => 'Bar',
+                'selected' => true
+            ],
+            [
+                'text' => 'Group',
+                'children' => [
+                    [
+                        'id' => 3,
+                        'text' => 'Child 1'
+                    ],
+                    [
+                        'id' => 4,
+                        'text' => 'Child 2'
+                    ]
+                    ...
+                ]
+            ]
+            ...
         ],
-        ...
+        'pagination' => [
+            'more' => true
+        ]
     ];
-
-    return ['result' => $results];
 }
 ```
 
-Due to the fact that JavaScript reorders numeric keys when interpreting the JSON data received by the AJAX handler, we suggest the method above for defining `results`. Support for the original `results` array format is however retained to ensure backwards compatibility.
+The results array can be assigned to either the `result` or `results` key. As an alternative to the Select2 format, results can also be provided as an associative array (also assigned to either key). Due to the fact that JavaScript does not guarantee the order of object properties, we suggest the method above for defining results.
 
 ```php
 public function onGetOptions()

--- a/modules/system/assets/ui/docs/select.md
+++ b/modules/system/assets/ui/docs/select.md
@@ -80,6 +80,27 @@ public function onGetOptions()
         'results' => [
             [
                 'id' => 1,
+                'text' => 'Foo'
+            ],
+            [
+                'id' => 2,
+                'text' => 'Bar'
+            ]
+            ...
+        ]
+    ];
+}
+```
+
+Or a more full-featured example:
+
+```php
+public function onGetOptions()
+{
+    return [
+        'results' => [
+            [
+                'id' => 1,
                 'text' => 'Foo',
                 'disabled' => true
             ],

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -90,6 +90,7 @@
                         var results = data.result || data.results,
                             options = []
 
+                        delete(data.result)
                         if (results[0] && results[0].id) { // Already in Select2 format
                             options = results
                         }

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -87,23 +87,25 @@
                         return $request
                     },
                     processResults: function (data, params) {
-                        var results = data.result;
-                        var options = [];
+                        var results = data.result || data.results,
+                            options = []
 
-                        for (var i in results) {
-                            if (results.hasOwnProperty(i)) {
-                                var isObject = i != null && i.constructor.name === 'Object';
-                                
-                                options.push({
-                                    id: isObject ? results[i].id : i,
-                                    text: isObject ? results[i].text : results[i],
-                                });
-                            };
-                        };
+                        if (results[0] && results[0].id) { // Already in Select2 format
+                            options = results
+                        }
+                        else {
+                            for (var i in results) {
+                                if (results.hasOwnProperty(i)) {
+                                    options.push({
+                                        id: i,
+                                        text: results[i],
+                                    })
+                                }
+                            }
+                        }
 
-                        return {
-                            results: options,
-                        };
+                        data.results = options
+                        return data
                     },
                     dataType: 'json'
                 }

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -91,10 +91,10 @@
                             options = []
 
                         delete(data.result)
-                        if (results[0] && results[0].id) { // Already in Select2 format
+                        if (results[0] && typeof(results[0]) === 'object') { // Pass through Select2 format
                             options = results
                         }
-                        else {
+                        else { // Key-value map
                             for (var i in results) {
                                 if (results.hasOwnProperty(i)) {
                                     options.push({

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3497,7 +3497,11 @@ if($element.hasClass('select-hide-selected')){extraOptions.dropdownCssClass+=' s
 var source=$element.data('handler');if(source){extraOptions.ajax={transport:function(params,success,failure){var $request=$element.request(source,{data:params.data})
 $request.done(success)
 $request.fail(failure)
-return $request},processResults:function(data,params){var results=data.result;var options=[];for(var i in results){if(results.hasOwnProperty(i)){var isObject=i!=null&&i.constructor.name==='Object';options.push({id:isObject?results[i].id:i,text:isObject?results[i].text:results[i],});};};return{results:options,};},dataType:'json'}}
+return $request},processResults:function(data,params){var results=data.result||data.results,options=[]
+if(results[0]&&results[0].id){options=results}
+else{for(var i in results){if(results.hasOwnProperty(i)){options.push({id:i,text:results[i],})}}}
+data.results=options
+return data},dataType:'json'}}
 var separators=$element.data('token-separators')
 if(separators){extraOptions.tags=true
 extraOptions.tokenSeparators=separators.split('|')

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3498,6 +3498,7 @@ var source=$element.data('handler');if(source){extraOptions.ajax={transport:func
 $request.done(success)
 $request.fail(failure)
 return $request},processResults:function(data,params){var results=data.result||data.results,options=[]
+delete(data.result)
 if(results[0]&&results[0].id){options=results}
 else{for(var i in results){if(results.hasOwnProperty(i)){options.push({id:i,text:results[i],})}}}
 data.results=options

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3499,7 +3499,7 @@ $request.done(success)
 $request.fail(failure)
 return $request},processResults:function(data,params){var results=data.result||data.results,options=[]
 delete(data.result)
-if(results[0]&&results[0].id){options=results}
+if(results[0]&&typeof(results[0])==='object'){options=results}
 else{for(var i in results){if(results.hasOwnProperty(i)){options.push({id:i,text:results[i],})}}}
 data.results=options
 return data},dataType:'json'}}

--- a/tests/js/cases/system/ui.select.test.js
+++ b/tests/js/cases/system/ui.select.test.js
@@ -95,5 +95,17 @@ describe('modules/system/assets/ui/js/select.js', function () {
             let result = processResults({ results: select2ResultFormat, pagination: { more: true }, other: 'value' })
             assert.deepInclude(result, { pagination: { more: true }, other: 'value' })
         })
+
+        it('passes through the Select2 format with a group as the first entry', function() {
+            let data = [
+                {
+                    text: 'Label',
+                    children: select2ResultFormat
+                }
+            ]
+
+            let result = processResults({ results: data })
+            assert.deepEqual(result, { results: data })
+        })
     })
 })

--- a/tests/js/cases/system/ui.select.test.js
+++ b/tests/js/cases/system/ui.select.test.js
@@ -1,0 +1,99 @@
+import { assert } from 'chai'
+import fakeDom from 'helpers/fakeDom'
+
+describe('modules/system/assets/ui/js/select.js', function () {
+    describe('AJAX processResults function', function () {
+        let dom,
+            window,
+            processResults,
+            keyValResultFormat = {
+                value1: 'text1',
+                value2: 'text2'
+            },
+            select2ResultFormat = [
+                {
+                    id: 'value1',
+                    text: 'text1',
+                    disabled: true
+                },
+                {
+                    id: 'value2',
+                    text: 'text2',
+                    selected: false
+                }
+            ]
+
+        this.timeout(1000)
+
+        beforeEach((done) => {
+            // Load framework.js and select.js in the fake DOM
+            dom = fakeDom(`
+                    <select class="custom-select" data-handler="onSearch"></select>
+                    <script src="file://./node_modules/jquery/dist/jquery.js" id="jqueryScript"></script>
+                    <script src="file://./modules/system/assets/js/framework.js" id="frameworkScript"></script>
+                    <script src="file://./modules/system/assets/ui/js/select.js" id="selectScript"></script>
+            `)
+
+            window = dom.window
+
+            window.selectScript.onload = () => {
+                window.jQuery.fn.select2 = function(options) {
+                    processResults = options.ajax.processResults
+                    done()
+                }
+            }
+        })
+
+        afterEach(() => {
+            window.close()
+        })
+
+        it('supports a key-value mapping on the "result" key', function () {
+            let result = processResults({ result: keyValResultFormat })
+            assert.deepEqual(result, { results: [
+                {
+                    id: 'value1',
+                    text: 'text1'
+                },
+                {
+                    id: 'value2',
+                    text: 'text2'
+                }
+            ]})
+        })
+
+        it('supports a key-value mapping on the "results" key', function() {
+            let result = processResults({ results: keyValResultFormat })
+            assert.deepEqual(result, { results: [
+                {
+                    id: 'value1',
+                    text: 'text1'
+                },
+                {
+                    id: 'value2',
+                    text: 'text2'
+                }
+            ]})
+        })
+
+        it('passes through other data provided with key-value mapping', function() {
+            let result = processResults({ result: keyValResultFormat, other1: 1, other2: '2' })
+            assert.include(result, { other1: 1, other2: '2'})
+        })
+
+        it('supports the Select2 result format on the "result" key', function() {
+            let result = processResults({ result: select2ResultFormat })
+            assert.deepEqual(result, { results: select2ResultFormat })
+        })
+
+        it('passes through the Select2 result format on the "results" key', function() {
+            let result = processResults({ results: select2ResultFormat })
+            assert.deepEqual(result, { results: select2ResultFormat })
+        })
+
+        it('passes through other data provided with Select2 results format', function() {
+            let result = processResults({ results: select2ResultFormat, pagination: { more: true }, other: 'value' })
+            assert.deepInclude(result, { pagination: { more: true }, other: 'value' })
+        })
+    })
+})


### PR DESCRIPTION
Referencing the conversation in #4413, this PR will restore the ability to use the Select2 data format in AJAX handlers while retaining the recently added support for a simple associative array of results.

It also updates the documentation with a more extensive example of the data format and (hopefully) a little more clarity.