### PR TITLE
Add "styles" for repeater widgets

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -43,6 +43,15 @@ class Repeater extends FormWidgetBase
      */
     public $maxItems;
 
+    /**
+     * @var string The style of the repeater. Can be one of three values:
+     *  - "default": Shows all repeater items expanded on load.
+     *  - "collapsed": Shows all repeater items collapsed on load.
+     *  - "accordion": Shows only the first repeater item expanded on load. When another item is clicked, all other open
+     *      items are collapsed.
+     */
+    public $style;
+
     //
     // Object properties
     //
@@ -101,6 +110,7 @@ class Repeater extends FormWidgetBase
 
         $this->fillFromConfig([
             'form',
+            'style',
             'prompt',
             'sortable',
             'titleFrom',
@@ -156,6 +166,7 @@ class Repeater extends FormWidgetBase
         $this->vars['titleFrom'] = $this->titleFrom;
         $this->vars['minItems'] = $this->minItems;
         $this->vars['maxItems'] = $this->maxItems;
+        $this->vars['style'] = $this->style;
 
         $this->vars['useGroups'] = $this->useGroups;
         $this->vars['groupDefinitions'] = $this->groupDefinitions;

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -35,7 +35,8 @@
         sortableContainer: 'ul.field-repeater-items',
         titleFrom: null,
         minItems: null,
-        maxItems: null
+        maxItems: null,
+        style: 'default',
     }
 
     Repeater.prototype.init = function() {
@@ -49,6 +50,7 @@
         this.$el.one('dispose-control', this.proxy(this.dispose))
 
         this.togglePrompt()
+        this.setStyle()
     }
 
     Repeater.prototype.dispose = function() {
@@ -157,7 +159,14 @@
 
         ev.preventDefault()
 
-        if (ev.ctrlKey || ev.metaKey) {
+        if (this.getStyle() === 'accordion') {
+            if (isCollapsed) {
+                this.expand($item)
+            }
+            return
+        }
+
+        if ((ev.ctrlKey || ev.metaKey)) {
             isCollapsed ? this.expandAll() : this.collapseAll()
         }
         else {
@@ -189,6 +198,9 @@
     }
 
     Repeater.prototype.expand = function($item) {
+        if (this.getStyle() === 'accordion') {
+            this.collapseAll()
+        }
         $item.removeClass('collapsed')
     }
 
@@ -227,6 +239,36 @@
         }
 
         return defaultText
+    }
+
+    Repeater.prototype.getStyle = function() {
+        var style = 'default';
+
+        // Validate style
+        if (this.options.style && ['collapsed', 'accordion'].indexOf(this.options.style) !== -1) {
+            style = this.options.style
+        }
+
+        return style;
+    }
+
+    Repeater.prototype.setStyle = function() {
+        var style = this.getStyle(),
+            self = this,
+            items = $(this.$el).children('.field-repeater-items').children('.field-repeater-item')
+
+        $.each(items, function(key, item) {
+            switch (style) {
+                case 'collapsed':
+                    self.collapse($(item))
+                    break
+                case 'accordion':
+                    if (key !== 0) {
+                        self.collapse($(item))
+                    }
+                    break
+            }
+        })
     }
 
     // FIELD REPEATER PLUGIN DEFINITION

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -176,7 +176,7 @@
 
     Repeater.prototype.collapseAll = function() {
         var self = this,
-            items = $('.field-repeater-item', this.$el)
+            items = $(this.$el).children('.field-repeater-items').children('.field-repeater-item')
 
         $.each(items, function(key, item){
             self.collapse($(item))
@@ -185,7 +185,7 @@
 
     Repeater.prototype.expandAll = function() {
         var self = this,
-            items = $('.field-repeater-item', this.$el)
+            items = $(this.$el).children('.field-repeater-items').children('.field-repeater-item')
 
         $.each(items, function(key, item){
             self.expand($(item))

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -166,7 +166,7 @@
             return
         }
 
-        if ((ev.ctrlKey || ev.metaKey)) {
+        if (ev.ctrlKey || ev.metaKey) {
             isCollapsed ? this.expandAll() : this.collapseAll()
         }
         else {

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -50,7 +50,7 @@
         this.$el.one('dispose-control', this.proxy(this.dispose))
 
         this.togglePrompt()
-        this.setStyle()
+        this.applyStyle()
     }
 
     Repeater.prototype.dispose = function() {
@@ -252,7 +252,7 @@
         return style;
     }
 
-    Repeater.prototype.setStyle = function() {
+    Repeater.prototype.applyStyle = function() {
         var style = this.getStyle(),
             self = this,
             items = $(this.$el).children('.field-repeater-items').children('.field-repeater-item')

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -3,6 +3,7 @@
      <?= $titleFrom ? 'data-title-from="'.$titleFrom.'"' : '' ?>
      <?= $minItems ? 'data-min-items="'.$minItems.'"' : '' ?>
      <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
+     <?= $style ? 'data-style="'.$style.'"' : '' ?>
      data-sortable-container="#<?= $this->getId('items') ?>"
      data-sortable-handle=".<?= $this->getId('items') ?>-handle">
 


### PR DESCRIPTION
Implements  #4801. Refs: https://github.com/rainlab/builder-plugin/issues/165, #2631

This adds a new configuration option for Repeater widgets, `style`, which defines the style of repeater on load. This configuration option accepts one of the following values:
- `default`: Shows all the repeater items as expanded on load. This is the default current behavior, and is used if `style` is not defined.
- `collapsed`: Shows all the repeater items as collapsed on load. The user can collapse or expand items as they wish.
- `accordion`: Shows only the first repeater item as expanded on load, all others are collapsed. When another item is exanded, any other expanded item is collapsed, effectively making it so that only one item is expanded at a time.

An additional tweak has been made to the "collapse all" and "expand all" functionality as well. These functions now only apply the collapse and expand on items in the same level as the one which the function was triggered - it no longer changes the state of any child or parent items. This matches most nested item interactions (such as those in Windows/OS X and file explorers like in VSCode or PHPStorm).