### PR TITLE
Add missing documentation comment blocks for fired events

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -242,8 +242,22 @@ class Controller extends ControllerBase
             }
         }
 
-        /*
-         * Extensibility
+        /**
+         * @event backend.page.beforeDisplay
+         * Called before the backend page is displayed
+         *
+         * Example usage:
+         *
+         *     Event::listen('backend.page.beforeDisplay', function ((\Backend\Classes\Controller) $backendController, (string) $action, (array) $param) {
+         *         // your code here
+         *     });
+         *
+         * Or
+         *
+         *     $backendController->bindEvent('page.beforeDisplay', function ((string) $action, (array) $param) {
+         *         // your code here
+         *     });
+         *
          */
         if ($event = $this->fireSystemEvent('backend.page.beforeDisplay', [$action, $params])) {
             return $event;

--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -255,7 +255,7 @@ class Controller extends ControllerBase
          *
          * Or
          *
-         *     $backendController->bindEvent('page.beforeDisplay', function ((string) $action, (array) $param) {
+         *     $backendController->bindEvent('page.beforeDisplay', function ((string) $action, (array) $params) {
          *         trace_log('redirect all backend pages to google');
          *         return \Redirect::to('https://google.com');
          *     });

--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -248,7 +248,7 @@ class Controller extends ControllerBase
          *
          * Example usage:
          *
-         *     Event::listen('backend.page.beforeDisplay', function ((\Backend\Classes\Controller) $backendController, (string) $action, (array) $param) {
+         *     Event::listen('backend.page.beforeDisplay', function ((\Backend\Classes\Controller) $backendController, (string) $action, (array) $params) {
          *         trace_log('redirect all backend pages to google');
          *         return \Redirect::to('https://google.com');
          *     });

--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -244,18 +244,20 @@ class Controller extends ControllerBase
 
         /**
          * @event backend.page.beforeDisplay
-         * Called before the backend page is displayed
+         * Provides an opportunity to override backend page content
          *
          * Example usage:
          *
          *     Event::listen('backend.page.beforeDisplay', function ((\Backend\Classes\Controller) $backendController, (string) $action, (array) $param) {
-         *         // your code here
+         *         trace_log('redirect all backend pages to google');
+         *         return \Redirect::to('https://google.com');
          *     });
          *
          * Or
          *
          *     $backendController->bindEvent('page.beforeDisplay', function ((string) $action, (array) $param) {
-         *         // your code here
+         *         trace_log('redirect all backend pages to google');
+         *         return \Redirect::to('https://google.com');
          *     });
          *
          */

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -100,8 +100,18 @@ class NavigationManager
             $this->registerMenuItems($id, $items);
         }
 
-        /*
-         * Extensibility
+        /**
+         * @event backend.menu.extendItems
+         * Provides an opportunity to add more menu items
+         *
+         * Example usage:
+         *
+         *     Event::listen('backend.menu.extendItems', function ((\Backend\Classes\NavigationManager) $navigationManager) {
+         *         $navigationManager->addMainMenuItems(...)
+         *         $navigationManager->addSideMenuItems(...)
+         *         $navigationManager->removeMainMenuItem(...)
+         *     });
+         *
          */
         Event::fire('backend.menu.extendItems', [$this]);
 

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -102,7 +102,7 @@ class NavigationManager
 
         /**
          * @event backend.menu.extendItems
-         * Provides an opportunity to add more menu items
+         * Provides an opportunity to manipulate the backend navigation
          *
          * Example usage:
          *

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -143,7 +143,7 @@ class User extends UserBase
          * Example usage:
          *
          *     Event::listen('backend.user.login', function ((\Backend\Models\User) $user) {
-         *         // your code here
+         *         Flash::success(sprintf('Welcome %s!', $user->getFullNameAttribute()));
          *     });
          *
          */

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -136,6 +136,7 @@ class User extends UserBase
     public function afterLogin()
     {
         parent::afterLogin();
+
         /**
          * @event backend.user.login
          * Provides an opportunity to interact with the Backend User model after the user has logged in

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -136,6 +136,17 @@ class User extends UserBase
     public function afterLogin()
     {
         parent::afterLogin();
+        /**
+         * @event backend.user.login
+         * Provides an opportunity to interact with the Backend User model after the user has logged in
+         *
+         * Example usage:
+         *
+         *     Event::listen('backend.user.login', function ((\Backend\Models\User) $user) {
+         *         // your code here
+         *     });
+         *
+         */
         Event::fire('backend.user.login', [$this]);
     }
 

--- a/modules/backend/routes.php
+++ b/modules/backend/routes.php
@@ -4,8 +4,17 @@
  * Register Backend routes before all user routes.
  */
 App::before(function ($request) {
-    /*
-     * Extensibility
+
+    /**
+     * @event backend.beforeRoute
+     * Fires before backend routes get added
+     *
+     * Example usage:
+     *
+     *     Event::listen('backend.beforeRoute', function () {
+     *         // your code here
+     *     });
+     *
      */
     Event::fire('backend.beforeRoute');
 
@@ -25,8 +34,16 @@ App::before(function ($request) {
      */
     Route::any(Config::get('cms.backendUri', 'backend'), 'Backend\Classes\BackendController@run')->middleware('web');
 
-    /*
-     * Extensibility
+    /**
+     * @event backend.route
+     * Fires after backend routes have been added
+     *
+     * Example usage:
+     *
+     *     Event::listen('backend.route', function () {
+     *         // your code here
+     *     });
+     *
      */
     Event::fire('backend.route');
 });

--- a/modules/cms/routes.php
+++ b/modules/cms/routes.php
@@ -4,8 +4,17 @@
  * Register CMS routes before all user routes.
  */
 App::before(function ($request) {
-    /*
-     * Extensibility
+
+    /**
+     * @event cms.beforeRoute
+     * Fires before cms routes get added
+     *
+     * Example usage:
+     *
+     *     Event::listen('cms.beforeRoute', function () {
+     *         // your code here
+     *     });
+     *
      */
     Event::fire('cms.beforeRoute');
 
@@ -15,8 +24,16 @@ App::before(function ($request) {
      */
     Route::any('{slug}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?')->middleware('web');
 
-    /*
-     * Extensibility
+    /**
+     * @event cms.route
+     * Fires after cms routes get added
+     *
+     * Example usage:
+     *
+     *     Event::listen('cms.route', function () {
+     *         // your code here
+     *     });
+     *
      */
     Event::fire('cms.route');
 });

--- a/modules/cms/twig/Extension.php
+++ b/modules/cms/twig/Extension.php
@@ -193,6 +193,19 @@ class Extension extends TwigExtension
             return $default;
         }
 
+        /**
+         * @event cms.block.render
+         * Provides an opportunity to modify the rendered block content
+         *
+         * Example usage:
+         *
+         *     Event::listen('cms.block.render', function ((string) $name, (string) $result) {
+         *         if ($name === 'myBlockName') {
+         *             return 'my custom content';
+         *         }
+         *     });
+         *
+         */
         if ($event = Event::fire('cms.block.render', [$name, $result], true)) {
             $result = $event;
         }

--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -411,8 +411,16 @@ class CombineAssets
      */
     protected function prepareCombiner(array $assets, $rewritePath = null)
     {
-        /*
-         * Extensibility
+        /**
+         * @event cms.combiner.beforePrepare
+         * Provides an opportunity to interact with the asset combiner before assets are combined
+         *
+         * Example usage:
+         *
+         *     Event::listen('cms.combiner.beforePrepare', function ((\System\Classes\CombineAssets) $assetCombiner, (array) $assets) {
+         *         $assetCombiner->registerFilter(...)
+         *     });
+         *
          */
         Event::fire('cms.combiner.beforePrepare', [$this, $assets]);
 
@@ -809,10 +817,19 @@ class CombineAssets
             $cacheKey .= $this->getDeepHashFromAssets($assets);
         }
 
-        /*
-         * Extensibility
-         */
         $dataHolder = (object) ['key' => $cacheKey];
+
+        /**
+         * @event cms.combiner.getCacheKey
+         * Provides an opportunity to modify the $dataHolder->key property in place
+         *
+         * Example usage:
+         *
+         *     Event::listen('cms.combiner.getCacheKey', function ((\System\Classes\CombineAssets) $assetCombiner, (stdClass) $dataHolder) {
+         *         $dataHolder->key = rand();
+         *     });
+         *
+         */
         Event::fire('cms.combiner.getCacheKey', [$this, $dataHolder]);
         $cacheKey = $dataHolder->key;
 

--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -821,7 +821,7 @@ class CombineAssets
 
         /**
          * @event cms.combiner.getCacheKey
-         * Provides an opportunity to modify the $dataHolder->key property in place
+         * Provides an opportunity to modify the asset combiner's cache key
          *
          * Example usage:
          *

--- a/modules/system/classes/SettingsManager.php
+++ b/modules/system/classes/SettingsManager.php
@@ -111,7 +111,7 @@ class SettingsManager
 
         /**
          * @event system.settings.extendItems
-         * Provides an opportunity to add interact with the system settings manager
+         * Provides an opportunity to manipulate the system settings manager
          *
          * Example usage:
          *

--- a/modules/system/classes/SettingsManager.php
+++ b/modules/system/classes/SettingsManager.php
@@ -115,7 +115,7 @@ class SettingsManager
          *
          * Example usage:
          *
-         *     Event::listen(system.settings.extendItems', function ((\System\Classes\SettingsManager) $settingsManager) {
+         *     Event::listen('system.settings.extendItems', function ((\System\Classes\SettingsManager) $settingsManager) {
          *         $settingsManager->addSettingItem(...)
          *         $settingsManager->removeSettingItem(...)
          *     });

--- a/modules/system/classes/SettingsManager.php
+++ b/modules/system/classes/SettingsManager.php
@@ -109,8 +109,17 @@ class SettingsManager
             $this->registerSettingItems($id, $items);
         }
 
-        /*
-         * Extensibility
+        /**
+         * @event system.settings.extendItems
+         * Provides an opportunity to add interact with the system settings manager
+         *
+         * Example usage:
+         *
+         *     Event::listen(system.settings.extendItems', function ((\System\Classes\SettingsManager) $settingsManager) {
+         *         $settingsManager->addSettingItem(...)
+         *         $settingsManager->removeSettingItem(...)
+         *     });
+         *
          */
         Event::fire('system.settings.extendItems', [$this]);
 

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -67,8 +67,16 @@ trait ConfigMaker
 
             $config = Yaml::parseFile($configFile);
 
-            /*
-             * Extensibility
+            /**
+             * @event system.extendConfigFile
+             * Provides an opportunity to modify config files
+             *
+             * Example usage:
+             *
+             *     Event::listen('system.extendConfigFile', function ((File) $publicFile, (array) $config) {
+             *         // your code here
+             *     });
+             *
              */
             $publicFile = File::localToPublic($configFile);
             if ($results = Event::fire('system.extendConfigFile', [$publicFile, $config])) {

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -74,7 +74,7 @@ trait ConfigMaker
              * Example usage:
              *
              *     Event::listen('system.extendConfigFile', function ((string) $path, (array) $config) {
-             *         if ($publicFile === '/plugins/author/plugin-name/controllers/mycontroller/config_relation.yaml') {
+             *         if ($path === '/plugins/author/plugin-name/controllers/mycontroller/config_relation.yaml') {
              *             unset($config['property_value']['view']['recordUrl']);
              *             return $config;
              *         }

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -74,7 +74,10 @@ trait ConfigMaker
              * Example usage:
              *
              *     Event::listen('system.extendConfigFile', function ((File) $publicFile, (array) $config) {
-             *         // your code here
+             *         if ($publicFile === '/plugins/author/plugin-name/controllers/mycontroller/config_relation.yaml') {
+             *             unset($config['property_value']['view']['recordUrl']);
+             *             return $config;
+             *         }
              *     });
              *
              */

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -73,7 +73,7 @@ trait ConfigMaker
              *
              * Example usage:
              *
-             *     Event::listen('system.extendConfigFile', function ((File) $publicFile, (array) $config) {
+             *     Event::listen('system.extendConfigFile', function ((string) $path, (array) $config) {
              *         if ($publicFile === '/plugins/author/plugin-name/controllers/mycontroller/config_relation.yaml') {
              *             unset($config['property_value']['view']['recordUrl']);
              *             return $config;


### PR DESCRIPTION
- most of the examples have a generic "// your code here" in the event handler examples for now, feel free to help with this.