### PR TITLE
Load mail templates from view files if not found in the database

### DIFF
--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -68,13 +68,18 @@ class MailLayout extends Model
 
     public static function getIdFromCode($code)
     {
-        $layoutId = array_get(self::listCodes(), $code);
-        if ($layoutId === null) {
-            self::createLayouts();
-            self::$codeCache = null;
-            $layoutId = array_get(self::listCodes(), $code);
+        return array_get(self::listCodes(), $code);
+    }
+
+    public static function findOrMakeLayout($code)
+    {
+        $layout = self::whereCode($code)->first();
+        if (!$layout && View::exists($code)) {
+            $layout = new self;
+            $layout->code = $code;
+            $layout->fillFromView($code);
         }
-        return $layoutId;
+        return $layout;
     }
 
     /**

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -74,11 +74,13 @@ class MailLayout extends Model
     public static function findOrMakeLayout($code)
     {
         $layout = self::whereCode($code)->first();
+
         if (!$layout && View::exists($code)) {
             $layout = new self;
             $layout->code = $code;
             $layout->fillFromView($code);
         }
+
         return $layout;
     }
 

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -68,13 +68,13 @@ class MailLayout extends Model
 
     public static function getIdFromCode($code)
     {
-        $styleId = array_get(self::listCodes(), $code);
-        if ($styleId === null) {
+        $layoutId = array_get(self::listCodes(), $code);
+        if ($layoutId === null) {
             self::createLayouts();
             self::$codeCache = null;
-            $styleId = array_get(self::listCodes(), $code);
+            $layoutId = array_get(self::listCodes(), $code);
         }
-        return $styleId;
+        return $layoutId;
     }
 
     /**

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -68,7 +68,13 @@ class MailLayout extends Model
 
     public static function getIdFromCode($code)
     {
-        return array_get(self::listCodes(), $code);
+        $styleId = array_get(self::listCodes(), $code);
+        if ($styleId === null) {
+            self::createLayouts();
+            self::$codeCache = null;
+            $styleId = array_get(self::listCodes(), $code);
+        }
+        return $styleId;
     }
 
     /**

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -141,7 +141,7 @@ class MailTemplate extends Model
         $this->subject = array_get($sections, 'settings.subject', 'No subject');
 
         $layoutCode = array_get($sections, 'settings.layout', 'default');
-        $this->layout_id = MailLayout::getIdFromCode($layoutCode);
+        $this->layout = MailLayout::findOrMakeLayout($layoutCode);
     }
 
     protected static function getTemplateSections($code)


### PR DESCRIPTION
The new layout should be saved in the system_mail_layouts table.

The  `MailLayout::createLayouts();` only be called in the MailTemplate Controller. So, the new mail layout can be added to the database only after opened the Mail templates page in the settings.

The current code will auto run `MailLayout::createLayouts();` when the layout code not found in the database.