### PR TITLE
Fix empty Richeditor class lists from breaking widget

### DIFF
--- a/modules/backend/formwidgets/RichEditor.php
+++ b/modules/backend/formwidgets/RichEditor.php
@@ -1,10 +1,12 @@
 <?php namespace Backend\FormWidgets;
 
 use App;
+use Config;
 use File;
 use Event;
 use Lang;
 use Request;
+use Backend;
 use BackendAuth;
 use Backend\Classes\FormWidgetBase;
 use Backend\Models\EditorSetting;
@@ -131,7 +133,16 @@ class RichEditor extends FormWidgetBase
     {
         $this->addCss('css/richeditor.css', 'core');
         $this->addJs('js/build-min.js', 'core');
-        $this->addJs('js/build-plugins-min.js', 'core');
+
+        if (Config::get('develop.decompileBackendAssets', false)) {
+            $scripts = Backend::decompileAsset($this->getAssetPath('js/build-plugins.js'));
+            foreach ($scripts as $script) {
+                $this->addJs($script, 'core');
+            }
+        } else {
+            $this->addJs('js/build-plugins-min.js', 'core');
+        }
+
         $this->addJs('/modules/backend/formwidgets/codeeditor/assets/js/build-min.js', 'core');
 
         if ($lang = $this->getValidEditorLang()) {

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -16,11 +16,11 @@
         <?php if ($noWrapTags): ?>data-no-wrap-tags="<?= e($noWrapTags) ?>"<?php endif ?>
         <?php if ($removeTags): ?>data-remove-tags="<?= e($removeTags) ?>"<?php endif ?>
         <?php if ($lineBreakerTags): ?>data-line-breaker-tags="<?= e($lineBreakerTags) ?>"<?php endif ?>
-        <?php if ($imageStyles): ?>data-image-styles="<?= e(json_encode($imageStyles)) ?>"<?php endif ?>
-        <?php if ($linkStyles): ?>data-link-styles="<?= e(json_encode($linkStyles)) ?>"<?php endif ?>
-        <?php if ($paragraphStyles): ?>data-paragraph-styles="<?= e(json_encode($paragraphStyles)) ?>"<?php endif ?>
-        <?php if ($tableStyles): ?>data-table-styles="<?= e(json_encode($tableStyles)) ?>"<?php endif ?>
-        <?php if ($tableCellStyles): ?>data-table-cell-styles="<?= e(json_encode($tableCellStyles)) ?>"<?php endif ?>
+        <?php if (isset($imageStyles)): ?>data-image-styles="<?= e(json_encode($imageStyles)) ?>"<?php endif ?>
+        <?php if (isset($linkStyles)): ?>data-link-styles="<?= e(json_encode($linkStyles)) ?>"<?php endif ?>
+        <?php if (isset($paragraphStyles)): ?>data-paragraph-styles="<?= e(json_encode($paragraphStyles)) ?>"<?php endif ?>
+        <?php if (isset($tableStyles)): ?>data-table-styles="<?= e(json_encode($tableStyles)) ?>"<?php endif ?>
+        <?php if (isset($tableCellStyles)): ?>data-table-cell-styles="<?= e(json_encode($tableCellStyles)) ?>"<?php endif ?>
         data-links-handler="<?= $this->getEventHandler('onLoadPageLinksForm') ?>"
         data-ace-vendor-path="<?= Url::asset('/modules/backend/formwidgets/codeeditor/assets/vendor/ace') ?>"
         data-control="richeditor">

--- a/modules/backend/models/EditorSetting.php
+++ b/modules/backend/models/EditorSetting.php
@@ -129,7 +129,7 @@ class EditorSetting extends Model
 
         if (is_array($value)) {
             $value = array_filter(array_build($value, function ($key, $value) {
-                if (array_has($value, 'class_name') && array_has($value, 'class_label')) {
+                if (array_has($value, ['class_name', 'class_label'])) {
                     return [
                         array_get($value, 'class_name'),
                         array_get($value, 'class_label')

--- a/modules/backend/models/EditorSetting.php
+++ b/modules/backend/models/EditorSetting.php
@@ -33,7 +33,7 @@ class EditorSetting extends Model
      * @var mixed Settings form field defitions
      */
     public $settingsFields = 'fields.yaml';
-    
+
     /**
      * @var string The key to store rendered CSS in the cache under
      */
@@ -128,9 +128,14 @@ class EditorSetting extends Model
         $defaultValue = $instance->getDefaultValue($key);
 
         if (is_array($value)) {
-            $value = array_build($value, function ($key, $value) {
-                return [array_get($value, 'class_name'), array_get($value, 'class_label')];
-            });
+            $value = array_filter(array_build($value, function ($key, $value) {
+                if (array_has($value, 'class_name') && array_has($value, 'class_label')) {
+                    return [
+                        array_get($value, 'class_name'),
+                        array_get($value, 'class_label')
+                    ];
+                }
+            }));
         }
 
         return $value != $defaultValue ? $value : $default;


### PR DESCRIPTION
Fixes #4579.

As reported, a JavaScript error occurred if someone empties any of the class lists from the Settings -> Editor Settings -> Markup Classes section, or has entries that are missing a label or class definition. This fixes this issue, and also allows users to have NO classes for any of the class lists if they so desire - in this case, the corresponding Froala action can be clicked, but simply shows no selections.