### PR TITLE
register cms twig environment

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -621,6 +621,13 @@ class Controller
         if ($isDebugMode) {
             $this->twig->addExtension(new DebugExtension($this));
         }
+
+        /*
+         * Register CMS Twig environment
+         */
+        App::singleton('twig.environment', function ($app) {
+            return $this->twig;
+        });
     }
 
     /**


### PR DESCRIPTION
One can now use `App::get('twig.environment')` to get CMS twig environment.