### PR TITLE
Invalid security token issue - Service worker September 2019 update to spec

### DIFF
--- a/modules/backend/layouts/_head.htm
+++ b/modules/backend/layouts/_head.htm
@@ -56,15 +56,14 @@
         /* Only run on HTTPS connections
          * Block off Front-end Service Worker from running in the Backend allowing security injections, see GitHub #4384
          */
-        if (location.protocol === 'https:') {
+        if ((location.protocol === 'https:') && ('serviceWorker' in navigator)) {
             // Unregister all service workers before signing in to prevent cache issues, see github issue: #3707
-            navigator.serviceWorker.getRegistrations().then(
-                function(registrations) {
-                    for (let registration of registrations) {
-                        registration.unregister();
+            navigator.serviceWorker.getRegistrations().then(function(registrations) {
+                    for (var key in registrations) {
+                        var registration = registrations[key]
+                        registration.unregister({ immediate: true });
                     }
-                }
-            );
+            });
         }
     </script>
 <?php endif; ?>

--- a/modules/backend/layouts/auth.htm
+++ b/modules/backend/layouts/auth.htm
@@ -43,15 +43,14 @@
                 /* Only run on HTTPS connections
                 * Block off Front-end Service Worker from running in the Backend allowing security injections, see GitHub #4384
                 */
-                if (location.protocol === 'https:') {
+                if ((location.protocol === 'https:') && ('serviceWorker' in navigator)) {
                     // Unregister all service workers before signing in to prevent cache issues, see github issue: #3707
-                    navigator.serviceWorker.getRegistrations().then(
-                        function(registrations) {
-                            for (let registration of registrations) {
-                                registration.unregister();
+                    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+                            for (var key in registrations) {
+                                var registration = registrations[key]
+                                registration.unregister({ immediate: true });
                             }
-                        }
-                    );
+                    });
                 }
             </script>
         <?php endif; ?>


### PR DESCRIPTION
Previous pr was found here: https://github.com/octobercms/october/pull/4805

@w20k please add to reviewers.

(Not sure what's gone wrong, but my github branch for the old pr is gone?)

---

Current status of the browsers adding the api `immediate: true` is seen below in the screenshot:

![image](https://user-images.githubusercontent.com/57409060/70354214-eff89d00-1866-11ea-9d97-e3d8da6ddfe9.png)

As per conversation with Luke I will contact them to get some written information on this api as proof. Also asked Luke to add the "blocked" label to put this pull request on hold until can get some written documentation proof of this new feature.

Info request found here: https://github.com/w3c/ServiceWorker/issues/1489

---

I previously wrote some code to uninstall a service worker when you try to login to the backend of the cms. It was important to turn off the service worker as it created a caching issue and produced "Invalid security token" messages.

However, there was always a problem with the service worker spec, the old spec does this: If you unregister a service worker, the registration is removed from the list of registrations, **_but it continues to control existing pages_** and this continued to cause issues with October using a service worker and trying to login to the backend.

The new update to the spec now fixes this issue! If you unregister a service worker registration it's removed from the list of registrations and **_stops controlling the existing pages_**! This means when you now open the backend `auth.htm` file the service worker will be completely removed and the cached properly cleared now! 