### PR TITLE
Public getters for backend list widget. getSortColumn and getSortDirection

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1549,7 +1549,7 @@ class Lists extends WidgetBase
      */
     public function getSortDirection()
     {
-        return $this->sortDirection = $this->sortDirection ?: 'asc';
+        return $this->sortDirection ?? 'asc';
     }
 
     /**

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1547,7 +1547,8 @@ class Lists extends WidgetBase
     /*
      * Returns the current sort direction or default of 'asc'
      */
-    public function getSortDirection () {
+    public function getSortDirection()
+    {
         return $this->sortDirection = $this->sortDirection ?: 'asc';
     }
 

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1497,7 +1497,7 @@ class Lists extends WidgetBase
     /**
      * Returns the current sorting column, saved in a session or cached.
      */
-    protected function getSortColumn()
+    public function getSortColumn()
     {
         if (!$this->isSortable()) {
             return false;
@@ -1542,6 +1542,13 @@ class Lists extends WidgetBase
         }
 
         return $this->sortColumn;
+    }
+
+    /*
+     * Returns the current sort direction or default of 'asc'
+     */
+    public function getSortDirection () {
+        return $this->sortDirection = $this->sortDirection ?: 'asc';
     }
 
     /**


### PR DESCRIPTION
Makes backend list widget's getSortColumn getter public, and adds a new public getter getSortDirection.

Use case: when leveraging listExtendRecords for custom sort operations, we need to know what column/sort order are currently selected in order to know if/how we should act on the current list. 
