### PR TITLE
Add variable helpers for ComponentBase

### DIFF
--- a/modules/cms/classes/ComponentBase.php
+++ b/modules/cms/classes/ComponentBase.php
@@ -264,6 +264,28 @@ abstract class ComponentBase extends Extendable
     }
 
     /**
+     * Sets an variable for component and page
+     * @param string $name Variable name
+     * @param mixed $value Value of variable
+     * @return mixed
+     */
+    protected function setVar($name, $value)
+    {
+        return $this->$name = $this->page[$name] = $value;
+    }
+
+    /**
+     * Sets an variable for page
+     * @param string $name Variable name
+     * @param mixed $value Value of variable
+     * @return mixed
+     */
+    protected function setPageVar($name, $value)
+    {
+        return $this->page[$name] = $value;
+    }
+
+    /**
      * Returns the external property name when the property value is an external property reference.
      * Otherwise the default value specified is returned.
      * @param string $name The property name


### PR DESCRIPTION
Using this helpers for a long time now and i was thinking maybe it will be good to make it as PR for core. What you think?


###  Usage of methods:

* `setVar` - if we want to set component variable and page variable
* `setPageVar` - or if we want to set only page variable

```php
class ProductsList extends ComponentBase
{
    public $myVariable;

    public function init()
    {
        $this->setVar('myVariable', 'value');
        $this->setPageVar('myPageVariable', 'value2');
    }
}
```