### PR TITLE
Protect server logs files when server errors are created

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,6 +21,7 @@
     ##
     ## Black listed folders
     ##
+    RewriteRule .log$ index.php [L,NC]
     RewriteRule ^bootstrap/.* index.php [L,NC]
     RewriteRule ^config/.* index.php [L,NC]
     RewriteRule ^vendor/.* index.php [L,NC]
@@ -55,12 +56,5 @@
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
-    
-    ##
-    ## Block browser access to log files
-    ##
-    <Files ~ "\.log$">
-        Require all denied
-    </Files>
 
 </IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -55,5 +55,12 @@
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
+    
+    ##
+    ## Block browser access to log files
+    ##
+	<Files  ~ "\.log$">
+  		Require all denied
+	</Files>
 
 </IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -59,8 +59,8 @@
     ##
     ## Block browser access to log files
     ##
-	<Files  ~ "\.log$">
-  		Require all denied
-	</Files>
+    <Files ~ "\.log$">
+        Require all denied
+    </Files>
 
 </IfModule>


### PR DESCRIPTION
This is part of the work we are doing with our October CMS Version II Proposal - Security Module, found here: https://github.com/ayumi-cloud/oc-security-module

We feel this update should be added now to October CMS version 1.

Basically when a php error is created the server will create an `errors.log` file at the root of the server. This is kind of bad as the file contains your server full url past the `public` folder.

To protect this important file, we decided to block all access to all `.log` files.

So if the file does get created, then October protects the webmaster/developer anyway.