### PR TITLE
Fix type compair

### DIFF
--- a/modules/system/assets/ui/js/inspector.editor.set.js
+++ b/modules/system/assets/ui/js/inspector.editor.set.js
@@ -304,8 +304,13 @@
         if (!value) {
             return false
         }
-
-        return value.indexOf(checkboxValue) > -1
+        /**
+         * Fix to getting set list. Needed for comonent property type support
+         * from: value.indexOf(checkboxValue) > -1
+         * to:  value.indexOf(checkboxValue.toString()) > -1
+         * 2019-12-07
+         */
+        return value.indexOf(checkboxValue.toString()) > -1
     }
 
     SetEditor.prototype.setPropertyValue = function(checkboxValue, isChecked) {
@@ -327,7 +332,13 @@
             items = this.getItemsSource()
             
         for (var itemValue in items) {
-            if (itemValue !== checkboxValue) {
+            /**
+             * Fix to adding set list. Needed for component property type support
+             * from: if (itemValue !== checkboxValue) {
+             * to:  if (itemValue.toString() !== checkboxValue.toString()) {
+             * 2019-12-07
+             */
+            if (itemValue.toString() !== checkboxValue.toString()) {
                 if (currentValue.indexOf(itemValue) !== -1) {
                     resultValue.push(itemValue)
                 }


### PR DESCRIPTION
Fix component property type supporting. Types in list not same as searched value

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->