### PR TITLE
Turn on redirects with HTTPS and also suggest to use HSTS with HTTPS

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,8 +15,15 @@
     ##
     ## Uncomment following lines to force HTTPS.
     ##
-    # RewriteCond %{HTTPS} off
-    # RewriteRule (.*) https://%{SERVER_NAME}/$1 [R,L]
+    # RewriteCond %{HTTPS} !=on
+    # RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+    ##
+    ## Uncomment following lines, turn on HSTS when using HTTPS.
+    ##
+    # <IfModule mod_headers.c>
+    #     # Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" env=HTTPS
+    # </IfModule>
 
     ##
     ## Black listed folders

--- a/.htaccess
+++ b/.htaccess
@@ -11,19 +11,6 @@
     ## if you have installed to a subdirectory, enter the name here also.
     ##
     # RewriteBase /
-    
-    ##
-    ## Uncomment following lines to force HTTPS.
-    ##
-    # RewriteCond %{HTTPS} !=on
-    # RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-
-    ##
-    ## Uncomment following lines, turn on HSTS when using HTTPS.
-    ##
-    # <IfModule mod_headers.c>
-    #     Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" env=HTTPS
-    # </IfModule>
 
     ##
     ## Black listed folders

--- a/.htaccess
+++ b/.htaccess
@@ -22,7 +22,7 @@
     ## Uncomment following lines, turn on HSTS when using HTTPS.
     ##
     # <IfModule mod_headers.c>
-    #     # Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" env=HTTPS
+    #     Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" env=HTTPS
     # </IfModule>
 
     ##


### PR DESCRIPTION
This pr does two things:

1. Instead of blocking HTTP, the website should 301 redirect a user or bot from HTTP to HTTPS.

2. When you use HTTPS you should be using HSTS at the same time, otherwise you allow hackers to bypass HTTPS.

### What is HSTS?

HTTP Strict Transport Security (HSTS) is a web server directive that informs user agents and web browsers how to handle its connection through a response header sent at the very beginning and back to the browser.

This sets the Strict-Transport-Security policy field parameter. It forces those connections over HTTPS encryption, disregarding any script's call to load any resource in that domain over HTTP. HSTS is but one arrow in a bundled sheaf of security settings for your web server or your web hosting service.

### Why Should Your Company Implement HSTS?

You never close your physical store or home without locking the doors, right? You may even have metal detectors at the door to control shrinkage. Data can be just as valuable as physical items in your shop or house, so it’s just as important to keep them locked up and secure. Padlocking your website is sometimes not enough as people will still find a way to reach your website over http://. HSTS forces browsers and app connections to use HTTPS if that is available. Even if someone just types in the www or http://.