### PR TITLE
Expand the character limit of the error message shown in the list view of system errors

### DIFF
--- a/config/develop.php
+++ b/config/develop.php
@@ -20,5 +20,21 @@ return [
     */
 
     'decompileBackendAssets' => false,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Limit event log summary
+    |--------------------------------------------------------------------------
+    |
+    | Enabling this will limit the event log summary to a length of 100
+    | characters.
+    |
+    | true  - limits the summary to 100 characters
+    |
+    | false - displays the whole first sentence summary
+    |
+    */
+
+    'limitEventLogSummary' => false,
 
 ];

--- a/config/develop.php
+++ b/config/develop.php
@@ -20,21 +20,5 @@ return [
     */
 
     'decompileBackendAssets' => false,
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Limit event log summary
-    |--------------------------------------------------------------------------
-    |
-    | Enabling this will limit the event log summary to a length of 100
-    | characters.
-    |
-    | true  - limits the summary to 100 characters
-    |
-    | false - displays the whole first sentence summary
-    |
-    */
-
-    'limitEventLogSummary' => false,
 
 ];

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -84,8 +84,8 @@ class EventLog extends Model
         if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
             return $match[1];
         }
-        elseif (preg_match("/^((.|\n)*)(\bStack trace\b)(\:)$/im", trim($this->message), $match)) {
-            return $match[1];
+        elseif (preg_match("/^(.*|\n)/im", trim($this->message), $match)) {
+            return str_replace('<br>', '', $match[1]);
         }
 
         return Str::limit($this->message, 100);

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -84,10 +84,9 @@ class EventLog extends Model
         if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
             return $match[1];
         }
-        elseif (preg_match("/^(.*|\n)/im", trim($this->message), $match)) {
+        elseif (preg_match("/^(.*|\r\n|\r|\n)/im", trim($this->message), $match)) {
             return str_replace('<br>', '', $match[1]);
         }
-
         return Str::limit($this->message, 100);
     }
 }

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -88,6 +88,6 @@ class EventLog extends Model
         // Get first line of message
         preg_match('/^([^\n\r]+)/m', $this->message, $matches);
 
-        return Str::limit($matches[1], 500);
+        return Str::limit($matches[1] ?? '', 500);
     }
 }

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -81,12 +81,15 @@ class EventLog extends Model
      */
     public function getSummaryAttribute()
     {
-        if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
-            return $match[1];
+        if (Config::get('develop.limitEventLogSummary', true)) {
+            if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
+                return $match[1];
+            }
+            return Str::limit($this->message, 100);
+        } else {
+            if (preg_match("/^(.*|\r\n|\r|\n)/im", trim($this->message), $match)) {
+                return str_replace('<br>', '', $match[1]);
+            }
         }
-        elseif (preg_match("/^(.*|\r\n|\r|\n)/im", trim($this->message), $match)) {
-            return str_replace('<br>', '', $match[1]);
-        }
-        return Str::limit($this->message, 100);
     }
 }

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -84,6 +84,9 @@ class EventLog extends Model
         if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
             return $match[1];
         }
+        elseif (preg_match("/^((.|\n)*)(\bStack trace\b)(\:)$/im", trim($this->message), $match)) {
+            return $match[1];
+        }
 
         return Str::limit($this->message, 100);
     }

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -84,11 +84,14 @@ class EventLog extends Model
         if (Config::get('develop.limitEventLogSummary', true)) {
             if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
                 return $match[1];
+            } else {
+                return Str::limit($this->message, 100);
             }
-            return Str::limit($this->message, 100);
         } else {
             if (preg_match("/^(.*|\r\n|\r|\n)/im", trim($this->message), $match)) {
                 return str_replace('<br>', '', $match[1]);
+            } else {
+                return Str::limit($this->message, 100);
             }
         }
     }

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -84,9 +84,10 @@ class EventLog extends Model
         if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
             return $match[1];
         }
-        elseif (preg_match("/^(.*|\r\n|\r|\n)/m", trim($this->message), $match)) {
-            return Str::limit(str_replace('<br>', '', $match[1]), 500);
-        }
-        return Str::limit($this->message, 100);
+
+        // Get first line of message
+        preg_match('/^([^\n\r]+)/m', $this->message, $matches);
+
+        return Str::limit($matches[1], 500);
     }
 }

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -81,18 +81,12 @@ class EventLog extends Model
      */
     public function getSummaryAttribute()
     {
-        if (Config::get('develop.limitEventLogSummary', true)) {
-            if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
-                return $match[1];
-            } else {
-                return Str::limit($this->message, 100);
-            }
-        } else {
-            if (preg_match("/^(.*|\r\n|\r|\n)/im", trim($this->message), $match)) {
-                return str_replace('<br>', '', $match[1]);
-            } else {
-                return Str::limit($this->message, 100);
-            }
+        if (preg_match("/with message '(.+)' in/", $this->message, $match)) {
+            return $match[1];
         }
+        elseif (preg_match("/^(.*|\r\n|\r|\n)/m", trim($this->message), $match)) {
+            return Str::limit(str_replace('<br>', '', $match[1]), 500);
+        }
+        return Str::limit($this->message, 100);
     }
 }


### PR DESCRIPTION
Github issue: https://github.com/octobercms/october/issues/4828

My regex:

![image](https://user-images.githubusercontent.com/57409060/70872313-0c02e980-1f9f-11ea-9aaf-dd0f0d7a5d70.png)

and

![image](https://user-images.githubusercontent.com/57409060/70872251-8ed77480-1f9e-11ea-9cf3-f561a56d099e.png)

The regex matches all the error before it finds the exact match word of `Stack trace` and then ends the regex after the exact match word of `Stack trace` on the `:`

Giving the following result:

![image](https://user-images.githubusercontent.com/57409060/70872289-d6f69700-1f9e-11ea-909d-6fef34ebd713.png)
