### PR TITLE
Refresh Relation Manager on Unlink and Delete

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1183,6 +1183,7 @@ class RelationController extends ControllerBehavior
                 $relatedModel->delete();
             }
 
+            // Reinitialise the form with a blank model
             $this->initRelation($this->model);
 
             $this->viewWidget->setFormValues([]);
@@ -1280,6 +1281,7 @@ class RelationController extends ControllerBehavior
                 $this->relationObject->dissociate();
                 $this->relationObject->getParent()->save();
 
+                // If the relation manager isn't using deferred binding, reinitialise the form with a blank model
                 if (is_null($sessionKey)) {
                     $this->model->refresh();
                     $this->initRelation($this->model);

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1183,6 +1183,8 @@ class RelationController extends ControllerBehavior
                 $relatedModel->delete();
             }
 
+            $this->initRelation($this->model);
+            
             $this->viewWidget->setFormValues([]);
             $this->viewModel = $this->relationModel;
         }
@@ -1276,6 +1278,14 @@ class RelationController extends ControllerBehavior
         elseif ($this->viewMode == 'single') {
             if ($this->relationType == 'belongsTo') {
                 $this->relationObject->dissociate();
+                $this->relationObject->getParent()->save();
+
+                if (is_null($sessionKey)) {
+                    $this->relationObject->getParent()->save();
+                    $this->model->refresh();
+                    $this->initRelation($this->model);
+                }
+
                 $this->relationObject->getParent()->save();
             }
             elseif ($this->relationType == 'hasOne' || $this->relationType == 'morphOne') {

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1184,7 +1184,7 @@ class RelationController extends ControllerBehavior
             }
 
             $this->initRelation($this->model);
-            
+
             $this->viewWidget->setFormValues([]);
             $this->viewModel = $this->relationModel;
         }
@@ -1281,12 +1281,9 @@ class RelationController extends ControllerBehavior
                 $this->relationObject->getParent()->save();
 
                 if (is_null($sessionKey)) {
-                    $this->relationObject->getParent()->save();
                     $this->model->refresh();
                     $this->initRelation($this->model);
                 }
-
-                $this->relationObject->getParent()->save();
             }
             elseif ($this->relationType == 'hasOne' || $this->relationType == 'morphOne') {
                 if ($obj = $relatedModel->find($recordId)) {


### PR DESCRIPTION
This fixes #3470 and #4718 and by refreshing the relation manager's form when the user unlinks or deletes the related record.