### PR TITLE
Fix saving of translations in relation controller by re-using the form widget's model

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1106,7 +1106,7 @@ class RelationController extends ControllerBehavior
             $this->relationObject->add($newModel, $sessionKey);
         }
         elseif ($this->viewMode == 'single') {
-            $newModel = $this->viewModel;
+            $newModel = $this->manageWidget->model;
             $this->viewWidget->setFormValues($saveData);
 
             /*

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1351,7 +1351,7 @@ class RelationController extends ControllerBehavior
         $this->beforeAjax();
 
         $foreignKeyName = $this->relationModel->getQualifiedKeyName();
-        $hydratedModel = $this->relationObject->where($foreignKeyName, $this->manageId)->first();
+        $hydratedModel = $this->pivotWidget->model;
         $saveData = $this->pivotWidget->getSaveData();
 
         $modelsToSave = $this->prepareModelsToSave($hydratedModel, $saveData);

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1150,6 +1150,8 @@ class RelationController extends ControllerBehavior
             }
         }
         elseif ($this->viewMode == 'single') {
+            $this->viewModel = $this->manageWidget->model;
+
             $this->viewWidget->setFormValues($saveData);
             $this->viewModel->save(null, $this->manageWidget->getSessionKey());
         }


### PR DESCRIPTION
This PR is an addition to https://github.com/octobercms/october/pull/4193

Re-using the pivotWidget's and manageWidget's models for saving form data fixes https://github.com/rainlab/translate-plugin/issues/209, where translations are not saved for the model when editing it in a relation widget.

I did some manual testing with this change and everything was working as expected: Translations are now properly saved when creating or editing related models with pivot data. Creating related models in `single` mode now works as well.

Credits to @alxy for his previous work on this issue!