### PR TITLE
Fix small typo in number range filter widget

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -153,7 +153,7 @@ class Filter extends WidgetBase
                     $min = $scope->value[0];
                     $max = $scope->value[1];
 
-                    $params['minStr'] = $min ?? '∞';
+                    $params['minStr'] = $min ?? '-∞';
                     $params['min'] = $min ?? null;
 
                     $params['maxStr'] = $max ?? '∞';


### PR DESCRIPTION
When a `max` is defined with no `min`, the filter should read "Negative infinity → max". Right now, it reads "Infinity → max", which is not accurate.

Before:
<img width="222" alt="Screen Shot 2020-01-16 at 8 12 02 PM" src="https://user-images.githubusercontent.com/7980426/72581438-925f6380-389c-11ea-9a21-2257bbe29ff9.png">

After:
<img width="216" alt="Screen Shot 2020-01-16 at 8 12 29 PM" src="https://user-images.githubusercontent.com/7980426/72581439-925f6380-389c-11ea-92dc-6d3eafae07f8.png">
