### PR TITLE
Storm: Disabled state for unchecked checkbox

### DIFF
--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -142,11 +142,8 @@
     }
 
     input:disabled + label:before {
+        background-color: #999 !important;
         border: 1px solid @color-checkbox-border !important;
-    }
-
-    input:disabled:checked + label:before {
-        background-color: #999;
     }
 
     &:focus {

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4119,9 +4119,7 @@ html.cssanimations .cursor-loading-indicator.hide {display:none}
 .custom-checkbox input[type=checkbox]:indeterminate + label:before,
 .custom-radio input[type=checkbox]:indeterminate + label:before {font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f068"}
 .custom-checkbox input:disabled + label:before,
-.custom-radio input:disabled + label:before {border:1px solid #d1d6d9 !important}
-.custom-checkbox input:disabled:checked + label:before,
-.custom-radio input:disabled:checked + label:before {background-color:#999}
+.custom-radio input:disabled + label:before {background-color:#999 !important;border:1px solid #d1d6d9 !important}
 .custom-checkbox:focus,
 .custom-radio:focus {outline:none}
 .custom-checkbox:focus label:before,


### PR DESCRIPTION
There was no visual difference in the disabled state for unchecked checkboxes.

**Before:**
<img width="197" alt="Capture d’écran 2020-01-28 à 12 59 30" src="https://user-images.githubusercontent.com/1875998/73265053-78931a00-41d4-11ea-9980-0b92040e9236.png">

**After:**
<img width="214" alt="Capture d’écran 2020-01-28 à 13 40 11" src="https://user-images.githubusercontent.com/1875998/73265064-7fba2800-41d4-11ea-9329-701e864afe79.png">

I tried to compile the assets using the october:util compile assets command but it generates other unwanted changes (for instance it replaces .2em with 0.2rem), so I didn't include them in the PR. Is there any setup to be done to compile assets?
