### PR TITLE
Add depedency injection to components, controllers and behaviours

### DIFF
--- a/modules/system/classes/DependenciesResolver.php
+++ b/modules/system/classes/DependenciesResolver.php
@@ -30,7 +30,7 @@ class DependenciesResolver
      * @param string $method
      * @return array
      */
-    public function resolveForExtendableObject(object $object, array $parameters, string $method): array
+    public function resolveForExtendableObject($object, array $parameters, string $method): array
     {
         if (method_exists($object, $method)) {
             try {

--- a/modules/system/classes/DependenciesResolver.php
+++ b/modules/system/classes/DependenciesResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace System\Classes;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Routing\RouteDependencyResolverTrait;
+
+class DependenciesResolver
+{
+    use RouteDependencyResolverTrait;
+
+    /**
+     * @var Container
+     */
+    private Container $container;
+
+    /**
+     * @param Container $container
+     */
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Resolve the dependencies for an object which uses the extendable trait
+     *
+     * @param object $object
+     * @param array $parameters
+     * @param string $method
+     * @return array
+     */
+    public function resolveForExtendableObject(object $object, array $parameters, string $method): array
+    {
+        if (method_exists($object, $method)) {
+            try {
+                return $this->resolveMethodDependencies($parameters, new \ReflectionMethod($object, $method));
+            } catch (\ReflectionException $exception) {
+                // do nothing
+            }
+        }
+
+        if (method_exists($object, 'getExtendableCallReflection')) {
+            $reflectionFunction = $object->getExtendableCallReflection($method);
+
+            return $this->resolveMethodDependencies($parameters, $reflectionFunction);
+        }
+
+        return $parameters;
+    }
+}

--- a/modules/system/classes/DependenciesResolver.php
+++ b/modules/system/classes/DependenciesResolver.php
@@ -12,7 +12,7 @@ class DependenciesResolver
     /**
      * @var Container
      */
-    private Container $container;
+    private $container;
 
     /**
      * @param Container $container

--- a/tests/fixtures/plugins/october/tester/components/Archive.php
+++ b/tests/fixtures/plugins/october/tester/components/Archive.php
@@ -1,6 +1,7 @@
 <?php namespace October\Tester\Components;
 
 use Cms\Classes\ComponentBase;
+use Illuminate\Http\Request;
 
 class Archive extends ComponentBase
 {
@@ -37,5 +38,10 @@ class Archive extends ComponentBase
     public function onTestAjax()
     {
         $this->page['var'] = 'page';
+    }
+
+    public function onTestDependencyInjection(Request $request)
+    {
+        return $request->method();
     }
 }

--- a/tests/unit/cms/classes/ControllerTest.php
+++ b/tests/unit/cms/classes/ControllerTest.php
@@ -370,6 +370,20 @@ ESC;
         $this->assertEquals('page', $content['ajax-result']);
     }
 
+    public function testComponentAjaxDependencyInjection()
+    {
+        Request::swap($this->configAjaxRequestMock('testArchive::onTestDependencyInjection'));
+
+        $theme = Theme::load('test');
+        $controller = new Controller($theme);
+        $response = $controller->run('/with-component');
+        $content = $response->getOriginalContent();
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertArrayHasKey('result', $content);
+        $this->assertEquals('POST', $content['result']);
+    }
+
     /**
      * @expectedException        October\Rain\Exception\SystemException
      * @expectedExceptionMessage is not registered for the component

--- a/tests/unit/system/classes/DependencyResolverTest.php
+++ b/tests/unit/system/classes/DependencyResolverTest.php
@@ -49,7 +49,7 @@ class DependencyResolverTest extends TestCase
         );
 
         $this->assertInstanceOf(Request::class, $result[0]);
-        $this->assertInstanceOf('test', $result[1]);
+        $this->assertEquals('test', $result[1]);
     }
 
     ///
@@ -88,6 +88,6 @@ class DependencyResolverTest extends TestCase
 //        );
 //
 //        $this->assertInstanceOf(Request::class, $result[0]);
-//        $this->assertInstanceOf('test', $result[1]);
+//        $this->assertEquals('test', $result[1]);
 //    }
 }

--- a/tests/unit/system/classes/DependencyResolverTest.php
+++ b/tests/unit/system/classes/DependencyResolverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Illuminate\Http\Request;
+use October\Rain\Extension\ExtendableTrait;
+use System\Classes\DependenciesResolver;
+
+class DependencyTestClass
+{
+    use ExtendableTrait;
+
+    public function testDependencyInjection(Request $request)
+    {
+    }
+
+    public function testDependencyInjectionWithParameters(Request $request, string $key)
+    {
+    }
+}
+
+class DependencyResolverTest extends TestCase
+{
+    public function testDependencyInjection()
+    {
+        /** @var DependenciesResolver $dependencyResolver */
+        $dependencyResolver = $this->app->make(DependenciesResolver::class);
+
+        $dependencyTestClass = new DependencyTestClass();
+
+        $result = $dependencyResolver->resolveForExtendableObject(
+            $dependencyTestClass,
+            [],
+            'testDependencyInjection'
+        );
+
+        $this->assertInstanceOf(Request::class, $result[0]);
+    }
+
+    public function testDependencyInjectionWithParameters()
+    {
+        /** @var DependenciesResolver $dependencyResolver */
+        $dependencyResolver = $this->app->make(DependenciesResolver::class);
+
+        $dependencyTestClass = new DependencyTestClass();
+
+        $result = $dependencyResolver->resolveForExtendableObject(
+            $dependencyTestClass,
+            ['test'],
+            'testDependencyInjection'
+        );
+
+        $this->assertInstanceOf(Request::class, $result[0]);
+        $this->assertInstanceOf('test', $result[1]);
+    }
+
+    ///
+    /// Uncomment below when PR https://github.com/octobercms/library/pull/453 is merged
+    ///
+
+//    public function testDependencyInjectionDynamicMethod()
+//    {
+//        /** @var DependenciesResolver $dependencyResolver */
+//        $dependencyResolver = $this->app->make(DependenciesResolver::class);
+//
+//        $dependencyTestClass = new DependencyTestClass();
+//        $dependencyTestClass->addDynamicMethod('testDynamic', static function (Request $request) {});
+//
+//        $result = $dependencyResolver->resolveForExtendableObject(
+//            $dependencyTestClass,
+//            [],
+//            'testDynamic'
+//        );
+//
+//        $this->assertInstanceOf(Request::class, $result[0]);
+//    }
+//
+//    public function testDependencyInjectionDynamicMethodWithParameters()
+//    {
+//        /** @var DependenciesResolver $dependencyResolver */
+//        $dependencyResolver = $this->app->make(DependenciesResolver::class);
+//
+//        $dependencyTestClass = new DependencyTestClass();
+//        $dependencyTestClass->addDynamicMethod('testDynamic', static function (Request $request) {});
+//
+//        $result = $dependencyResolver->resolveForExtendableObject(
+//            $dependencyTestClass,
+//            ['testDynamic'],
+//            'testDependencyInjection'
+//        );
+//
+//        $this->assertInstanceOf(Request::class, $result[0]);
+//        $this->assertInstanceOf('test', $result[1]);
+//    }
+}


### PR DESCRIPTION
# Problem
In the current components, controllers and behaviours we don't have dependency injection. This forces us to use facades or resolve the dependencies manually with the `app` or `resolve` helper methods.
# Solution
Resolve the dependencies like laravel does with their controller actions for:
- Ajax handlers in components, behaviours and backend controllers
- Actions in backend controllers
- Methods defined with `addDynamicMethod` for components and backend controllers

This allows us to have an ajax handler like this:
```php
public function onTest(Illuminate\Http\Request $request){
     dd($request->all());
}
```
# Related PR
For this functionality to work I made this PR octobercms/library#453

# Discussion
I would also like to see dependency injection for the `init` method for a component, but this requires us to remove the init method from the ComponentBase class.