### PR TITLE
Add option to set custom content type for cms page

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -252,6 +252,13 @@ class Controller
         }
 
         /*
+         * Apply custom content type header
+         */
+        if ($page->contentType) {
+            $this->setResponseHeader('Content-Type', $page->contentType);
+        }
+
+        /*
          * Prepare and return response
          * @see \System\Traits\ResponseMaker
          */

--- a/modules/cms/classes/page/fields.yaml
+++ b/modules/cms/classes/page/fields.yaml
@@ -43,6 +43,12 @@ tabs:
             type: dropdown
             options: getLayoutOptions
 
+        settings[contentType]:
+            tab: cms::lang.editor.settings
+            span: left
+            label: cms::lang.editor.contenttype
+            comment: cms::lang.editor.contenttype_comment
+
         settings[description]:
             tab: cms::lang.editor.settings
             label: cms::lang.editor.description

--- a/modules/cms/lang/en/lang.php
+++ b/modules/cms/lang/en/lang.php
@@ -194,6 +194,8 @@ return [
         'resetting' => 'Resetting',
         'commit_success' => 'The :type has been committed to the filesystem',
         'reset_success' => 'The :type has been reset to the filesystem version',
+        'contenttype' => 'Content Type',
+        'contenttype_comment' => 'If not set defaults to "text/html".'
     ],
     'asset' => [
         'menu_label' => 'Assets',

--- a/themes/demo/pages/test.htm
+++ b/themes/demo/pages/test.htm
@@ -1,0 +1,6 @@
+title = "test"
+url = "/test"
+contentType = "text/plain"
+is_hidden = 0
+==
+test

--- a/themes/demo/pages/test.htm
+++ b/themes/demo/pages/test.htm
@@ -1,6 +1,0 @@
-title = "test"
-url = "/test"
-contentType = "text/plain"
-is_hidden = 0
-==
-test


### PR DESCRIPTION
This adds option to set custom Content-Type header per CMS page. It allows to simplify job of creating dynamic robots.txt file (https://octobertricks.com/tricks/dynamic-robotstxt) or any other files that needs to be other content type then text/html.

![obrázok](https://user-images.githubusercontent.com/3110002/70513438-e8204d80-1b31-11ea-8e28-5ab7eee8c8fd.png)
