### PR TITLE
Only put sortOptions to the session if the List query succeeded

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1496,14 +1496,20 @@ class Lists extends WidgetBase
 
             $this->sortColumn = $sortOptions['column'] = $column;
 
-            $this->putSession('sort', $sortOptions);
-
             /*
              * Persist the page number
              */
             $this->currentPageNumber = post('page');
 
-            return $this->onRefresh();
+            /*
+             * Try to refresh the list with the new sortOptions. Put the
+             * new sortOptions in to the session if the query succeeded.
+             */
+            $result = $this->onRefresh();
+
+            $this->putSession('sort', $sortOptions);
+
+            return $result;
         }
     }
 


### PR DESCRIPTION
It happens that you specify a column in your `columns.yaml`, that is not actually a sortable database column (like a partial or relation). If you don't explicitly set `sortable` to `false` for it, an end-user might try to sort by this column.

This will trigger a `QueryException` like `Unknown column 'unsortable' in 'order clause'`.

These new sort options are persisted in to the session data. This results in users locking themselves out of a page since the invalid sort options are applied now on every page refresh, triggering an Exception.

This PR delays the `putSession` call so it only happens once the `onRefresh` handler was executed successfully and did not throw an Exception.