### PR TITLE
Add UTF-8 BOM when exporting with the useList option

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -619,6 +619,7 @@ class ImportExportController extends ControllerBehavior
          * Prepare CSV
          */
         $csv = CsvWriter::createFromFileObject(new SplTempFileObject);
+        $csv->setOutputBOM(CsvWriter::BOM_UTF8);
         $csv->setDelimiter($options['delimiter']);
         $csv->setEnclosure($options['enclosure']);
         $csv->setEscape($options['escape']);


### PR DESCRIPTION
When using the `ImportExportController` behavior in the backend, there are 2 ways to configure it:
1. Export the actual state of the list, including filters and visible columns (option `useList: true`). In this case the CSV output is made by the Behavior.
2. The `/export` route displays a page asking the user to choose columns and the CSV is generated by an AJAX handler (option `useList: false`). An ExportModel is required in this case, and this model will generate the CSV output.

A long time ago in #1958, the ExportModel CSV output was modified to include an UTF-8 BOM, but the output in the behavior was left untouched.
This PR adds the BOM to the behavior output as well.

**Background**
Adding the BOM to a CSV output is (in particular) useful when dealing with files meant to be open by Excel. If no BOM is present, Excel blindly opens the file as if it was encoded with Windows1250 characters (probably depending on the user configured locale). Adding a BOM makes Excel interpret it as UTF-8.