### PR TITLE
Remove JS layout calculations of the backend navbar by using flexbox

### DIFF
--- a/modules/backend/assets/css/october.css
+++ b/modules/backend/assets/css/october.css
@@ -660,7 +660,7 @@ ul.mainmenu-nav li {}
 ul.mainmenu-nav li .svg-icon {-webkit-backface-visibility:hidden;backface-visibility:hidden}
 ul.mainmenu-nav li span.counter {display:block;position:absolute;top:.143em;right:0;padding:.143em .429em .214em .286em;background-color:#d9350f;color:#fff;font-size:.786em;line-height:100%;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;opacity:1;filter:alpha(opacity=100);-webkit-transform:scale(1,);-ms-transform:scale(1,);transform:scale(1,);-webkit-transition:all 0.3s;transition:all 0.3s}
 ul.mainmenu-nav li span.counter.empty {opacity:0;filter:alpha(opacity=0);-webkit-transform:scale(0,);-ms-transform:scale(0,);transform:scale(0,)}
-nav#layout-mainmenu {background-color:#000;padding:0 0 0 20px;line-height:0;white-space:nowrap;vertical-align:top}
+nav#layout-mainmenu {background-color:#000;padding:0 0 0 20px;line-height:0;white-space:nowrap;display:flex}
 nav#layout-mainmenu a {text-decoration:none}
 nav#layout-mainmenu a:focus {background:transparent}
 nav#layout-mainmenu ul {margin:0;padding:0;list-style:none;float:left;white-space:nowrap;overflow:hidden}
@@ -672,7 +672,8 @@ nav#layout-mainmenu ul li a:focus {text-decoration:none;color:rgba(255,255,255,0
 nav#layout-mainmenu ul li a i {line-height:1;font-size:30px;vertical-align:middle}
 nav#layout-mainmenu ul li a img.svg-icon {height:30px;width:30px;margin-right:10px;position:relative;top:0}
 nav#layout-mainmenu ul.nav {display:inline-block}
-nav#layout-mainmenu .toolbar-item {padding-right:0}
+nav#layout-mainmenu .toolbar-item {flex:1 1 auto;display:block;padding-right:0;overflow:hidden}
+nav#layout-mainmenu .toolbar-item-account {flex:0 0 auto}
 nav#layout-mainmenu .toolbar-item:before,
 nav#layout-mainmenu .toolbar-item:after {margin-top:0}
 nav#layout-mainmenu .toolbar-item:before {left:-12px}

--- a/modules/backend/assets/js/october-min.js
+++ b/modules/backend/assets/js/october-min.js
@@ -760,8 +760,8 @@ return this}}(window.jQuery);(function($){$(document).ready(function(){$('nav.na
 navbar=$(this),nav=$('ul.nav',navbar),collapseMode=navbar.hasClass('navbar-mode-collapse'),isMobile=$('html').hasClass('mobile')
 nav.verticalMenu($('a.menu-toggle',navbar),{breakpoint:collapseMode?Infinity:769})
 $('li.with-tooltip:not(.active) > a',navbar).tooltip({container:'body',placement:'bottom',template:'<div class="tooltip mainmenu-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'}).on('show.bs.tooltip',function(e){if(isMobile)e.preventDefault()})
-$('[data-calculate-width]',navbar).one('oc.widthFixed',function(){var dragScroll=$('[data-control=toolbar]',navbar).data('oc.dragScroll')
-if(dragScroll){dragScroll.goToElement($('ul.nav > li.active',navbar),undefined,{'duration':0})}})})})})(jQuery);+function($){"use strict";if($.oc===undefined)
+var dragScroll=$('[data-control=toolbar]',navbar).data('oc.dragScroll')
+if(dragScroll){dragScroll.goToElement($('ul.nav > li.active',navbar),undefined,{'duration':0})}})})})(jQuery);+function($){"use strict";if($.oc===undefined)
 $.oc={}
 var SideNav=function(element,options){this.options=options
 this.$el=$(element)

--- a/modules/backend/assets/js/october.navbar.js
+++ b/modules/backend/assets/js/october.navbar.js
@@ -31,12 +31,11 @@
                 if (isMobile) e.preventDefault()
             })
 
-            $('[data-calculate-width]', navbar).one('oc.widthFixed', function() {
-                var dragScroll = $('[data-control=toolbar]', navbar).data('oc.dragScroll')
-                if (dragScroll) {
-                    dragScroll.goToElement($('ul.nav > li.active', navbar), undefined, {'duration': 0})
-                }
-            })
+            // Scroll to the currently active nav item.
+            var dragScroll = $('[data-control=toolbar]', navbar).data('oc.dragScroll')
+            if (dragScroll) {
+                dragScroll.goToElement($('ul.nav > li.active', navbar), undefined, {'duration': 0})
+            }
         })
     })
 })(jQuery);

--- a/modules/backend/assets/less/layout/mainmenu.less
+++ b/modules/backend/assets/less/layout/mainmenu.less
@@ -113,7 +113,7 @@ nav#layout-mainmenu {
     padding: 0 0 0 20px;
     line-height: 0;
     white-space: nowrap;
-    vertical-align: top;
+    display: flex;
 
     a {
         text-decoration: none;
@@ -158,6 +158,12 @@ nav#layout-mainmenu {
 
     .toolbar-item {
         padding-right: 0;
+        flex: 1 1 auto;
+        overflow: hidden;
+
+        &-account {
+            flex: 0 0 auto;
+        }
 
         &:before, &:after {
             margin-top: 0;

--- a/modules/backend/assets/less/layout/mainmenu.less
+++ b/modules/backend/assets/less/layout/mainmenu.less
@@ -157,8 +157,9 @@ nav#layout-mainmenu {
     }
 
     .toolbar-item {
-        padding-right: 0;
         flex: 1 1 auto;
+        display: block;
+        padding-right: 0;
         overflow: hidden;
 
         &-account {

--- a/modules/backend/layouts/_mainmenu.htm
+++ b/modules/backend/layouts/_mainmenu.htm
@@ -47,7 +47,7 @@
             </ul>
         </div>
     </div>
-    <div class="toolbar-item" data-calculate-width>
+    <div class="toolbar-item toolbar-item-account">
         <ul class="mainmenu-toolbar">
             <li class="mainmenu-preview with-tooltip">
                 <a


### PR DESCRIPTION
By using flexbox for the backend navbar, we can prevent the usage of the `data-calculate-width` helper which is run on every page load and visibly fixes the navbar:

#### Before

![before](https://user-images.githubusercontent.com/8600029/70425296-4802ef80-1a71-11ea-921e-65acb9990e8b.gif)

#### After

![after](https://user-images.githubusercontent.com/8600029/70425302-49341c80-1a71-11ea-9d7c-1309aefa9da4.gif)

* :heavy_check_mark: Drag scroll works 
* :heavy_check_mark: If the items overflow, the active item is scrolled into view
* :heavy_check_mark: Works in IE11

Let me know if I forgot a feature that needs testing!

As a side note: What is the current IE version October targets? There is [some `for .. of` code](https://github.com/octobercms/october/blob/882ca6019c9c1b124e6e3f052b6aec02b6fa826b/modules/backend/layouts/_head.htm#L63) in the backend that won't work in IE11:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#Browser_compatibility
