### PR TITLE
Add event to override URL for a record in a List widget

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -677,8 +677,8 @@ class Lists extends WidgetBase
          * @event backend.list.recordUrl
          * Provides an opportunity to define the URL for a particular record in a list.
          *
-         * You may either return a string to define a custom URL for a record, or you may define `false` to force the
-         * record to have no URL, and thus become unclickable.
+         * You may either override the $url parameter with a string to define a custom URL for a record, or you may
+         * override it with `false` to specify the record to have no URL and thus become unclickable.
          *
          * Example usage:
          *

--- a/tests/unit/backend/widgets/ListsTest.php
+++ b/tests/unit/backend/widgets/ListsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Backend;
+use Backend\Helpers\Backend;
 use Backend\Models\User;
 use Backend\Widgets\Lists;
 use October\Rain\Exception\ApplicationException;


### PR DESCRIPTION
Provides an opportunity to define the URL for a particular record in a list widget.

You may either override the $url parameter with a string to define a custom URL for a record, or you may override it with `false` to specify the record to have no URL and thus become unclickable.

~~Resolves #4784.~~