### PR TITLE
Dynamic TagList Options

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -174,7 +174,7 @@ class TagList extends FormWidgetBase
         if (!$options) {
             $methodName = 'get'.studly_case($this->fieldName).'Options';
             if ($this->objectMethodExists($this->model, $methodName)) {
-                $options = $this->model->$methodName($this->data);
+                $options = $this->model->$methodName($this->data[$this->fieldName], $this->data);
             };
         }
 

--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -171,9 +171,11 @@ class TagList extends FormWidgetBase
         if (!$options && $this->mode === static::MODE_RELATION) {
             $options = RelationBase::noConstraints(function () {
                 $query = $this->getRelationObject()->newQuery();
-                // Even though "no constraints" is applied, belongsToMany constrains the query	
-                // by joining its pivot table. Remove all joins from the query.	
-                $query->getQuery()->getQuery()->joins = [];	
+
+                // Even though "no constraints" is applied, belongsToMany constrains the query
+                // by joining its pivot table. Remove all joins from the query.
+                $query->getQuery()->getQuery()->joins = [];
+
                 return $query->lists($this->nameFrom);
             });
         }


### PR DESCRIPTION
This PR implements support for a `get*FieldName*Options()` method that returns dynamic options for the TagList widget, much like it does on the dropdown form field (see [the documentation](https://octobercms.com/docs/backend/forms#field-dropdown)).

For example, this method returns dynamic options for the `tags` TagList widget:
```
public function getTagsOptions($value, $formData)
{
    return ['one', 'two', 'three', 'four', 'five'];
}
```