### PR TITLE
Refactor relation saving in multi-relation widget

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1096,7 +1096,9 @@ class RelationController extends ControllerBehavior
 
             $modelsToSave = $this->prepareModelsToSave($newModel, $saveData);
             foreach ($modelsToSave as $modelToSave) {
-                $modelToSave->save(null, $this->manageWidget->getSessionKey());
+                if (get_class($modelToSave) !== get_class($newModel)) {
+                    $modelToSave->save(null, $this->manageWidget->getSessionKey());
+                }
             }
 
             $this->relationObject->add($newModel, $sessionKey);


### PR DESCRIPTION
Prevents the relationModel from saving until when the relation is established with `$this->relationObject->add`, preventing multiple event calls for the model.

Fixes #4246.