### PR TITLE
Fix and standardized cross-browser focus ring issues

### DIFF
--- a/modules/system/assets/ui/less/site.normalize.less
+++ b/modules/system/assets/ui/less/site.normalize.less
@@ -1,3 +1,13 @@
+/*! Make focus ring standard on every browser */
+
+// See github issue https://github.com/octobercms/october/issues/4892
+
+&:focus {
+    outline: none;
+    -webkit-box-shadow: inset 0 1px 2px rgba(27,31,35,.075), 0 0 0 0.2em rgba(3,102,214,.3);
+    box-shadow: inset 0 1px 2px rgba(27,31,35,.075), 0 0 0 0.2em rgba(3,102,214,.3);
+}
+
 /*! normalize.css v3.0.0 | MIT License | git.io/normalize */
 
 //

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -1,3 +1,4 @@
+:focus {outline:none;-webkit-box-shadow:inset 0 1px 2px rgba(27,31,35,.075),0 0 0 .2em rgba(3,102,214,.3);box-shadow:inset 0 1px 2px rgba(27,31,35,.075),0 0 0 .2em rgba(3,102,214,.3)}
 html {font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
 body {margin:0}
 article,


### PR DESCRIPTION
This fixes the github issue: https://github.com/octobercms/october/issues/4892

Google Chrome 1 - 80 used a light blue focus ring and Chrome 81 and above uses a dark black line. I have a theory they changed this for people with poor eye sight?

### Chrome 81 (before)

![image](https://user-images.githubusercontent.com/57409060/72822063-60b61600-3c69-11ea-8747-f8e25a0e69be.png)

### Chrome 81 (after)

![image](https://user-images.githubusercontent.com/57409060/72822088-6ad81480-3c69-11ea-9a4c-30ab982d23d8.png)

p.s. In firefox it will remove the dotted line and put the same blue line as seen in the after picture in chrome into firefrox.