### PR TITLE
Initial WIP on implementing dependsOn support for filter scopes.

### DIFF
--- a/modules/backend/classes/FilterScope.php
+++ b/modules/backend/classes/FilterScope.php
@@ -52,6 +52,11 @@ class FilterScope
     public $options;
 
     /**
+     * @var array Other scope names this scope depends on, when the other scopes are modified, this scope will update.
+     */
+    public $dependsOn;
+
+    /**
      * @var string Specifies contextual visibility of this form scope.
      */
     public $context;
@@ -113,33 +118,32 @@ class FilterScope
      */
     protected function evalConfig($config)
     {
-        if (isset($config['options'])) {
-            $this->options = $config['options'];
+        if ($config === null) {
+            $config = [];
         }
-        if (isset($config['context'])) {
-            $this->context = $config['context'];
+
+        /*
+         * Standard config:property values
+         */
+        $applyConfigValues = [
+            'options',
+            'dependsOn',
+            'context',
+            'default',
+            'conditions',
+            'scope',
+            'cssClass',
+            'nameFrom',
+            'descriptionFrom',
+            'disabled',
+        ];
+
+        foreach ($applyConfigValues as $value) {
+            if (array_key_exists($value, $config)) {
+                $this->{$value} = $config[$value];
+            }
         }
-        if (isset($config['default'])) {
-            $this->defaults = $config['default'];
-        }
-        if (isset($config['conditions'])) {
-            $this->conditions = $config['conditions'];
-        }
-        if (isset($config['scope'])) {
-            $this->scope = $config['scope'];
-        }
-        if (isset($config['cssClass'])) {
-            $this->cssClass = $config['cssClass'];
-        }
-        if (isset($config['nameFrom'])) {
-            $this->nameFrom = $config['nameFrom'];
-        }
-        if (isset($config['descriptionFrom'])) {
-            $this->descriptionFrom = $config['descriptionFrom'];
-        }
-        if (array_key_exists('disabled', $config)) {
-            $this->disabled = $config['disabled'];
-        }
+
         return $config;
     }
 

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -317,7 +317,7 @@ class Filter extends WidgetBase
         } else {
             // Ensure that only valid values are set on the current scope
             $active = $this->filterActiveOptions($activeKeys, $available);
-            $this->setScopeValue($scope, array_keys($active));
+            $this->setScopeValue($scope, $active);
         }
 
         return [
@@ -690,6 +690,15 @@ class Filter extends WidgetBase
         $this->defineFilterScopes();
 
         foreach ($this->allScopes as $scope) {
+            // Ensure that only valid values are set scopes of type: group
+            if ($scope->type === 'group') {
+                $activeKeys = $scope->value ? array_keys($scope->value) : [];
+                $available = $this->getAvailableOptions($scope);
+                $active = $this->filterActiveOptions($activeKeys, $available);
+                $value = !empty($active) ? $active : null;
+                $this->setScopeValue($scope, $value);
+            }
+
             $this->applyScopeToQuery($scope, $query);
         }
 
@@ -831,6 +840,10 @@ class Filter extends WidgetBase
 
             default:
                 $value = is_array($scope->value) ? array_keys($scope->value) : $scope->value;
+
+                if (empty($value)) {
+                    break;
+                }
 
                 /*
                  * Condition

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -667,16 +667,6 @@ class Filter extends WidgetBase
         $scope = new FilterScope($name, $label);
         $scope->displayAs($scopeType, $config);
         $scope->idPrefix = $this->alias;
-
-        /*
-         * Set scope value
-         */
-        if ($scope->type === 'group') {
-
-        }
-
-
-
         $scope->value = $this->getScopeValue($scope, @$config['default']);
 
         return $scope;

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -667,6 +667,10 @@ class Filter extends WidgetBase
         $scope = new FilterScope($name, $label);
         $scope->displayAs($scopeType, $config);
         $scope->idPrefix = $this->alias;
+
+        /*
+         * Set scope value
+         */
         $scope->value = $this->getScopeValue($scope, @$config['default']);
 
         return $scope;

--- a/modules/backend/widgets/filter/partials/_scope_group.htm
+++ b/modules/backend/widgets/filter/partials/_scope_group.htm
@@ -2,7 +2,9 @@
 <a
     class="filter-scope <?= $scope->value ? 'active' : '' ?>"
     href="javascript:;"
-    data-scope-name="<?= $scope->scopeName ?>">
+    data-scope-name="<?= $scope->scopeName ?>"
+    <?php if ($depends = $this->getScopeDepends($scope)): ?>data-scope-depends="<?= $depends ?>"<?php endif ?>
+>
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
     <span class="filter-setting"><?= $scope->value ? count($scope->value) : e(trans('backend::lang.filter.all')) ?></span>
 </a>

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -221,8 +221,27 @@
         this.dependantUpdateTimers[scopeName] = window.setTimeout(function() {
             $.each(toRefresh.scopes, function (index, dependantScope) {
                 self.scopeValues[dependantScope] = null
+                var $scope = self.$el.find('[data-scope-name="'+dependantScope+'"]')
+
+                /*
+                 * Request options from server
+                 */
+                self.$el.request(self.options.optionsHandler, {
+                    data: { scopeName: dependantScope },
+                    success: function(data) {
+                        self.fillOptions(dependantScope, data.options)
+                        self.updateScopeSetting($scope, data.options.active.length)
+                        $scope.loadIndicator('hide')
+                    }
+                })
             })
         }, this.dependantUpdateInterval)
+
+        $.each(toRefresh.scopes, function(index, scope) {
+            scopeElements.filter('[data-scope-name="'+scope+'"]')
+                .addClass('loading-indicator-container')
+                .loadIndicator()
+        })
     }
 
     FilterWidget.prototype.focusSearch = function() {

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -19,7 +19,6 @@
 +function ($) { "use strict";
 
     var FilterWidget = function (element, options) {
-
         this.$el = $(element);
 
         this.options = options || {}
@@ -27,6 +26,12 @@
         this.$activeScope = null
         this.activeScopeName = null
         this.isActiveScopeDirty = false
+
+        /*
+         * Throttle dependency updating
+         */
+        this.dependantUpdateInterval = 300
+        this.dependantUpdateTimers = {}
 
         this.init()
     }
@@ -89,6 +94,9 @@
     FilterWidget.prototype.init = function() {
         var self = this
 
+        this.bindDependants()
+
+        // Setup event handler on type: checkbox scopes
         this.$el.on('change', '.filter-scope input[type="checkbox"]', function(){
             var $scope = $(this).closest('.filter-scope')
 
@@ -100,12 +108,14 @@
             }
         })
 
+        // Apply classes to type: checkbox scopes that are active from the server
         $('.filter-scope input[type="checkbox"]', this.$el).each(function() {
             $(this)
                 .closest('.filter-scope')
                 .toggleClass('active', $(this).is(':checked'))
         })
 
+        // Setup click handler on type: group scopes
         this.$el.on('click', 'a.filter-scope', function(){
             var $scope = $(this),
                 scopeName = $scope.data('scope-name')
@@ -120,6 +130,7 @@
             $scope.addClass('filter-scope-open')
         })
 
+        // Setup event handlers on type: group scopes' controls
         this.$el.on('show.oc.popover', 'a.filter-scope', function(event){
             self.focusSearch()
 
@@ -144,9 +155,9 @@
                 e.preventDefault()
                 self.filterScope(true)
             })
-
         })
 
+        // Setup event handler to apply selected options when closing the type: group scope popup
         this.$el.on('hide.oc.popover', 'a.filter-scope', function(){
             var $scope = $(this)
             self.pushOptions(self.activeScopeName)
@@ -156,6 +167,62 @@
             // Second click closes the filter scope
             setTimeout(function() { $scope.removeClass('filter-scope-open') }, 200)
         })
+    }
+
+    /*
+     * Bind dependant scopes
+     */
+    FilterWidget.prototype.bindDependants = function() {
+        if (!$('[data-scope-depends]', this.$el).length) {
+            return;
+        }
+
+        var self = this,
+            scopeMap = {},
+            scopeElements = this.$el.find('.filter-scope')
+
+        /*
+         * Map master and slave scope
+         */
+        scopeElements.filter('[data-scope-depends]').each(function() {
+            var name = $(this).data('scope-name'),
+                depends = $(this).data('scope-depends')
+
+            $.each(depends, function(index, depend){
+                if (!scopeMap[depend]) {
+                    scopeMap[depend] = { scopes: [] }
+                }
+
+                scopeMap[depend].scopes.push(name)
+            })
+        })
+
+        /*
+         * When a master is updated, refresh its slaves
+         */
+        $.each(scopeMap, function(scopeName, toRefresh){
+            scopeElements.filter('[data-scope-name="'+scopeName+'"]')
+                .on('change.oc.filterScope', $.proxy(self.onRefreshDependants, self, scopeName, toRefresh))
+        })
+    }
+
+    /*
+     * Refresh a dependancy scope
+     * Uses a throttle to prevent duplicate calls and click spamming
+     */
+    FilterWidget.prototype.onRefreshDependants = function(scopeName, toRefresh) {
+        var self = this,
+            scopeElements = this.$el.find('.filter-scope')
+
+        if (this.dependantUpdateTimers[scopeName] !== undefined) {
+            window.clearTimeout(this.dependantUpdateTimers[scopeName])
+        }
+
+        this.dependantUpdateTimers[scopeName] = window.setTimeout(function() {
+            $.each(toRefresh.scopes, function (index, dependantScope) {
+                self.scopeValues[dependantScope] = null
+            })
+        }, this.dependantUpdateInterval)
     }
 
     FilterWidget.prototype.focusSearch = function() {
@@ -369,7 +436,7 @@
         var items = $('#controlFilterPopover .filter-active-items > ul'),
             buttonContainer = $('#controlFilterPopover .filter-buttons')
 
-        if(data) {
+        if (data) {
             data.active.length > 0 ? buttonContainer.show() : buttonContainer.hide()
         } else {
             items.children().length > 0 ? buttonContainer.show() : buttonContainer.hide()
@@ -383,16 +450,21 @@
         if (!this.isActiveScopeDirty || !this.options.updateHandler)
             return
 
-        var data = {
+        var self = this,
+            data = {
                 scopeName: scopeName,
                 options: this.scopeValues[scopeName]
             }
 
         $.oc.stripeLoadIndicator.show()
+
         this.$el.request(this.options.updateHandler, {
             data: data
-        }).always(function(){
+        }).always(function () {
             $.oc.stripeLoadIndicator.hide()
+        }).done(function () {
+            // Trigger dependsOn updates on successful requests
+            self.$el.find('[data-scope-name="'+scopeName+'"]').trigger('change.oc.filterScope')
         })
     }
 

--- a/modules/system/assets/ui/less/filter.less
+++ b/modules/system/assets/ui/less/filter.less
@@ -55,6 +55,27 @@
             .transition(color 0.6s);
         }
 
+        &.loading-indicator-container.in-progress {
+            pointer-events: none;
+            cursor: default;
+
+            .loading-indicator {
+                background: transparent;
+
+                > span {
+                    left: unset;
+                    right: 0;
+                    top: 10px;
+                    background-color: @color-filter-bg;
+                    border-radius: 50%;
+                    margin-top: 0;
+                    width: 20px;
+                    height: 20px;
+                    background-size: 15px 15px;
+                }
+            }
+        }
+
         &:after {
             font-size: 14px;
             .icon(@angle-down);

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4786,6 +4786,9 @@ ul.autocomplete.dropdown-menu.inspector-autocomplete li a {padding:5px 12px;whit
 .control-filter >.filter-scope {display:inline-block;padding:10px}
 .control-filter >.filter-scope .filter-label {margin-right:5px}
 .control-filter >.filter-scope .filter-setting {display:inline-block;margin-right:5px;-webkit-transition:color 0.6s;transition:color 0.6s}
+.control-filter >.filter-scope.loading-indicator-container.in-progress {pointer-events:none;cursor:default}
+.control-filter >.filter-scope.loading-indicator-container.in-progress .loading-indicator {background:transparent}
+.control-filter >.filter-scope.loading-indicator-container.in-progress .loading-indicator >span {left:unset;right:0;top:10px;background-color:#ecf0f1;border-radius:50%;margin-top:0;width:20px;height:20px;background-size:15px 15px}
 .control-filter >.filter-scope:after {font-size:14px;font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f107"}
 .control-filter >.filter-scope.active .filter-setting {padding-left:5px;padding-right:5px;color:#FFF;background-color:#6aab55;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-transition:color 1s,background-color 1s;transition:color 1s,background-color 1s}
 .control-filter >.filter-scope.checkbox {padding-left:35px}


### PR DESCRIPTION
Still need to resolve an issue where if the slave filter has values set when the master filter updates, thus triggering a change of the available options to the slave, the original values are still set on the slave but not actually visible in the popup as options because they're no longer valid options. To fix this we'll need the ability to get the browser to refresh the slave filter's selected values (count icon basically since it already forces the options popup to refresh) when its masters update; while at the same rechecking the slave's scope values set on the server to ensure that they're all valid and there aren't values left over from the previous request that are no longer valid but are still being applied to the query.