### PR TITLE
Updated getParameter method

### DIFF
--- a/modules/cms/classes/Router.php
+++ b/modules/cms/classes/Router.php
@@ -300,15 +300,13 @@ class Router
 
     /**
      * Returns a routing parameter.
-     * @return array
+     * @param  string $name
+     * @param  string|null $default
+     * @return string|null
      */
-    public function getParameter($name, $default = null)
+    public function getParameter(string $name, string $default = null)
     {
-        if (isset($this->parameters[$name]) && ($this->parameters[$name] === '0' || !empty($this->parameters[$name]))) {
-            return $this->parameters[$name];
-        }
-
-        return $default;
+        return $this->parameters[$name] ?? $default;
     }
 
     /**

--- a/modules/cms/classes/Router.php
+++ b/modules/cms/classes/Router.php
@@ -306,7 +306,8 @@ class Router
      */
     public function getParameter(string $name, string $default = null)
     {
-        return $this->parameters[$name] ?? $default;
+        $value = $this->parameters[$name] ?? '';
+        return $value !== '' ? $value : $default;
     }
 
     /**


### PR DESCRIPTION
Fixed typehinting for getParameter method in Router class (this method returns a string or null, not an array) and simplified its body.