### PR TITLE
More strict checking of "add item" requests for child repeaters

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -98,7 +98,7 @@ class Repeater extends FormWidgetBase
     public function init()
     {
         $this->prompt = Lang::get('backend::lang.repeater.add_new_item');
-        
+
         $this->fillFromConfig([
             'form',
             'prompt',
@@ -404,15 +404,15 @@ class Repeater extends FormWidgetBase
         if ($this->alias === $widgetName) {
             // This repeater has made the AJAX request
             self::$onAddItemCalled = true;
-        } else if (strpos($widgetName, $this->alias) === 0) {
+        } else if (strpos($widgetName, $this->alias . 'Form') === 0) {
             // A child repeater has made the AJAX request
 
             // Get index from AJAX handler
             $handlerSuffix = str_replace($this->alias . 'Form', '', $widgetName);
-            preg_match('/^[0-9]+/', $handlerSuffix, $matches);
-
-            $this->childAddItemCalled = true;
-            $this->childIndexCalled = (int) $matches[0];
+            if (preg_match('/^[0-9]+/', $handlerSuffix, $matches)) {
+                $this->childAddItemCalled = true;
+                $this->childIndexCalled = (int) $matches[0];
+            }
         }
     }
 


### PR DESCRIPTION
Similarly named repeater fields being used in viewBag variables were being assigned aliases which succeeded the `strpos` check on [this line](https://github.com/octobercms/october/blob/master/modules/backend/formwidgets/Repeater.php#L390) of `modules/backend/formwidgets/Repeater.php`, causing an exception to be thrown when the next lines tried to retrieve an index. This will more clearly look for a child repeater form and index.

Fixes #4808.