### PR TITLE
Adds the ability to override the column header label in list export.

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -629,7 +629,7 @@ class ImportExportController extends ControllerBehavior
         $headers = [];
         $columns = $widget->getVisibleColumns();
         foreach ($columns as $column) {
-            $headers[] = Lang::get($column->label);
+            $headers[] = $widget->getHeaderValue($column);
         }
         $csv->insertOne($headers);
 


### PR DESCRIPTION
Now we can use the `backend.list.overrideHeaderValue` event also in the list export.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->