### PR TITLE
Remove excess space from tab titles

### DIFF
--- a/modules/system/assets/ui/js/tab.js
+++ b/modules/system/assets/ui/js/tab.js
@@ -100,7 +100,7 @@
             .attr('data-toggle', 'tab')
 
         if (!$anchor.attr('title'))
-            $anchor.attr('title', $anchor.text())
+            $anchor.attr('title', $anchor.text().trim())
 
         // Setup the required tabs markup if it does not exist already.
         if ($anchor.find('> span.title > span').length < 1) {

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -4588,7 +4588,7 @@ Tab.prototype.initTab=function(li){var
 $tabs=$('>li',this.$tabsContainer),tabIndex=$tabs.index(li),time=new Date().getTime(),targetId=this.tabId+'-tab-'+tabIndex+time,$anchor=$('a',li)
 $anchor.data('target','#'+targetId).attr('data-target','#'+targetId).attr('data-toggle','tab')
 if(!$anchor.attr('title'))
-$anchor.attr('title',$anchor.text())
+$anchor.attr('title',$anchor.text().trim())
 if($anchor.find('> span.title > span').length<1){var html=$anchor.html()
 $anchor.html('').append($('<span class="title"></span>').append($('<span></span>').html(html)))}
 var pane=$('> .tab-pane',this.$pagesContainer).eq(tabIndex).attr('id',targetId)


### PR DESCRIPTION
When creating a backend form with tabs, a title is automatically generated based on the name given to the tab. 

Due to the way the HTML is generated
![Screen Shot 2020-01-14 at 3 56 52 pm](https://user-images.githubusercontent.com/334808/72318211-63ec5780-36e7-11ea-9ee8-7e0992d0d4a5.png)

the results in a massive tooltip when hovering over the tab title consisting mostly of whitespace:
![Screen Shot 2020-01-14 at 3 53 25 pm](https://user-images.githubusercontent.com/334808/72318182-4dde9700-36e7-11ea-8a15-316dd7976d3b.png)

This PR simply trims the whitespace from the title for a much nicer looking tooltip.

The title in my example images was generated with a pretty simple YAML file:
```yaml
tabs:
  fields:
    someField:
      label: My Field
      type: text
      comment: Comment goes here.
      tab: General
```