### PR TITLE
Minor : Typo in "Automatically run migrations on login"

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -98,7 +98,7 @@ return [
     | Automatically run migrations on login
     |--------------------------------------------------------------------------
     |
-    | If value is true, UpdateMananger will be run on logging in to the backend.
+    | If value is true, UpdateManager will be run on logging in to the backend.
     | It's recommended to set this value to 'null' in production enviroments
     | because it clears the cache every time a user logs in to the backend.
     | If set to null, this setting is enabled when debug mode (app.debug) is enabled


### PR DESCRIPTION
MINOR: Changed typo "UpdateMananger > UpdateManager in section "Automatically run migrations on login".