### PR TITLE
Fix checkbox lists

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,3 +46,4 @@ $response = $kernel->handle(
 $response->send();
 
 $kernel->terminate($request, $response);
+//test

--- a/index.php
+++ b/index.php
@@ -46,4 +46,3 @@ $response = $kernel->handle(
 $response->send();
 
 $kernel->terminate($request, $response);
-//test

--- a/modules/system/assets/ui/less/form.base.less
+++ b/modules/system/assets/ui/less/form.base.less
@@ -197,7 +197,7 @@ input[type="date"] {
     display: block;
     min-height: @line-height-computed; // clear the floating input if there is no label text
     margin-top: 10px;
-    margin-bottom: 10px;
+    margin-bottom: 15px;
     padding-left: 20px;
     label {
         display: inline;

--- a/modules/system/assets/ui/less/form.less
+++ b/modules/system/assets/ui/less/form.less
@@ -328,6 +328,13 @@
     &.size-giant { min-height: @size-giant; }
 }
 
+.field-checkboxlist.is-scrollable {
+    .checkboxlist-controls {
+        background: #fff;
+        border: 1px solid #e2e2e2;
+    }
+}
+
 .field-checkboxlist {
     &:not(.is-scrollable) {
         .border-radius(@border-radius-base);
@@ -348,8 +355,12 @@
         -webkit-box-align: baseline;
         -ms-flex-align: baseline;
         align-items: baseline;
+        padding:15px 15px 0;
+        border-bottom:1px solid #e2e2e2;
+        color:#2a3e51;
         > div {
-            padding-bottom: 7px;
+            padding-right: 15px;
+            padding-bottom: 15px;
 
             > a {
                 font-size: 13px;
@@ -365,6 +376,9 @@
                 }
             }
         }
+        .search-input-wrap {
+            margin-left: auto;
+        }
     }
 }
 
@@ -372,13 +386,12 @@
 .field-checkboxlist-scrollable {
     background: @color-form-checkboxlist-background;
     border: 1px solid @color-form-checkboxlist-border;
-    padding-left: 15px;
+    padding: 20px 0 2px 20px;
     height: @size-large + 100;
 
     // First checkbox
     .checkbox {
-        margin-top: 15px;
-        margin-bottom: 5px;
+        margin-bottom: 10px;
     }
 
     // All others

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -3705,7 +3705,7 @@ input[type="search"] {-webkit-appearance:none}
 input[type="date"] {line-height:38px}
 .form-group {margin-bottom:15px}
 .radio,
-.checkbox {display:block;min-height:20px;margin-top:10px;margin-bottom:10px;padding-left:20px}
+.checkbox {display:block;min-height:20px;margin-top:10px;margin-bottom:15px;padding-left:20px}
 .radio label,
 .checkbox label {display:inline;font-weight:normal;cursor:pointer}
 .radio input[type="radio"],
@@ -4242,15 +4242,17 @@ html.cssanimations .cursor-loading-indicator.hide {display:none}
 .field-textarea.size-large {min-height:200px}
 .field-textarea.size-huge {min-height:250px}
 .field-textarea.size-giant {min-height:350px}
+.field-checkboxlist.is-scrollable .checkboxlist-controls { background:#fff;border: 1px solid #e2e2e2}
 .field-checkboxlist:not(.is-scrollable) {-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;background:#fff;border:1px solid #e2e2e2}
 .field-checkboxlist:not(.is-scrollable) .field-checkboxlist-inner {padding:20px 20px 2px 20px}
-.field-checkboxlist .checkboxlist-controls {display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-align:baseline;-ms-flex-align:baseline;align-items:baseline}
-.field-checkboxlist .checkboxlist-controls >div {padding-bottom:7px}
+.field-checkboxlist .checkboxlist-controls {display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-align:baseline;-ms-flex-align:baseline;align-items:baseline;padding:15px 15px 0;border-bottom:1px solid #e2e2e2;color:#2a3e51}
+.field-checkboxlist .checkboxlist-controls >div {padding-right:15px;padding-bottom:15px}
 .field-checkboxlist .checkboxlist-controls >div >a {font-size:13px;margin-right:20px;text-decoration:none}
 .field-checkboxlist .checkboxlist-controls >div >a >i {color:#999;margin:0 4px}
 .field-checkboxlist .checkboxlist-controls >div >a:hover >i {color:#2a3e51}
-.field-checkboxlist-scrollable {background:#fff;border:1px solid #e2e2e2;padding-left:15px;height:300px}
-.field-checkboxlist-scrollable .checkbox {margin-top:15px;margin-bottom:5px}
+.field-checkboxlist .checkboxlist-controls .search-input-wrap {margin-left: auto}
+.field-checkboxlist-scrollable {background:#fff;border:1px solid #e2e2e2;padding:20px 0 2px 20px;height:300px}
+.field-checkboxlist-scrollable .checkbox {margin-bottom:10px}
 .field-checkboxlist-scrollable .checkbox ~ .checkbox {margin-top:0}
 .field-recordfinder {background-color:#fff;border:1px solid #d1d6d9;overflow:hidden;position:relative;-webkit-box-shadow:inset 0 1px 0 rgba(209,214,217,0.25),0 1px 0 rgba(255,255,255,.5);box-shadow:inset 0 1px 0 rgba(209,214,217,0.25),0 1px 0 rgba(255,255,255,.5);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}
 .field-recordfinder .form-control {background:transparent;border-color:transparent;height:auto;text-overflow:ellipsis;overflow:hidden;white-space:nowrap;padding:7px 30px 7px 11px;-webkit-box-shadow:none;box-shadow:none}


### PR DESCRIPTION
This pr fixes issue: https://github.com/octobercms/october/issues/4823

I created a new install and loaded build 461, I added the test plugin pr I created here: https://github.com/octoberrain/test-plugin/pull/82

### Before screenshot:

![b4](https://user-images.githubusercontent.com/57409060/70840231-d3310c00-1e08-11ea-9c40-15dc45e13f80.png)

### After screenshot 1

(This has the `quickselect` option turned **_on_** for both checkbox lists).

![after1](https://user-images.githubusercontent.com/57409060/70840259-ffe52380-1e08-11ea-8f02-934d355485a3.png)

- Checkbox list 2 the `select none` my mouse is hovering over it - that is why it's not blue (same like the rest).

### After screenshot 2

(This has the `quickselect` option turned **_off_** for both checkbox lists).

![after2](https://user-images.githubusercontent.com/57409060/70840274-14292080-1e09-11ea-9330-e44aee52f851.png)

@LukeTowers @daftspunk 

p.s. checkbox's are spaced 16px apart to allow touch screen actions, as web standards says "tap targets need to be 16px or greater spaced apart".