### PR TITLE
Add an unique identifier to all the filter container popup boxes

### DIFF
--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -104,7 +104,7 @@
      */
     FilterWidget.prototype.getPopoverDateTemplate = function () {
         return '                                                                                                        \
-                <form>                                                                                                  \
+                <form id="controlFilterPopoverDate-{{ scopeName }}">                                                    \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
                     <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover">       \
                         <div class="filter-search loading-indicator-container size-input-text">                         \
@@ -136,7 +136,7 @@
      */
     FilterWidget.prototype.getPopoverRangeTemplate = function () {
         return '                                                                                                          \
-                <form>                                                                                                    \
+                <form id="controlFilterPopoverRange-{{ scopeName }}">                                                     \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                      \
                     <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover --range"> \
                         <div class="filter-search loading-indicator-container size-input-text">                           \

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -43,14 +43,14 @@
         this.$el.on('show.oc.popover', 'a.filter-scope-date', function (event) {
             self.initDatePickers($(this).hasClass('range'))
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverDate [data-filter-action="filter"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverDate-' + scopeName + ' [data-filter-action="filter"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
 
                 self.filterByDate()
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverDate [data-filter-action="clear"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverDate-' + scopeName + ' [data-filter-action="clear"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
 
@@ -103,31 +103,31 @@
      * Get popover date template
      */
     FilterWidget.prototype.getPopoverDateTemplate = function () {
-        return '                                                                                                        \
-                <form id="controlFilterPopoverDate-{{ scopeName }}">                                                    \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
-                    <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover">       \
-                        <div class="filter-search loading-indicator-container size-input-text">                         \
-                            <div class="field-datepicker">                                                              \
-                                <div class="input-with-icon right-align">                                               \
-                                    <i class="icon icon-calendar-o"></i>                                                \
-                                    <input                                                                              \
-                                        type="text"                                                                     \
-                                        name="date"                                                                     \
-                                        value="{{ date }}"                                                              \
-                                        class="form-control align-right popup-allow-focus"                              \
-                                        autocomplete="off"                                                              \
-                                        placeholder="{{ date_placeholder }}" />                                         \
-                                </div>                                                                                  \
-                            </div>                                                                                      \
-                            <div class="filter-buttons">                                                                \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                 \
-                                    {{ reset_button_text }}                                                             \
-                                </button>                                                                               \
-                            </div>                                                                                      \
-                        </div>                                                                                          \
-                    </div>                                                                                              \
-                </form>                                                                                                 \
+        return '                                                                                                                  \
+                <form>                                                                                                            \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                              \
+                    <div id="controlFilterPopoverDate-{{ scopeName }}" class="control-filter-popover control-filter-box-popover"> \
+                        <div class="filter-search loading-indicator-container size-input-text">                                   \
+                            <div class="field-datepicker">                                                                        \
+                                <div class="input-with-icon right-align">                                                         \
+                                    <i class="icon icon-calendar-o"></i>                                                          \
+                                    <input                                                                                        \
+                                        type="text"                                                                               \
+                                        name="date"                                                                               \
+                                        value="{{ date }}"                                                                        \
+                                        class="form-control align-right popup-allow-focus"                                        \
+                                        autocomplete="off"                                                                        \
+                                        placeholder="{{ date_placeholder }}" />                                                   \
+                                </div>                                                                                            \
+                            </div>                                                                                                \
+                            <div class="filter-buttons">                                                                          \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                           \
+                                    {{ reset_button_text }}                                                                       \
+                                </button>                                                                                         \
+                            </div>                                                                                                \
+                        </div>                                                                                                    \
+                    </div>                                                                                                        \
+                </form>                                                                                                           \
             '
     }
 
@@ -135,46 +135,46 @@
      * Get popover range template
      */
     FilterWidget.prototype.getPopoverRangeTemplate = function () {
-        return '                                                                                                          \
-                <form id="controlFilterPopoverRange-{{ scopeName }}">                                                     \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                      \
-                    <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover --range"> \
-                        <div class="filter-search loading-indicator-container size-input-text">                           \
-                            <div class="field-datepicker">                                                                \
-                                <div class="input-with-icon right-align">                                                 \
-                                    <i class="icon icon-calendar-o"></i>                                                  \
-                                    <input                                                                                \
-                                        type="text"                                                                       \
-                                        name="date"                                                                       \
-                                        value="{{ date }}"                                                                \
-                                        class="form-control align-right popup-allow-focus"                                \
-                                        autocomplete="off"                                                                \
-                                        placeholder="{{ after_placeholder }}" />                                          \
-                                </div>                                                                                    \
-                            </div>                                                                                        \
-                            <div class="field-datepicker">                                                                \
-                                <div class="input-with-icon right-align">                                                 \
-                                    <i class="icon icon-calendar-o"></i>                                                  \
-                                    <input                                                                                \
-                                        type="text"                                                                       \
-                                        name="date"                                                                       \
-                                        value="{{ date }}"                                                                \
-                                        class="form-control align-right popup-allow-focus"                                \
-                                        autocomplete="off"                                                                \
-                                        placeholder="{{ before_placeholder }}" />                                         \
-                                </div>                                                                                    \
-                            </div>                                                                                        \
-                            <div class="filter-buttons">                                                                  \
-                                <button class="btn btn-block btn-primary" data-filter-action="filter">                    \
-                                    {{ filter_button_text }}                                                              \
-                                </button>                                                                                 \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                   \
-                                    {{ reset_button_text }}                                                               \
-                                </button>                                                                                 \
-                            </div>                                                                                        \
-                        </div>                                                                                            \
-                    </div>                                                                                                \
-                </form>                                                                                                   \
+        return '                                                                                                                          \
+                <form>                                                                                                                    \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                                      \
+                    <div id="controlFilterPopoverDate-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range"> \
+                        <div class="filter-search loading-indicator-container size-input-text">                                           \
+                            <div class="field-datepicker">                                                                                \
+                                <div class="input-with-icon right-align">                                                                 \
+                                    <i class="icon icon-calendar-o"></i>                                                                  \
+                                    <input                                                                                                \
+                                        type="text"                                                                                       \
+                                        name="date"                                                                                       \
+                                        value="{{ date }}"                                                                                \
+                                        class="form-control align-right popup-allow-focus"                                                \
+                                        autocomplete="off"                                                                                \
+                                        placeholder="{{ after_placeholder }}" />                                                          \
+                                </div>                                                                                                    \
+                            </div>                                                                                                        \
+                            <div class="field-datepicker">                                                                                \
+                                <div class="input-with-icon right-align">                                                                 \
+                                    <i class="icon icon-calendar-o"></i>                                                                  \
+                                    <input                                                                                                \
+                                        type="text"                                                                                       \
+                                        name="date"                                                                                       \
+                                        value="{{ date }}"                                                                                \
+                                        class="form-control align-right popup-allow-focus"                                                \
+                                        autocomplete="off"                                                                                \
+                                        placeholder="{{ before_placeholder }}" />                                                         \
+                                </div>                                                                                                    \
+                            </div>                                                                                                        \
+                            <div class="filter-buttons">                                                                                  \
+                                <button class="btn btn-block btn-primary" data-filter-action="filter">                                    \
+                                    {{ filter_button_text }}                                                                              \
+                                </button>                                                                                                 \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                                   \
+                                    {{ reset_button_text }}                                                                               \
+                                </button>                                                                                                 \
+                            </div>                                                                                                        \
+                        </div>                                                                                                            \
+                    </div>                                                                                                                \
+                </form>                                                                                                                   \
             '
     }
 
@@ -238,7 +238,7 @@
     FilterWidget.prototype.initDatePickers = function (isRange) {
         var self = this,
             scopeData = this.$activeScope.data('scope-data'),
-            $inputs = $('.field-datepicker input', '#controlFilterPopoverDate'),
+            $inputs = $('.field-datepicker input', '#controlFilterPopoverDate-' + scopeName),
             data = this.scopeValues[this.activeScopeName]
 
         if (!data) {
@@ -277,7 +277,7 @@
     }
 
     FilterWidget.prototype.clearDatePickers = function () {
-        var $inputs = $('.field-datepicker input', '#controlFilterPopoverDate')
+        var $inputs = $('.field-datepicker input', '#controlFilterPopoverDate-' + scopeName)
 
         $inputs.each(function (index, datepicker) {
             var $datepicker = $(datepicker)
@@ -330,7 +330,7 @@
             dates = []
 
         if (!isReset) {
-            var datepickers = $('.field-datepicker input', '#controlFilterPopoverDate')
+            var datepickers = $('.field-datepicker input', '#controlFilterPopoverDate-' + scopeName)
 
             datepickers.each(function (index, datepicker) {
                 var date = $(datepicker).data('pikaday').toString('YYYY-MM-DD')

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -43,14 +43,14 @@
         this.$el.on('show.oc.popover', 'a.filter-scope-date', function (event) {
             self.initDatePickers($(this).hasClass('range'))
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverDate-' + scopeName + ' [data-filter-action="filter"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverDate [data-filter-action="filter"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
 
                 self.filterByDate()
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverDate-' + scopeName + ' [data-filter-action="clear"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverDate [data-filter-action="clear"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
 
@@ -103,31 +103,31 @@
      * Get popover date template
      */
     FilterWidget.prototype.getPopoverDateTemplate = function () {
-        return '                                                                                                                  \
-                <form>                                                                                                            \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                              \
-                    <div id="controlFilterPopoverDate-{{ scopeName }}" class="control-filter-popover control-filter-box-popover"> \
-                        <div class="filter-search loading-indicator-container size-input-text">                                   \
-                            <div class="field-datepicker">                                                                        \
-                                <div class="input-with-icon right-align">                                                         \
-                                    <i class="icon icon-calendar-o"></i>                                                          \
-                                    <input                                                                                        \
-                                        type="text"                                                                               \
-                                        name="date"                                                                               \
-                                        value="{{ date }}"                                                                        \
-                                        class="form-control align-right popup-allow-focus"                                        \
-                                        autocomplete="off"                                                                        \
-                                        placeholder="{{ date_placeholder }}" />                                                   \
-                                </div>                                                                                            \
-                            </div>                                                                                                \
-                            <div class="filter-buttons">                                                                          \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                           \
-                                    {{ reset_button_text }}                                                                       \
-                                </button>                                                                                         \
-                            </div>                                                                                                \
-                        </div>                                                                                                    \
-                    </div>                                                                                                        \
-                </form>                                                                                                           \
+        return '                                                                                                        \
+                <form id="controlFilterPopoverDate-{{ scopeName }}">                                                    \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
+                    <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover">       \
+                        <div class="filter-search loading-indicator-container size-input-text">                         \
+                            <div class="field-datepicker">                                                              \
+                                <div class="input-with-icon right-align">                                               \
+                                    <i class="icon icon-calendar-o"></i>                                                \
+                                    <input                                                                              \
+                                        type="text"                                                                     \
+                                        name="date"                                                                     \
+                                        value="{{ date }}"                                                              \
+                                        class="form-control align-right popup-allow-focus"                              \
+                                        autocomplete="off"                                                              \
+                                        placeholder="{{ date_placeholder }}" />                                         \
+                                </div>                                                                                  \
+                            </div>                                                                                      \
+                            <div class="filter-buttons">                                                                \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                 \
+                                    {{ reset_button_text }}                                                             \
+                                </button>                                                                               \
+                            </div>                                                                                      \
+                        </div>                                                                                          \
+                    </div>                                                                                              \
+                </form>                                                                                                 \
             '
     }
 
@@ -135,46 +135,46 @@
      * Get popover range template
      */
     FilterWidget.prototype.getPopoverRangeTemplate = function () {
-        return '                                                                                                                          \
-                <form>                                                                                                                    \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                                      \
-                    <div id="controlFilterPopoverDate-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range"> \
-                        <div class="filter-search loading-indicator-container size-input-text">                                           \
-                            <div class="field-datepicker">                                                                                \
-                                <div class="input-with-icon right-align">                                                                 \
-                                    <i class="icon icon-calendar-o"></i>                                                                  \
-                                    <input                                                                                                \
-                                        type="text"                                                                                       \
-                                        name="date"                                                                                       \
-                                        value="{{ date }}"                                                                                \
-                                        class="form-control align-right popup-allow-focus"                                                \
-                                        autocomplete="off"                                                                                \
-                                        placeholder="{{ after_placeholder }}" />                                                          \
-                                </div>                                                                                                    \
-                            </div>                                                                                                        \
-                            <div class="field-datepicker">                                                                                \
-                                <div class="input-with-icon right-align">                                                                 \
-                                    <i class="icon icon-calendar-o"></i>                                                                  \
-                                    <input                                                                                                \
-                                        type="text"                                                                                       \
-                                        name="date"                                                                                       \
-                                        value="{{ date }}"                                                                                \
-                                        class="form-control align-right popup-allow-focus"                                                \
-                                        autocomplete="off"                                                                                \
-                                        placeholder="{{ before_placeholder }}" />                                                         \
-                                </div>                                                                                                    \
-                            </div>                                                                                                        \
-                            <div class="filter-buttons">                                                                                  \
-                                <button class="btn btn-block btn-primary" data-filter-action="filter">                                    \
-                                    {{ filter_button_text }}                                                                              \
-                                </button>                                                                                                 \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                                   \
-                                    {{ reset_button_text }}                                                                               \
-                                </button>                                                                                                 \
-                            </div>                                                                                                        \
-                        </div>                                                                                                            \
-                    </div>                                                                                                                \
-                </form>                                                                                                                   \
+        return '                                                                                                          \
+                <form id="controlFilterPopoverRange-{{ scopeName }}">                                                     \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                      \
+                    <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover --range"> \
+                        <div class="filter-search loading-indicator-container size-input-text">                           \
+                            <div class="field-datepicker">                                                                \
+                                <div class="input-with-icon right-align">                                                 \
+                                    <i class="icon icon-calendar-o"></i>                                                  \
+                                    <input                                                                                \
+                                        type="text"                                                                       \
+                                        name="date"                                                                       \
+                                        value="{{ date }}"                                                                \
+                                        class="form-control align-right popup-allow-focus"                                \
+                                        autocomplete="off"                                                                \
+                                        placeholder="{{ after_placeholder }}" />                                          \
+                                </div>                                                                                    \
+                            </div>                                                                                        \
+                            <div class="field-datepicker">                                                                \
+                                <div class="input-with-icon right-align">                                                 \
+                                    <i class="icon icon-calendar-o"></i>                                                  \
+                                    <input                                                                                \
+                                        type="text"                                                                       \
+                                        name="date"                                                                       \
+                                        value="{{ date }}"                                                                \
+                                        class="form-control align-right popup-allow-focus"                                \
+                                        autocomplete="off"                                                                \
+                                        placeholder="{{ before_placeholder }}" />                                         \
+                                </div>                                                                                    \
+                            </div>                                                                                        \
+                            <div class="filter-buttons">                                                                  \
+                                <button class="btn btn-block btn-primary" data-filter-action="filter">                    \
+                                    {{ filter_button_text }}                                                              \
+                                </button>                                                                                 \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                   \
+                                    {{ reset_button_text }}                                                               \
+                                </button>                                                                                 \
+                            </div>                                                                                        \
+                        </div>                                                                                            \
+                    </div>                                                                                                \
+                </form>                                                                                                   \
             '
     }
 
@@ -238,7 +238,7 @@
     FilterWidget.prototype.initDatePickers = function (isRange) {
         var self = this,
             scopeData = this.$activeScope.data('scope-data'),
-            $inputs = $('.field-datepicker input', '#controlFilterPopoverDate-' + scopeName),
+            $inputs = $('.field-datepicker input', '#controlFilterPopoverDate'),
             data = this.scopeValues[this.activeScopeName]
 
         if (!data) {
@@ -277,7 +277,7 @@
     }
 
     FilterWidget.prototype.clearDatePickers = function () {
-        var $inputs = $('.field-datepicker input', '#controlFilterPopoverDate-' + scopeName)
+        var $inputs = $('.field-datepicker input', '#controlFilterPopoverDate')
 
         $inputs.each(function (index, datepicker) {
             var $datepicker = $(datepicker)
@@ -330,7 +330,7 @@
             dates = []
 
         if (!isReset) {
-            var datepickers = $('.field-datepicker input', '#controlFilterPopoverDate-' + scopeName)
+            var datepickers = $('.field-datepicker input', '#controlFilterPopoverDate')
 
             datepickers.each(function (index, datepicker) {
                 var date = $(datepicker).data('pikaday').toString('YYYY-MM-DD')

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -46,7 +46,7 @@
      */
     FilterWidget.prototype.getPopoverTemplate = function() {
         return '                                                                                                       \
-                <form>                                                                                                 \
+                <form id="controlFilterPopover-{{ scopeName }}">                                                       \
                     <input type="hidden" name="scopeName"  value="{{ scopeName }}" />                                  \
                     <div id="controlFilterPopover" class="control-filter-popover control-filter-box-popover --range">  \
                         <div class="filter-search loading-indicator-container size-input-text">                        \

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -45,49 +45,49 @@
      * Get popover template
      */
     FilterWidget.prototype.getPopoverTemplate = function() {
-        return '                                                                                                       \
-                <form id="filterPopover-{{ scopeName }}">                                                              \
-                    <input type="hidden" name="scopeName"  value="{{ scopeName }}" />                                  \
-                    <div id="controlFilterPopover" class="control-filter-popover control-filter-box-popover --range">  \
-                        <div class="filter-search loading-indicator-container size-input-text">                        \
-                            <button class="close" data-dismiss="popover" type="button">&times;</button>                \
-                            <input                                                                                     \
-                                type="text"                                                                            \
-                                name="search"                                                                          \
-                                autocomplete="off"                                                                     \
-                                class="filter-search-input form-control icon search popup-allow-focus"                 \
-                                data-request="{{ optionsHandler }}"                                                    \
-                                data-load-indicator-opaque                                                             \
-                                data-load-indicator                                                                    \
-                                data-track-input />                                                                    \
-                            <div class="filter-items">                                                                 \
-                                <ul>                                                                                   \
-                                    {{#available}}                                                                     \
-                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>             \
-                                    {{/available}}                                                                     \
-                                    {{#loading}}                                                                       \
-                                        <li class="loading"><span></span></li>                                         \
-                                    {{/loading}}                                                                       \
-                                </ul>                                                                                  \
-                            </div>                                                                                     \
-                            <div class="filter-active-items">                                                          \
-                                <ul>                                                                                   \
-                                    {{#active}}                                                                        \
-                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>             \
-                                    {{/active}}                                                                        \
-                                </ul>                                                                                  \
-                            </div>                                                                                     \
-                            <div class="filter-buttons">                                                               \
-                                <button class="btn btn-block btn-primary oc-icon-filter" data-filter-action="apply">   \
-                                    {{ apply_button_text }}                                                            \
-                                </button>                                                                              \
-                                <button class="btn btn-block btn-secondary oc-icon-eraser" data-filter-action="clear"> \
-                                    {{ clear_button_text }}                                                            \
-                                </button>                                                                              \
-                            </div>                                                                                     \
-                        </div>                                                                                         \
-                    </div>                                                                                             \
-                </form>                                                                                                \
+        return '                                                                                                                       \
+                <form>                                                                                                                 \
+                    <input type="hidden" name="scopeName"  value="{{ scopeName }}" />                                                  \
+                    <div id="controlFilterPopover-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range">  \
+                        <div class="filter-search loading-indicator-container size-input-text">                                        \
+                            <button class="close" data-dismiss="popover" type="button">&times;</button>                                \
+                            <input                                                                                                     \
+                                type="text"                                                                                            \
+                                name="search"                                                                                          \
+                                autocomplete="off"                                                                                     \
+                                class="filter-search-input form-control icon search popup-allow-focus"                                 \
+                                data-request="{{ optionsHandler }}"                                                                    \
+                                data-load-indicator-opaque                                                                             \
+                                data-load-indicator                                                                                    \
+                                data-track-input />                                                                                    \
+                            <div class="filter-items">                                                                                 \
+                                <ul>                                                                                                   \
+                                    {{#available}}                                                                                     \
+                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>                             \
+                                    {{/available}}                                                                                     \
+                                    {{#loading}}                                                                                       \
+                                        <li class="loading"><span></span></li>                                                         \
+                                    {{/loading}}                                                                                       \
+                                </ul>                                                                                                  \
+                            </div>                                                                                                     \
+                            <div class="filter-active-items">                                                                          \
+                                <ul>                                                                                                   \
+                                    {{#active}}                                                                                        \
+                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>                             \
+                                    {{/active}}                                                                                        \
+                                </ul>                                                                                                  \
+                            </div>                                                                                                     \
+                            <div class="filter-buttons">                                                                               \
+                                <button class="btn btn-block btn-primary oc-icon-filter" data-filter-action="apply">                   \
+                                    {{ apply_button_text }}                                                                            \
+                                </button>                                                                                              \
+                                <button class="btn btn-block btn-secondary oc-icon-eraser" data-filter-action="clear">                 \
+                                    {{ clear_button_text }}                                                                            \
+                                </button>                                                                                              \
+                            </div>                                                                                                     \
+                        </div>                                                                                                         \
+                    </div>                                                                                                             \
+                </form>                                                                                                                \
             '
     }
 
@@ -134,24 +134,24 @@
         this.$el.on('show.oc.popover', 'a.filter-scope', function(event){
             self.focusSearch()
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover .filter-items > ul > li', function(){
+            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' .filter-items > ul > li', function(){
                 self.selectItem($(this))
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover .filter-active-items > ul > li', function(){
+            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' .filter-active-items > ul > li', function(){
                 self.selectItem($(this), true)
             })
 
-            $(event.relatedTarget).on('ajaxDone', '#controlFilterPopover input.filter-search-input', function(event, context, data){
+            $(event.relatedTarget).on('ajaxDone', '#controlFilterPopover-' + scopeName + ' input.filter-search-input', function(event, context, data){
                 self.filterAvailable(data.scopeName, data.options.available)
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover [data-filter-action="apply"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' [data-filter-action="apply"]', function (e) {
                 e.preventDefault()
                 self.filterScope()
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover [data-filter-action="clear"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' [data-filter-action="clear"]', function (e) {
                 e.preventDefault()
                 self.filterScope(true)
             })
@@ -248,7 +248,7 @@
         if (Modernizr.touchevents)
             return
 
-        var $input = $('#controlFilterPopover input.filter-search-input'),
+        var $input = $('#controlFilterPopover-' + scopeName + ' input.filter-search-input'),
             length = $input.val().length
 
         $input.focus()
@@ -398,13 +398,13 @@
         /*
          * Inject available
          */
-        var container = $('#controlFilterPopover .filter-items > ul').empty()
+        var container = $('#controlFilterPopover-' + scopeName + ' .filter-items > ul').empty()
         this.addItemsToListElement(container, data.available)
 
         /*
          * Inject active
          */
-        var container = $('#controlFilterPopover .filter-active-items > ul')
+        var container = $('#controlFilterPopover-' + scopeName + ' .filter-active-items > ul')
         this.addItemsToListElement(container, data.active)
     }
 
@@ -437,7 +437,7 @@
             filtered = available
         }
 
-        var container = $('#controlFilterPopover .filter-items > ul').empty()
+        var container = $('#controlFilterPopover-' + scopeName + ' .filter-items > ul').empty()
         self.addItemsToListElement(container, filtered)
     }
 
@@ -452,8 +452,8 @@
 
     FilterWidget.prototype.toggleFilterButtons = function(data)
     {
-        var items = $('#controlFilterPopover .filter-active-items > ul'),
-            buttonContainer = $('#controlFilterPopover .filter-buttons')
+        var items = $('#controlFilterPopover-' + scopeName + ' .filter-active-items > ul'),
+            buttonContainer = $('#controlFilterPopover-' + scopeName + ' .filter-buttons')
 
         if (data) {
             data.active.length > 0 ? buttonContainer.show() : buttonContainer.hide()

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -46,7 +46,7 @@
      */
     FilterWidget.prototype.getPopoverTemplate = function() {
         return '                                                                                                       \
-                <form id="controlFilterPopover-{{ scopeName }}">                                                       \
+                <form id="filterPopover-{{ scopeName }}">                                                              \
                     <input type="hidden" name="scopeName"  value="{{ scopeName }}" />                                  \
                     <div id="controlFilterPopover" class="control-filter-popover control-filter-box-popover --range">  \
                         <div class="filter-search loading-indicator-container size-input-text">                        \

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -45,49 +45,49 @@
      * Get popover template
      */
     FilterWidget.prototype.getPopoverTemplate = function() {
-        return '                                                                                                                       \
-                <form>                                                                                                                 \
-                    <input type="hidden" name="scopeName"  value="{{ scopeName }}" />                                                  \
-                    <div id="controlFilterPopover-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range">  \
-                        <div class="filter-search loading-indicator-container size-input-text">                                        \
-                            <button class="close" data-dismiss="popover" type="button">&times;</button>                                \
-                            <input                                                                                                     \
-                                type="text"                                                                                            \
-                                name="search"                                                                                          \
-                                autocomplete="off"                                                                                     \
-                                class="filter-search-input form-control icon search popup-allow-focus"                                 \
-                                data-request="{{ optionsHandler }}"                                                                    \
-                                data-load-indicator-opaque                                                                             \
-                                data-load-indicator                                                                                    \
-                                data-track-input />                                                                                    \
-                            <div class="filter-items">                                                                                 \
-                                <ul>                                                                                                   \
-                                    {{#available}}                                                                                     \
-                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>                             \
-                                    {{/available}}                                                                                     \
-                                    {{#loading}}                                                                                       \
-                                        <li class="loading"><span></span></li>                                                         \
-                                    {{/loading}}                                                                                       \
-                                </ul>                                                                                                  \
-                            </div>                                                                                                     \
-                            <div class="filter-active-items">                                                                          \
-                                <ul>                                                                                                   \
-                                    {{#active}}                                                                                        \
-                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>                             \
-                                    {{/active}}                                                                                        \
-                                </ul>                                                                                                  \
-                            </div>                                                                                                     \
-                            <div class="filter-buttons">                                                                               \
-                                <button class="btn btn-block btn-primary oc-icon-filter" data-filter-action="apply">                   \
-                                    {{ apply_button_text }}                                                                            \
-                                </button>                                                                                              \
-                                <button class="btn btn-block btn-secondary oc-icon-eraser" data-filter-action="clear">                 \
-                                    {{ clear_button_text }}                                                                            \
-                                </button>                                                                                              \
-                            </div>                                                                                                     \
-                        </div>                                                                                                         \
-                    </div>                                                                                                             \
-                </form>                                                                                                                \
+        return '                                                                                                       \
+                <form id="filterPopover-{{ scopeName }}">                                                              \
+                    <input type="hidden" name="scopeName"  value="{{ scopeName }}" />                                  \
+                    <div id="controlFilterPopover" class="control-filter-popover control-filter-box-popover --range">  \
+                        <div class="filter-search loading-indicator-container size-input-text">                        \
+                            <button class="close" data-dismiss="popover" type="button">&times;</button>                \
+                            <input                                                                                     \
+                                type="text"                                                                            \
+                                name="search"                                                                          \
+                                autocomplete="off"                                                                     \
+                                class="filter-search-input form-control icon search popup-allow-focus"                 \
+                                data-request="{{ optionsHandler }}"                                                    \
+                                data-load-indicator-opaque                                                             \
+                                data-load-indicator                                                                    \
+                                data-track-input />                                                                    \
+                            <div class="filter-items">                                                                 \
+                                <ul>                                                                                   \
+                                    {{#available}}                                                                     \
+                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>             \
+                                    {{/available}}                                                                     \
+                                    {{#loading}}                                                                       \
+                                        <li class="loading"><span></span></li>                                         \
+                                    {{/loading}}                                                                       \
+                                </ul>                                                                                  \
+                            </div>                                                                                     \
+                            <div class="filter-active-items">                                                          \
+                                <ul>                                                                                   \
+                                    {{#active}}                                                                        \
+                                        <li data-item-id="{{id}}"><a href="javascript:;">{{name}}</a></li>             \
+                                    {{/active}}                                                                        \
+                                </ul>                                                                                  \
+                            </div>                                                                                     \
+                            <div class="filter-buttons">                                                               \
+                                <button class="btn btn-block btn-primary oc-icon-filter" data-filter-action="apply">   \
+                                    {{ apply_button_text }}                                                            \
+                                </button>                                                                              \
+                                <button class="btn btn-block btn-secondary oc-icon-eraser" data-filter-action="clear"> \
+                                    {{ clear_button_text }}                                                            \
+                                </button>                                                                              \
+                            </div>                                                                                     \
+                        </div>                                                                                         \
+                    </div>                                                                                             \
+                </form>                                                                                                \
             '
     }
 
@@ -134,24 +134,24 @@
         this.$el.on('show.oc.popover', 'a.filter-scope', function(event){
             self.focusSearch()
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' .filter-items > ul > li', function(){
+            $(event.relatedTarget).on('click', '#controlFilterPopover .filter-items > ul > li', function(){
                 self.selectItem($(this))
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' .filter-active-items > ul > li', function(){
+            $(event.relatedTarget).on('click', '#controlFilterPopover .filter-active-items > ul > li', function(){
                 self.selectItem($(this), true)
             })
 
-            $(event.relatedTarget).on('ajaxDone', '#controlFilterPopover-' + scopeName + ' input.filter-search-input', function(event, context, data){
+            $(event.relatedTarget).on('ajaxDone', '#controlFilterPopover input.filter-search-input', function(event, context, data){
                 self.filterAvailable(data.scopeName, data.options.available)
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' [data-filter-action="apply"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopover [data-filter-action="apply"]', function (e) {
                 e.preventDefault()
                 self.filterScope()
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopover-' + scopeName + ' [data-filter-action="clear"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopover [data-filter-action="clear"]', function (e) {
                 e.preventDefault()
                 self.filterScope(true)
             })
@@ -248,7 +248,7 @@
         if (Modernizr.touchevents)
             return
 
-        var $input = $('#controlFilterPopover-' + scopeName + ' input.filter-search-input'),
+        var $input = $('#controlFilterPopover input.filter-search-input'),
             length = $input.val().length
 
         $input.focus()
@@ -398,13 +398,13 @@
         /*
          * Inject available
          */
-        var container = $('#controlFilterPopover-' + scopeName + ' .filter-items > ul').empty()
+        var container = $('#controlFilterPopover .filter-items > ul').empty()
         this.addItemsToListElement(container, data.available)
 
         /*
          * Inject active
          */
-        var container = $('#controlFilterPopover-' + scopeName + ' .filter-active-items > ul')
+        var container = $('#controlFilterPopover .filter-active-items > ul')
         this.addItemsToListElement(container, data.active)
     }
 
@@ -437,7 +437,7 @@
             filtered = available
         }
 
-        var container = $('#controlFilterPopover-' + scopeName + ' .filter-items > ul').empty()
+        var container = $('#controlFilterPopover .filter-items > ul').empty()
         self.addItemsToListElement(container, filtered)
     }
 
@@ -452,8 +452,8 @@
 
     FilterWidget.prototype.toggleFilterButtons = function(data)
     {
-        var items = $('#controlFilterPopover-' + scopeName + ' .filter-active-items > ul'),
-            buttonContainer = $('#controlFilterPopover-' + scopeName + ' .filter-buttons')
+        var items = $('#controlFilterPopover .filter-active-items > ul'),
+            buttonContainer = $('#controlFilterPopover .filter-buttons')
 
         if (data) {
             data.active.length > 0 ? buttonContainer.show() : buttonContainer.hide()

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -97,7 +97,7 @@
      */
     FilterWidget.prototype.getPopoverNumberTemplate = function () {
         return '                                                                                                        \
-                <form>                                                                                                  \
+                <form id="filterPopoverNumber-{{ scopeName }}">                                                         \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
                     <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">\
                         <div class="filter-search loading-indicator-container size-input-text">                         \
@@ -129,7 +129,7 @@
      */
     FilterWidget.prototype.getPopoverNumberRangeTemplate = function () {
         return '                                                                                                            \
-                <form>                                                                                                      \
+                <form id="filterPopoverNumberRange-{{ scopeName }}">                                                        \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                        \
                     <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">    \
                         <div class="filter-search loading-indicator-container size-input-text">                             \

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -42,13 +42,13 @@
         this.$el.on('show.oc.popover', 'a.filter-scope-number', function (event) {
             self.initNumberInputs($(this).hasClass('range'))
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverNum-' + scopeName + ' [data-filter-action="filter"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverNum [data-filter-action="filter"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
                 self.filterByNumber()
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverNum-' + scopeName + ' [data-filter-action="clear"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverNum [data-filter-action="clear"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
 
@@ -96,31 +96,31 @@
      * Get popover number template
      */
     FilterWidget.prototype.getPopoverNumberTemplate = function () {
-        return '                                                                                                                         \
-                <form>                                                                                                                   \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                                     \
-                    <div id="controlFilterPopoverNum-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range"> \
-                        <div class="filter-search loading-indicator-container size-input-text">                                          \
-                            <div class="field-number">                                                                                   \
-                                <input                                                                                                   \
-                                    type="number"                                                                                        \
-                                    name="number"                                                                                        \
-                                    value="{{ number }}"                                                                                 \
-                                    class="form-control align-right"                                                                     \
-                                    autocomplete="off"                                                                                   \
-                                    placeholder="{{ number_placeholder }}" />                                                            \
-                            </div>                                                                                                       \
-                            <div class="filter-buttons">                                                                                 \
-                                <button class="btn btn-block btn-primary" data-filter-action="filter">                                   \
-                                    {{ filter_button_text }}                                                                             \
-                                </button>                                                                                                \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                                  \
-                                    {{ reset_button_text }}                                                                              \
-                                </button>                                                                                                \
-                            </div>                                                                                                       \
-                        </div>                                                                                                           \
-                    </div>                                                                                                               \
-                </form>                                                                                                                  \
+        return '                                                                                                        \
+                <form id="filterPopoverNumber-{{ scopeName }}">                                                         \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
+                    <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">\
+                        <div class="filter-search loading-indicator-container size-input-text">                         \
+                            <div class="field-number">                                                                  \
+                                <input                                                                                  \
+                                    type="number"                                                                       \
+                                    name="number"                                                                       \
+                                    value="{{ number }}"                                                                \
+                                    class="form-control align-right"                                                    \
+                                    autocomplete="off"                                                                  \
+                                    placeholder="{{ number_placeholder }}" />                                           \
+                            </div>                                                                                      \
+                            <div class="filter-buttons">                                                                \
+                                <button class="btn btn-block btn-primary" data-filter-action="filter">                  \
+                                    {{ filter_button_text }}                                                            \
+                                </button>                                                                               \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                 \
+                                    {{ reset_button_text }}                                                             \
+                                </button>                                                                               \
+                            </div>                                                                                      \
+                        </div>                                                                                          \
+                    </div>                                                                                              \
+                </form>                                                                                                 \
             '
     }
 
@@ -128,45 +128,45 @@
      * Get popover number range template
      */
     FilterWidget.prototype.getPopoverNumberRangeTemplate = function () {
-        return '                                                                                                                         \
-                <form>                                                                                                                   \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                                     \
-                    <div id="controlFilterPopoverNum-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range"> \
-                        <div class="filter-search loading-indicator-container size-input-text">                                          \
-                            <div class="field-number">                                                                                   \
-                                <div class="right-align">                                                                                \
-                                    <input                                                                                               \
-                                        type="number"                                                                                    \
-                                        name="number"                                                                                    \
-                                        value="{{ number }}"                                                                             \
-                                        class="form-control align-right"                                                                 \
-                                        autocomplete="off"                                                                               \
-                                        placeholder="{{ min_placeholder }}" />                                                           \
-                                </div>                                                                                                   \
-                            </div>                                                                                                       \
-                            <div class="field-number">                                                                                   \
-                                <div class="right-align">                                                                                \
-                                    <input                                                                                               \
-                                        type="number"                                                                                    \
-                                        {{ maxNumber }}                                                                                  \
-                                        name="number"                                                                                    \
-                                        value="{{ number }}"                                                                             \
-                                        class="form-control align-right"                                                                 \
-                                        autocomplete="off"                                                                               \
-                                        placeholder="{{ max_placeholder }}" />                                                           \
-                                </div>                                                                                                   \
-                            </div>                                                                                                       \
-                            <div class="filter-buttons">                                                                                 \
-                                <button class="btn btn-block btn-primary" data-filter-action="filter">                                   \
-                                    {{ filter_button_text }}                                                                             \
-                                </button>                                                                                                \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                                  \
-                                    {{ reset_button_text }}                                                                              \
-                                </button>                                                                                                \
-                            </div>                                                                                                       \
-                        </div>                                                                                                           \
-                    </div>                                                                                                               \
-                </form>                                                                                                                  \
+        return '                                                                                                            \
+                <form id="filterPopoverNumberRange-{{ scopeName }}">                                                        \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                        \
+                    <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">    \
+                        <div class="filter-search loading-indicator-container size-input-text">                             \
+                            <div class="field-number">                                                                      \
+                                <div class="right-align">                                                                   \
+                                    <input                                                                                  \
+                                        type="number"                                                                       \
+                                        name="number"                                                                       \
+                                        value="{{ number }}"                                                                \
+                                        class="form-control align-right"                                                    \
+                                        autocomplete="off"                                                                  \
+                                        placeholder="{{ min_placeholder }}" />                                              \
+                                </div>                                                                                      \
+                            </div>                                                                                          \
+                            <div class="field-number">                                                                      \
+                                <div class="right-align">                                                                   \
+                                    <input                                                                                  \
+                                        type="number"                                                                       \
+                                        {{ maxNumber }}                                                                     \
+                                        name="number"                                                                       \
+                                        value="{{ number }}"                                                                \
+                                        class="form-control align-right"                                                    \
+                                        autocomplete="off"                                                                  \
+                                        placeholder="{{ max_placeholder }}" />                                              \
+                                </div>                                                                                      \
+                            </div>                                                                                          \
+                            <div class="filter-buttons">                                                                    \
+                                <button class="btn btn-block btn-primary" data-filter-action="filter">                      \
+                                    {{ filter_button_text }}                                                                \
+                                </button>                                                                                   \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                     \
+                                    {{ reset_button_text }}                                                                 \
+                                </button>                                                                                   \
+                            </div>                                                                                          \
+                        </div>                                                                                              \
+                    </div>                                                                                                  \
+                </form>                                                                                                     \
             '
     }
 
@@ -225,7 +225,7 @@
     FilterWidget.prototype.initNumberInputs = function (isRange) {
         var self = this,
             scopeData = this.$activeScope.data('scope-data'),
-            $inputs = $('.field-number input', '#controlFilterPopoverNum-' + scopeName),
+            $inputs = $('.field-number input', '#controlFilterPopoverNum'),
             data = this.scopeValues[this.activeScopeName]
 
         if (!data) {
@@ -288,7 +288,7 @@
             numbers = []
 
         if (!isReset) {
-            var numberinputs = $('.field-number input', '#controlFilterPopoverNum-' + scopeName)
+            var numberinputs = $('.field-number input', '#controlFilterPopoverNum')
             numberinputs.each(function (index, numberinput) {
                 var number = $(numberinput).val()
                 numbers.push(number)

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -42,13 +42,13 @@
         this.$el.on('show.oc.popover', 'a.filter-scope-number', function (event) {
             self.initNumberInputs($(this).hasClass('range'))
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverNum [data-filter-action="filter"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverNum-' + scopeName + ' [data-filter-action="filter"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
                 self.filterByNumber()
             })
 
-            $(event.relatedTarget).on('click', '#controlFilterPopoverNum [data-filter-action="clear"]', function (e) {
+            $(event.relatedTarget).on('click', '#controlFilterPopoverNum-' + scopeName + ' [data-filter-action="clear"]', function (e) {
                 e.preventDefault()
                 e.stopPropagation()
 
@@ -96,31 +96,31 @@
      * Get popover number template
      */
     FilterWidget.prototype.getPopoverNumberTemplate = function () {
-        return '                                                                                                        \
-                <form id="filterPopoverNumber-{{ scopeName }}">                                                         \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
-                    <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">\
-                        <div class="filter-search loading-indicator-container size-input-text">                         \
-                            <div class="field-number">                                                                  \
-                                <input                                                                                  \
-                                    type="number"                                                                       \
-                                    name="number"                                                                       \
-                                    value="{{ number }}"                                                                \
-                                    class="form-control align-right"                                                    \
-                                    autocomplete="off"                                                                  \
-                                    placeholder="{{ number_placeholder }}" />                                           \
-                            </div>                                                                                      \
-                            <div class="filter-buttons">                                                                \
-                                <button class="btn btn-block btn-primary" data-filter-action="filter">                  \
-                                    {{ filter_button_text }}                                                            \
-                                </button>                                                                               \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                 \
-                                    {{ reset_button_text }}                                                             \
-                                </button>                                                                               \
-                            </div>                                                                                      \
-                        </div>                                                                                          \
-                    </div>                                                                                              \
-                </form>                                                                                                 \
+        return '                                                                                                                         \
+                <form>                                                                                                                   \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                                     \
+                    <div id="controlFilterPopoverNum-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range"> \
+                        <div class="filter-search loading-indicator-container size-input-text">                                          \
+                            <div class="field-number">                                                                                   \
+                                <input                                                                                                   \
+                                    type="number"                                                                                        \
+                                    name="number"                                                                                        \
+                                    value="{{ number }}"                                                                                 \
+                                    class="form-control align-right"                                                                     \
+                                    autocomplete="off"                                                                                   \
+                                    placeholder="{{ number_placeholder }}" />                                                            \
+                            </div>                                                                                                       \
+                            <div class="filter-buttons">                                                                                 \
+                                <button class="btn btn-block btn-primary" data-filter-action="filter">                                   \
+                                    {{ filter_button_text }}                                                                             \
+                                </button>                                                                                                \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                                  \
+                                    {{ reset_button_text }}                                                                              \
+                                </button>                                                                                                \
+                            </div>                                                                                                       \
+                        </div>                                                                                                           \
+                    </div>                                                                                                               \
+                </form>                                                                                                                  \
             '
     }
 
@@ -128,45 +128,45 @@
      * Get popover number range template
      */
     FilterWidget.prototype.getPopoverNumberRangeTemplate = function () {
-        return '                                                                                                            \
-                <form id="filterPopoverNumberRange-{{ scopeName }}">                                                        \
-                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                        \
-                    <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">    \
-                        <div class="filter-search loading-indicator-container size-input-text">                             \
-                            <div class="field-number">                                                                      \
-                                <div class="right-align">                                                                   \
-                                    <input                                                                                  \
-                                        type="number"                                                                       \
-                                        name="number"                                                                       \
-                                        value="{{ number }}"                                                                \
-                                        class="form-control align-right"                                                    \
-                                        autocomplete="off"                                                                  \
-                                        placeholder="{{ min_placeholder }}" />                                              \
-                                </div>                                                                                      \
-                            </div>                                                                                          \
-                            <div class="field-number">                                                                      \
-                                <div class="right-align">                                                                   \
-                                    <input                                                                                  \
-                                        type="number"                                                                       \
-                                        {{ maxNumber }}                                                                     \
-                                        name="number"                                                                       \
-                                        value="{{ number }}"                                                                \
-                                        class="form-control align-right"                                                    \
-                                        autocomplete="off"                                                                  \
-                                        placeholder="{{ max_placeholder }}" />                                              \
-                                </div>                                                                                      \
-                            </div>                                                                                          \
-                            <div class="filter-buttons">                                                                    \
-                                <button class="btn btn-block btn-primary" data-filter-action="filter">                      \
-                                    {{ filter_button_text }}                                                                \
-                                </button>                                                                                   \
-                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                     \
-                                    {{ reset_button_text }}                                                                 \
-                                </button>                                                                                   \
-                            </div>                                                                                          \
-                        </div>                                                                                              \
-                    </div>                                                                                                  \
-                </form>                                                                                                     \
+        return '                                                                                                                         \
+                <form>                                                                                                                   \
+                    <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                                     \
+                    <div id="controlFilterPopoverNum-{{ scopeName }}" class="control-filter-popover control-filter-box-popover --range"> \
+                        <div class="filter-search loading-indicator-container size-input-text">                                          \
+                            <div class="field-number">                                                                                   \
+                                <div class="right-align">                                                                                \
+                                    <input                                                                                               \
+                                        type="number"                                                                                    \
+                                        name="number"                                                                                    \
+                                        value="{{ number }}"                                                                             \
+                                        class="form-control align-right"                                                                 \
+                                        autocomplete="off"                                                                               \
+                                        placeholder="{{ min_placeholder }}" />                                                           \
+                                </div>                                                                                                   \
+                            </div>                                                                                                       \
+                            <div class="field-number">                                                                                   \
+                                <div class="right-align">                                                                                \
+                                    <input                                                                                               \
+                                        type="number"                                                                                    \
+                                        {{ maxNumber }}                                                                                  \
+                                        name="number"                                                                                    \
+                                        value="{{ number }}"                                                                             \
+                                        class="form-control align-right"                                                                 \
+                                        autocomplete="off"                                                                               \
+                                        placeholder="{{ max_placeholder }}" />                                                           \
+                                </div>                                                                                                   \
+                            </div>                                                                                                       \
+                            <div class="filter-buttons">                                                                                 \
+                                <button class="btn btn-block btn-primary" data-filter-action="filter">                                   \
+                                    {{ filter_button_text }}                                                                             \
+                                </button>                                                                                                \
+                                <button class="btn btn-block btn-secondary" data-filter-action="clear">                                  \
+                                    {{ reset_button_text }}                                                                              \
+                                </button>                                                                                                \
+                            </div>                                                                                                       \
+                        </div>                                                                                                           \
+                    </div>                                                                                                               \
+                </form>                                                                                                                  \
             '
     }
 
@@ -225,7 +225,7 @@
     FilterWidget.prototype.initNumberInputs = function (isRange) {
         var self = this,
             scopeData = this.$activeScope.data('scope-data'),
-            $inputs = $('.field-number input', '#controlFilterPopoverNum'),
+            $inputs = $('.field-number input', '#controlFilterPopoverNum-' + scopeName),
             data = this.scopeValues[this.activeScopeName]
 
         if (!data) {
@@ -288,7 +288,7 @@
             numbers = []
 
         if (!isReset) {
-            var numberinputs = $('.field-number input', '#controlFilterPopoverNum')
+            var numberinputs = $('.field-number input', '#controlFilterPopoverNum-' + scopeName)
             numberinputs.each(function (index, numberinput) {
                 var number = $(numberinput).val()
                 numbers.push(number)

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3052,7 +3052,7 @@ this.dependantUpdateTimers={}
 this.init()}
 FilterWidget.DEFAULTS={optionsHandler:null,updateHandler:null}
 FilterWidget.prototype.getPopoverTemplate=function(){return'                                                                                                       \
-                <form>                                                                                                 \
+                <form id="filterPopover-{{ scopeName }}">                                                              \
                     <input type="hidden" name="scopeName"  value="{{ scopeName }}" />                                  \
                     <div id="controlFilterPopover" class="control-filter-popover control-filter-box-popover --range">  \
                         <div class="filter-search loading-indicator-container size-input-text">                        \
@@ -3269,7 +3269,7 @@ if($scope.hasClass('range')){self.displayPopoverRange($scope)}
 else{self.displayPopoverDate($scope)}
 $scope.addClass('filter-scope-open')})}
 FilterWidget.prototype.getPopoverDateTemplate=function(){return'                                                                                                        \
-                <form>                                                                                                  \
+                <form id="controlFilterPopoverDate-{{ scopeName }}">                                                    \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
                     <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover">       \
                         <div class="filter-search loading-indicator-container size-input-text">                         \
@@ -3295,7 +3295,7 @@ FilterWidget.prototype.getPopoverDateTemplate=function(){return'                
                 </form>                                                                                                 \
             '}
 FilterWidget.prototype.getPopoverRangeTemplate=function(){return'                                                                                                          \
-                <form>                                                                                                    \
+                <form id="controlFilterPopoverRange-{{ scopeName }}">                                                     \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                      \
                     <div id="controlFilterPopoverDate" class="control-filter-popover control-filter-box-popover --range"> \
                         <div class="filter-search loading-indicator-container size-input-text">                           \
@@ -3403,7 +3403,7 @@ if($scope.hasClass('range')){self.displayPopoverNumberRange($scope)}
 else{self.displayPopoverNumber($scope)}
 $scope.addClass('filter-scope-open')})}
 FilterWidget.prototype.getPopoverNumberTemplate=function(){return'                                                                                                        \
-                <form>                                                                                                  \
+                <form id="filterPopoverNumber-{{ scopeName }}">                                                         \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                    \
                     <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">\
                         <div class="filter-search loading-indicator-container size-input-text">                         \
@@ -3429,7 +3429,7 @@ FilterWidget.prototype.getPopoverNumberTemplate=function(){return'              
                 </form>                                                                                                 \
             '}
 FilterWidget.prototype.getPopoverNumberRangeTemplate=function(){return'                                                                                                            \
-                <form>                                                                                                      \
+                <form id="filterPopoverNumberRange-{{ scopeName }}">                                                        \
                     <input type="hidden" name="scopeName" value="{{ scopeName }}" />                                        \
                     <div id="controlFilterPopoverNum" class="control-filter-popover control-filter-box-popover --range">    \
                         <div class="filter-search loading-indicator-container size-input-text">                             \


### PR DESCRIPTION
See github issue: https://github.com/octobercms/october/issues/4845

Best to show screenshots, so you can understand.

### Before

![image](https://user-images.githubusercontent.com/57409060/71377080-952ba900-25bb-11ea-8e65-4db76ee67aff.png)

Fixed width no way to adjust each different filter pop-up container box to different widths. Because October's ID tag is the same for every filter box!

### After

![image](https://user-images.githubusercontent.com/57409060/71377204-fc495d80-25bb-11ea-8629-38875f1a041d.png)

Now can adjust each filter pop-up container boxes to different widths. Because now we got a true unique identifier on every filter box!






