### PR TITLE
Avoid array_intersect error if argv is not defined

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -153,7 +153,7 @@ class ServiceProvider extends ModuleServiceProvider
         /*
          * CLI
          */
-        if (App::runningInConsole() && count(array_intersect($commands, Request::server('argv'))) > 0) {
+        if (App::runningInConsole() && count(array_intersect($commands, Request::server('argv', []))) > 0) {
             PluginManager::$noInit = true;
         }
     }


### PR DESCRIPTION
I rencontered this issue because, I'm working on a way to run [Laravel HTTP tests](https://laravel.com/docs/6.x/http-tests) on OctoberCMS and for Backend work properly, I have to rerun few october Service provider.

I know my usage is not commun (and not very recommended), but this fix seems legit for avoid fatal PHP error.

Anyway thanks to have take few minutes to read me ;)