### PR TITLE
Use browser 2020 recommendations for SameSite cookie rules

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -163,10 +163,14 @@ return [
     | even if the user follows a link to another website. Lax cookies are
     | only sent with a top-level get request.
     |
-    | Supported: "lax", "strict"
+    | First-party cookies that match the domain, be set to 'Strict' or 'Lax'.
+    |
+    | Third-party cookies from other domains, be set to 'None' and need
+    | the Secure set to true.
+    |
+    | Supported: "Lax", "Strict" and "None"
     |
     */
-
-    'same_site' => null,
+    'same_site' => 'Strict',
 
 ];


### PR DESCRIPTION
Discussion found here: https://github.com/octobercms/october/issues/4752

Basically done the following:

1. Removed the `SameSite = null` as default. Under new rules this **will cause an issue** (see point 2).

2. `SameSite = blank`. Under new rules will become `SameSite = None`.

3. Cookies are made up of two main groups `First-party` and `Third-party`. 

3.a). `First-party` cookies are set to strict or lax. Strict has an extra layer of security and I have been running October websites between 1-2 years will zero problems with Strict. (Our company has over 300 October websites, so we have tested it in a big'ish trail for over a year).

For new websites the default will be set to strict.

3.b). `Third-party` cookies are set to `SameSite None` and `Secure true`. 

### Testing guide

First-Party uses flag: `chrome://flags/#same-site-by-default-cookies`

Third-Party uses flag: `chrome://flags/#cookies-without-same-site-must-be-secure`

### Thoughts

Maybe need to update October's min php version to 7.3 or above with regards to SameSite support.

---

Note: **_Issue with Windows 10 and SameSite Google Chrome V80_**, users need to install KB4534273

See here for link: https://support.microsoft.com/en-gb/help/4534273/windows-10-update-kb4534273