### PR TITLE
Normalize PluginManager  storage/access

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -363,9 +363,7 @@ class PluginManager
     {
         $classId = $this->getIdentifier($namespace);
 
-        $normalized = $this->normalizeIdentifier($classId);
-
-        return isset($this->plugins[$normalized]);
+        return isset($this->plugins[$classId]);
     }
 
     /**
@@ -427,30 +425,30 @@ class PluginManager
     {
         $namespace = Str::normalizeClassName($namespace);
         if (strpos($namespace, '\\') === null) {
-            return $namespace;
+            return strtoupper($namespace);
         }
 
         $parts = explode('\\', $namespace);
         $slice = array_slice($parts, 1, 2);
         $namespace = implode('.', $slice);
 
-        return $namespace;
+        return strtoupper($namespace);
     }
 
     /**
-     * Takes a human plugin code (acme.blog) and makes it authentic (Acme.Blog)
-     * @param  string $id
+     * @param  string $identifier
      * @return string
      */
     public function normalizeIdentifier($identifier)
     {
+        $code = strtoupper($identifier);
         foreach ($this->plugins as $id => $object) {
-            if (strtolower($id) == strtolower($identifier)) {
-                return $id;
+            if ($id == $code) {
+                $code = $id;
             }
         }
 
-        return $identifier;
+        return $code;
     }
 
     /**
@@ -552,6 +550,7 @@ class PluginManager
         $disabled = Db::table('system_plugin_versions')->where('is_disabled', 1)->lists('code');
 
         foreach ($disabled as $code) {
+            $code = $this->getIdentifier($code);
             $this->disabledPlugins[$code] = true;
         }
     }

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -419,7 +419,7 @@ class PluginManager
     /**
      * Resolves a plugin identifier from a plugin class name or object.
      * @param mixed Plugin class name or object
-     * @return string Identifier in format of Vendor.Plugin
+     * @return string Identifier in format of VENDOR.PLUGIN
      */
     public function getIdentifier($namespace)
     {

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -487,7 +487,7 @@ class PluginManager
     }
 
     /**
-     * Loads all disables plugins from the meta file.
+     * Loads all disabled plugins from the meta file.
      */
     protected function loadDisabled()
     {
@@ -495,12 +495,14 @@ class PluginManager
 
         if (($configDisabled = Config::get('cms.disablePlugins')) && is_array($configDisabled)) {
             foreach ($configDisabled as $disabled) {
-                $this->disabledPlugins[$disabled] = true;
+                $code = $this->getIdentifier($disabled);
+                $this->disabledPlugins[$code] = true;
             }
         }
 
         if (File::exists($path)) {
             $disabled = json_decode(File::get($path), true) ?: [];
+            //TODO: need to normalize $disabled array keys before merging with $this->disabledPlugins
             $this->disabledPlugins = array_merge($this->disabledPlugins, $disabled);
         }
         else {

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -5,6 +5,18 @@ class PluginManagerTest extends TestCase
 {
     public $manager;
 
+    public $plugins = [
+        'October.NoUpdates' => 'October\NoUpdates\Plugin',
+        'October.Sample' => 'October\Sample\Plugin',
+        'October.Tester' => 'October\Tester\Plugin',
+        'Database.Tester' => 'Database\Tester\Plugin',
+        'TestVendor.Test' => 'TestVendor\Test\Plugin',
+        'DependencyTest.Found' => 'DependencyTest\Found\Plugin',
+        'DependencyTest.NotFound' => 'DependencyTest\NotFound\Plugin',
+        'DependencyTest.WrongCase' => 'DependencyTest\WrongCase\Plugin',
+        'DependencyTest.Dependency' => 'DependencyTest\Dependency\Plugin',
+    ];
+
     public function setUp()
     {
         parent::setUp();
@@ -26,27 +38,12 @@ class PluginManagerTest extends TestCase
         $result = $this->manager->loadPlugins();
 
         $this->assertCount(9, $result);
-        $this->assertArrayHasKey('October.NoUpdates', $result);
-        $this->assertArrayHasKey('October.Sample', $result);
-        $this->assertArrayHasKey('October.Tester', $result);
-        $this->assertArrayHasKey('Database.Tester', $result);
-        $this->assertArrayHasKey('TestVendor.Test', $result);
-        $this->assertArrayHasKey('DependencyTest.Found', $result);
-        $this->assertArrayHasKey('DependencyTest.NotFound', $result);
-        $this->assertArrayHasKey('DependencyTest.WrongCase', $result);
-        $this->assertArrayHasKey('DependencyTest.Dependency', $result);
+        foreach ($this->plugins as $code => $class) {
+            $this->assertArrayHasKey($code, $result);
+            $this->assertInstanceOf($class, $result[$code]);
+        }
 
         $this->assertArrayNotHasKey('TestVendor.Goto', $result);
-
-        $this->assertInstanceOf('October\NoUpdates\Plugin', $result['October.NoUpdates']);
-        $this->assertInstanceOf('October\Sample\Plugin', $result['October.Sample']);
-        $this->assertInstanceOf('October\Tester\Plugin', $result['October.Tester']);
-        $this->assertInstanceOf('Database\Tester\Plugin', $result['Database.Tester']);
-        $this->assertInstanceOf('TestVendor\Test\Plugin', $result['TestVendor.Test']);
-        $this->assertInstanceOf('DependencyTest\Found\Plugin', $result['DependencyTest.Found']);
-        $this->assertInstanceOf('DependencyTest\NotFound\Plugin', $result['DependencyTest.NotFound']);
-        $this->assertInstanceOf('DependencyTest\WrongCase\Plugin', $result['DependencyTest.WrongCase']);
-        $this->assertInstanceOf('DependencyTest\Dependency\Plugin', $result['DependencyTest.Dependency']);
     }
 
     public function testUnloadablePlugin()
@@ -68,26 +65,13 @@ class PluginManagerTest extends TestCase
         $result = $this->manager->getPlugins();
 
         $this->assertCount(8, $result);
-        $this->assertArrayHasKey('October.NoUpdates', $result);
-        $this->assertArrayHasKey('October.Sample', $result);
-        $this->assertArrayHasKey('October.Tester', $result);
-        $this->assertArrayHasKey('Database.Tester', $result);
-        $this->assertArrayHasKey('TestVendor.Test', $result);
-        $this->assertArrayHasKey('DependencyTest.Found', $result);
-        $this->assertArrayHasKey('DependencyTest.WrongCase', $result);
-        $this->assertArrayHasKey('DependencyTest.Dependency', $result);
+        foreach ($this->plugins as $code => $class) {
+            $this->assertArrayHasKey($code, $result);
+            $this->assertInstanceOf($class, $result[$code]);
+        }
 
         $this->assertArrayNotHasKey('DependencyTest.NotFound', $result);
         $this->assertArrayNotHasKey('TestVendor.Goto', $result);
-
-        $this->assertInstanceOf('October\NoUpdates\Plugin', $result['October.NoUpdates']);
-        $this->assertInstanceOf('October\Sample\Plugin', $result['October.Sample']);
-        $this->assertInstanceOf('October\Tester\Plugin', $result['October.Tester']);
-        $this->assertInstanceOf('Database\Tester\Plugin', $result['Database.Tester']);
-        $this->assertInstanceOf('TestVendor\Test\Plugin', $result['TestVendor.Test']);
-        $this->assertInstanceOf('DependencyTest\Found\Plugin', $result['DependencyTest.Found']);
-        $this->assertInstanceOf('DependencyTest\WrongCase\Plugin', $result['DependencyTest.WrongCase']);
-        $this->assertInstanceOf('DependencyTest\Dependency\Plugin', $result['DependencyTest.Dependency']);
     }
 
     public function testFindByNamespace()

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -39,6 +39,7 @@ class PluginManagerTest extends TestCase
 
         $this->assertCount(9, $result);
         foreach ($this->plugins as $code => $class) {
+            $code = strtoupper($code);
             $this->assertArrayHasKey($code, $result);
             $this->assertInstanceOf($class, $result[$code]);
         }
@@ -66,6 +67,7 @@ class PluginManagerTest extends TestCase
 
         $this->assertCount(8, $result);
         foreach ($this->plugins as $code => $class) {
+            $code = strtoupper($code);
             $this->assertArrayHasKey($code, $result);
             $this->assertInstanceOf($class, $result[$code]);
         }


### PR DESCRIPTION
makes accessing plugins with PluginManager easier (solves case-sensitivity related errors)

e.g. 
```
$manager = PluginManager::instance();

$manager->hasPlugin('Rainlab.Blog');
$manager->exists('RainLab.Blog');
$manager->isDisabled('rainlab.blog');

All access the same plugin without confusion.
``` 