### PR TITLE
Add info about adding custom rules to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -52,6 +52,7 @@
 
     ##
     ## Standard routes
+    ## Add any custom rules above this line, anything below this line won't take effect
     ##
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]


### PR DESCRIPTION
As per conversion with @LukeTowers 

It's important to place custom rules in `.htaccess` **before** the last code line and not **after** as they will not work. Below is proof of concept:

### After example

![image](https://user-images.githubusercontent.com/57409060/73022008-9e10d400-3e20-11ea-82cb-69d2c9254716.png)

Above: Not working returns a `404` error code.

### Before example

![image](https://user-images.githubusercontent.com/57409060/73021753-1925ba80-3e20-11ea-8c91-195e93c8ccc0.png)

Above: Working returns a `403` error code.
