### PR TITLE
Add compatibility for changes in repeater widget

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -129,10 +129,12 @@
 
         $(ev.target).closest('.field-repeater-item').remove()
         this.togglePrompt()
+        $(ev.target).closest('[data-field-name]').trigger('change.oc.formwidget')
     }
 
     Repeater.prototype.onAddItemSuccess = function(ev) {
         this.togglePrompt()
+        $(ev.target).closest('[data-field-name]').trigger('change.oc.formwidget')
     }
 
     Repeater.prototype.togglePrompt = function () {

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -83,8 +83,13 @@
             return this.fieldElementCache
         }
 
-        var form = this.$el,
-            nestedFields = form.find('[data-control="formwidget"] [data-field-name]')
+        var form = this.$el
+
+        if (!form) {
+            return;
+        }
+
+        var nestedFields = form.find('[data-control="formwidget"] [data-field-name]')
 
         return this.fieldElementCache = form.find('[data-field-name]').not(nestedFields)
     }
@@ -117,13 +122,12 @@
                 fieldMap[depend].fields.push(name)
             })
         })
-
+        
         /*
          * When a master is updated, refresh its slaves
          */
         $.each(fieldMap, function(fieldName, toRefresh){
-            fieldElements.filter('[data-field-name="'+fieldName+'"]')
-                .on('change.oc.formwidget', $.proxy(self.onRefreshDependants, self, fieldName, toRefresh))
+            $(document).on('change.oc.formwidget', '[data-field-name="' + fieldName + '"]', $.proxy(self.onRefreshDependants, self, fieldName, toRefresh));
         })
     }
 
@@ -137,6 +141,10 @@
             formEl = this.$form,
             fieldElements = this.getFieldElements()
 
+        if (!form) {
+            return;
+        }
+        
         if (this.dependantUpdateTimers[fieldName] !== undefined) {
             window.clearTimeout(this.dependantUpdateTimers[fieldName])
         }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->
PR for https://github.com/octobercms/october/issues/3595

Trigger `change.oc.formwidget` when adding of removing repeater item