### PR TITLE
Allow users to skip seeding when running migrations for modules.

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -128,9 +128,10 @@ class UpdateManager
 
     /**
      * Creates the migration table and updates
+     * @param bool $seed If true, the tables will also be seeded.
      * @return self
      */
-    public function update()
+    public function update(bool $seed = true)
     {
         $firstUp = !Schema::hasTable($this->getMigrationTableName());
         if ($firstUp) {
@@ -160,7 +161,7 @@ class UpdateManager
         /*
          * Seed modules
          */
-        if ($firstUp) {
+        if ($firstUp && $seed) {
             $modules = Config::get('cms.loadModules', []);
             foreach ($modules as $module) {
                 $this->seedModule($module);

--- a/modules/system/console/OctoberInstall.php
+++ b/modules/system/console/OctoberInstall.php
@@ -101,7 +101,8 @@ class OctoberInstall extends Command
     protected function getOptions()
     {
         return [
-            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run'],
+            ['no-seed', null, InputOption::VALUE_NONE, 'Do not seed tables'],
         ];
     }
 
@@ -306,8 +307,7 @@ class OctoberInstall extends Command
 
             UpdateManager::instance()
                 ->setNotesOutput($this->output)
-                ->update()
-            ;
+                ->update(!$this->option('no-seed'));
         }
         catch (Exception $ex) {
             $this->error($ex->getMessage());

--- a/modules/system/console/OctoberUp.php
+++ b/modules/system/console/OctoberUp.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use System\Classes\UpdateManager;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Console command to migrate the database.
@@ -32,7 +33,17 @@ class OctoberUp extends Command
 
         UpdateManager::instance()
             ->setNotesOutput($this->output)
-            ->update()
+            ->update(!$this->option('no-seed'))
         ;
+    }
+
+    /**
+     * Get the console command options.
+     */
+    protected function getOptions()
+    {
+        return [
+            ['no-seed', null, InputOption::VALUE_NONE, 'Do not seed tables.'],
+        ];
     }
 }


### PR DESCRIPTION
Adds the "--no-seed" option for the "october:up" and "october:install" Artisan commands.

Fixes #2360.