### PR TITLE
Update .htaccess standard file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -60,7 +60,6 @@
     ## Standard routes, remove index.php and redirect to /
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{THE_REQUEST} ^.*/index\.php
-    RewriteRule ^index.php(.*)$ /$1 [R=301,L]
+    RewriteRule ^ index.php [L]
 
 </IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -34,6 +34,11 @@
     ## Disable PHP in storage folder
     ##
     RewriteRule ^storage/.*\.(?:php[1-6]?)$ - [NC,F]
+    
+    ##
+    ## Whitelist the favicon.ico file in root
+    ##
+    RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
 
     ##
     ## White listed folders
@@ -47,11 +52,6 @@
     RewriteCond %{REQUEST_FILENAME} !/plugins/.*/(assets|resources)/.*
     RewriteCond %{REQUEST_FILENAME} !/modules/.*/(assets|resources)/.*
     RewriteRule !^index.php index.php [L,NC]
-    
-    ##
-    ## Whitelist the favicon.ico file in root
-    ##
-    RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
 
     ##
     ## Block all PHP files, except index

--- a/.htaccess
+++ b/.htaccess
@@ -57,7 +57,7 @@
     RewriteRule !^index.php index.php [L,NC]
 
     ##
-    ## Standard routes and remove index.php and redirect to /
+    ## Standard routes, remove index.php and redirect to /
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{THE_REQUEST} ^.*/index\.php

--- a/.htaccess
+++ b/.htaccess
@@ -31,11 +31,6 @@
     RewriteRule ^storage/app/uploads/protected/.* index.php [L,NC]
     
     ##
-    ## Disable PHP in storage folder
-    ##
-    RewriteRule ^storage/.*\.(?:php[1-6]?)$ - [NC,F]
-    
-    ##
     ## Whitelist the favicon.ico file in root
     ##
     RewriteCond %{REQUEST_FILENAME} !/favicon\.ico

--- a/.htaccess
+++ b/.htaccess
@@ -29,6 +29,9 @@
     RewriteRule ^storage/framework/.* index.php [L,NC]
     RewriteRule ^storage/temp/protected/.* index.php [L,NC]
     RewriteRule ^storage/app/uploads/protected/.* index.php [L,NC]
+    
+    ## Disable PHP in Storage Folder
+    RewriteRule ^storage/.*\.(?:php[1-6]?)$ - [NC,F]
 
     ##
     ## White listed folders
@@ -42,6 +45,9 @@
     RewriteCond %{REQUEST_FILENAME} !/plugins/.*/(assets|resources)/.*
     RewriteCond %{REQUEST_FILENAME} !/modules/.*/(assets|resources)/.*
     RewriteRule !^index.php index.php [L,NC]
+    
+	# Whitelist the Favicon.ico File
+	RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
 
     ##
     ## Block all PHP files, except index
@@ -51,9 +57,10 @@
     RewriteRule !^index.php index.php [L,NC]
 
     ##
-    ## Standard routes
+    ## Standard routes and remove index.php and redirect to /
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^ index.php [L]
+    RewriteCond %{THE_REQUEST} ^.*/index\.php
+    RewriteRule ^index.php(.*)$ /$1 [R=301,L]
 
 </IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -57,7 +57,7 @@
     RewriteRule !^index.php index.php [L,NC]
 
     ##
-    ## Standard routes, remove index.php and redirect to /
+    ## Standard routes
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]

--- a/.htaccess
+++ b/.htaccess
@@ -46,7 +46,7 @@
     RewriteCond %{REQUEST_FILENAME} !/modules/.*/(assets|resources)/.*
     RewriteRule !^index.php index.php [L,NC]
     
-    # Whitelist the favicon.ico file in root
+    ## Whitelist the favicon.ico file in root
     RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
 
     ##

--- a/.htaccess
+++ b/.htaccess
@@ -46,8 +46,8 @@
     RewriteCond %{REQUEST_FILENAME} !/modules/.*/(assets|resources)/.*
     RewriteRule !^index.php index.php [L,NC]
     
-	# Whitelist the favicon.ico file in root
-	RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
+    # Whitelist the favicon.ico file in root
+    RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
 
     ##
     ## Block all PHP files, except index

--- a/.htaccess
+++ b/.htaccess
@@ -30,7 +30,9 @@
     RewriteRule ^storage/temp/protected/.* index.php [L,NC]
     RewriteRule ^storage/app/uploads/protected/.* index.php [L,NC]
     
+    ##
     ## Disable PHP in storage folder
+    ##
     RewriteRule ^storage/.*\.(?:php[1-6]?)$ - [NC,F]
 
     ##
@@ -46,7 +48,9 @@
     RewriteCond %{REQUEST_FILENAME} !/modules/.*/(assets|resources)/.*
     RewriteRule !^index.php index.php [L,NC]
     
+    ##
     ## Whitelist the favicon.ico file in root
+    ##
     RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
 
     ##

--- a/.htaccess
+++ b/.htaccess
@@ -30,7 +30,7 @@
     RewriteRule ^storage/temp/protected/.* index.php [L,NC]
     RewriteRule ^storage/app/uploads/protected/.* index.php [L,NC]
     
-    ## Disable PHP in Storage Folder
+    ## Disable PHP in storage folder
     RewriteRule ^storage/.*\.(?:php[1-6]?)$ - [NC,F]
 
     ##
@@ -46,7 +46,7 @@
     RewriteCond %{REQUEST_FILENAME} !/modules/.*/(assets|resources)/.*
     RewriteRule !^index.php index.php [L,NC]
     
-	# Whitelist the Favicon.ico File
+	# Whitelist the favicon.ico file in root
 	RewriteCond %{REQUEST_FILENAME} !/favicon\.ico
 
     ##

--- a/server.php
+++ b/server.php
@@ -11,7 +11,7 @@ $uri = urldecode(
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
 // application without having installed a "real" web server software here.
-if ($uri !== '/' and file_exists(__DIR__.'/'.$uri))
+if ($uri !== '/' && file_exists(__DIR__.'/'.$uri))
 {
     return false;
 }

--- a/server.php
+++ b/server.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Laravel - A PHP Framework For Web Artisans
  *
@@ -8,9 +9,12 @@
 $uri = urldecode(
     parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
 );
-// This file allows us to emulate Apache's "mod_rewrite" functionality from the
-// built-in PHP web server. This provides a convenient way to test a Laravel
-// application without having installed a "real" web server software here.
+
+/**
+ * This file allows us to emulate Apache's "mod_rewrite" functionality from the
+ * built-in PHP web server. This provides a convenient way to test a Laravel
+ * application without having installed a "real" web server software here.
+ */
 if ($uri !== '/' && file_exists(__DIR__.'/'.$uri))
 {
     return false;

--- a/server.php
+++ b/server.php
@@ -18,4 +18,5 @@ $uri = urldecode(
 if ($uri !== '/' && file_exists(__DIR__.'/'.$uri)) {
     return false;
 }
+
 require_once __DIR__.'/index.php';

--- a/server.php
+++ b/server.php
@@ -15,8 +15,7 @@ $uri = urldecode(
  * built-in PHP web server. This provides a convenient way to test a Laravel
  * application without having installed a "real" web server software here.
  */
-if ($uri !== '/' && file_exists(__DIR__.'/'.$uri))
-{
+if ($uri !== '/' && file_exists(__DIR__.'/'.$uri)) {
     return false;
 }
 require_once __DIR__.'/index.php';


### PR DESCRIPTION
This pull request adds three things:

1. Disable PHP in Storage Folder (added security protection).

2. Whitelist the `favicon.ico` file in root.

3. Cleanup the standard routes, remove the `index.php` and redirect to `/ ` the issue here was October was creating two exact same web pages which caused a duplicate content issue with search engines, now we get the following:

```html
https://www.example.com/index.php redirects to https://www.example.com/
```

instead of having two exact same web pages:

```html
https://www.example.com/index.php
https://www.example.com/
```

Ok I found a coding error in October stopping the **mod-rewrite** functions from working!

I have removed part 3 from the `.HTaccess` and corrected the `server.php` file.

Ready for testing now!