### PR TITLE
Allow DI in console command constructor

### DIFF
--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -262,11 +262,7 @@ class PluginBase extends ServiceProviderBase
     public function registerConsoleCommand($key, $class)
     {
         $key = 'command.'.$key;
-
-        $this->app->singleton($key, function ($app) use ($class) {
-            return new $class;
-        });
-
+        $this->app->singleton($key, $class);
         $this->commands($key);
     }
 

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -256,13 +256,13 @@ class PluginBase extends ServiceProviderBase
      * Registers a new console (artisan) command
      *
      * @param string $key The command name
-     * @param string $class The command class
+     * @param string|\Closure $command The command class or closure
      * @return void
      */
-    public function registerConsoleCommand($key, $class)
+    public function registerConsoleCommand($key, $command)
     {
         $key = 'command.'.$key;
-        $this->app->singleton($key, $class);
+        $this->app->singleton($key, $command);
         $this->commands($key);
     }
 


### PR DESCRIPTION
When registering a console command in your Plugin.php by using the registerConsoleCommand method it is currently not allowed to have any parameters the constructor of your command. This pull request addresses that issue by simply binding the class name in the container instead of an object that is constructed without parameters.