### PR TITLE
Reduce discoverability of session cookie name and add RFC 6265 support

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -109,7 +109,10 @@ return [
     |
     */
 
-    'cookie' => 'october_session',
+    'cookie' => env(
+        'october_session',
+        Str::slug(env('APP_NAME', 'october'), '_').'_session'
+    ),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
While researching a different issue, I came across this post: https://github.com/laravel/laravel/pull/4305

Laravel link: https://github.com/laravel/laravel/blob/5.8/config/session.php#L127-L130

I leave this open for the admins to discuss and look deeper into this.