### PR TITLE
Invalid security token issue - Service worker September 2019 update to spec

### DIFF
--- a/modules/backend/layouts/_head.htm
+++ b/modules/backend/layouts/_head.htm
@@ -56,7 +56,7 @@
         /* Only run on HTTPS connections
          * Block off Front-end Service Worker from running in the Backend allowing security injections, see GitHub #4384
          */
-        if (location.protocol === 'https:') {
+        if ((location.protocol === 'https:') && ('serviceWorker' in navigator)) {
             // Unregister all service workers before signing in to prevent cache issues, see github issue: #3707
             navigator.serviceWorker.getRegistrations().then(
                 function(registrations) {

--- a/modules/backend/layouts/_head.htm
+++ b/modules/backend/layouts/_head.htm
@@ -61,7 +61,7 @@
             navigator.serviceWorker.getRegistrations().then(
                 function(registrations) {
                     for (let registration of registrations) {
-                        registration.unregister();
+                        registration.unregister({ immediate: true });
                     }
                 }
             );

--- a/modules/backend/layouts/auth.htm
+++ b/modules/backend/layouts/auth.htm
@@ -48,7 +48,7 @@
                     navigator.serviceWorker.getRegistrations().then(
                         function(registrations) {
                             for (let registration of registrations) {
-                                registration.unregister();
+                                registration.unregister({ immediate: true });
                             }
                         }
                     );

--- a/modules/backend/layouts/auth.htm
+++ b/modules/backend/layouts/auth.htm
@@ -43,7 +43,7 @@
                 /* Only run on HTTPS connections
                 * Block off Front-end Service Worker from running in the Backend allowing security injections, see GitHub #4384
                 */
-                if (location.protocol === 'https:') {
+                if ((location.protocol === 'https:') && ('serviceWorker' in navigator)) {
                     // Unregister all service workers before signing in to prevent cache issues, see github issue: #3707
                     navigator.serviceWorker.getRegistrations().then(
                         function(registrations) {


### PR DESCRIPTION
I previously wrote some code to uninstall a service worker when you try to login to the backend of the cms. It was important to turn off the service worker as it created a caching issue and produced "Invalid security token" messages.

However, there was always a problem with the service worker spec, the old spec does this: If you unregister a service worker, the registration is removed from the list of registrations, **_but it continues to control existing pages_** and this continued to cause issues with October using a service worker and trying to login to the backend.

The new update to the spec now fixes this issue! If you unregister a service worker registration it's removed from the list of registrations and **_stops controlling the existing pages_**! This means when you now open the backend `auth.htm` file the service worker will be completely removed and the cached properly cleared now! 

Horray! 👍 

To admin's if you don't understand this please ask me. This is a really important fix.
