### PR TITLE
Fixed DataTable dropdowns in Modals

### DIFF
--- a/modules/backend/widgets/table/assets/js/build-min.js
+++ b/modules/backend/widgets/table/assets/js/build-min.js
@@ -871,7 +871,8 @@ return cachingKey}
 DropdownProcessor.prototype.getAbsolutePosition=function(element){var top=document.body.scrollTop,left=0
 do{top+=element.offsetTop||0;top-=element.scrollTop||0;left+=element.offsetLeft||0;element=element.offsetParent;}while(element)
 return{top:top,left:left}}
-DropdownProcessor.prototype.updateCellFromFocusedItem=function(){var focusedItem=this.findFocusedItem();this.setSelectedItem(focusedItem);}
+DropdownProcessor.prototype.updateCellFromFocusedItem=function(focusedItem){if(!focusedItem){focusedItem=this.findFocusedItem();}
+this.setSelectedItem(focusedItem);}
 DropdownProcessor.prototype.findSelectedItem=function(){if(this.itemListElement)
 return this.itemListElement.querySelector('ul li.selected')
 return null}
@@ -883,7 +884,7 @@ DropdownProcessor.prototype.findFocusedItem=function(){if(this.itemListElement)
 return this.itemListElement.querySelector('ul li:focus')
 return null}
 DropdownProcessor.prototype.onItemClick=function(ev){var target=this.tableObj.getEventTarget(ev)
-if(target.tagName=='LI'){target.focus();this.updateCellFromFocusedItem()
+if(target.tagName=='LI'){target.focus();this.updateCellFromFocusedItem(target)
 this.hideDropdown()}}
 DropdownProcessor.prototype.onItemKeyDown=function(ev){if(!this.itemListElement)
 return

--- a/modules/backend/widgets/table/assets/js/table.processor.dropdown.js
+++ b/modules/backend/widgets/table/assets/js/table.processor.dropdown.js
@@ -270,8 +270,10 @@
         }
     }
 
-    DropdownProcessor.prototype.updateCellFromFocusedItem = function() {
-        var focusedItem = this.findFocusedItem();
+    DropdownProcessor.prototype.updateCellFromFocusedItem = function(focusedItem) {
+        if (!focusedItem) {
+            focusedItem = this.findFocusedItem();
+        }
         this.setSelectedItem(focusedItem);
     }
 
@@ -309,7 +311,7 @@
 
         if (target.tagName == 'LI') {
             target.focus();
-            this.updateCellFromFocusedItem()
+            this.updateCellFromFocusedItem(target)
             this.hideDropdown()
         }
     }


### PR DESCRIPTION
This is a minor bug I encountered when using the DataTable widget in a modal.

The dropdown inside the datatable uses some strange `:focus` selectors to pass along the selected dropdown value.

When the DataTable is inside the modal, it seems like the modal itself is stealing the focus. I figured this out by logging the focused element to the console, immediately after the `.focus()` call in the `onItemClick` handler:

```js
    DropdownProcessor.prototype.onItemClick = function(ev) {
        var target = this.tableObj.getEventTarget(ev)

        if (target.tagName == 'LI') {
            target.focus();
            console.log(document.querySelectorAll(':focus'))
            this.updateCellFromFocusedItem()
            this.hideDropdown()
        }
    }
```

As you can see in this GIF, the `li` is not focused correctly. It works as long as the DataTable is not inside the modal.

![popup](https://user-images.githubusercontent.com/8600029/70332514-04766e80-1842-11ea-8ffa-ef55a7145468.gif)


The easiest workaround for this problem is to pass along the target element explicitly since it is already known in this case. I'm aware that this is not solving the actual problem but it seems to be a reasonble fix that prevents bigger changes to this component.

You can reproduce this bug using my fork of the test plugin (Playground -> People -> Show DataTable):

https://github.com/OFFLINE-GmbH/test-plugin/tree/database-dropdown-bug

https://github.com/OFFLINE-GmbH/test-plugin/commit/3faa07513c3e2c8cb063f76c841ecd0181f8f2bc

