### PR TITLE
Improve error message for safe mode enabled

### DIFF
--- a/modules/cms/lang/en/lang.php
+++ b/modules/cms/lang/en/lang.php
@@ -11,7 +11,7 @@ return [
         'error_deleting' => "Error deleting the template file ':name'. Please check write permissions.",
         'delete_success' => 'Templates deleted: :count.',
         'file_name_required' => 'The File Name field is required.',
-        'safe_mode_enabled' => 'Safe mode is currently enabled (editing the PHP section is disabled) to turn this off, edit the config file: \'cms/enableSafeMode\'.'
+        'safe_mode_enabled' => 'Safe mode is currently enabled. Editing the PHP code of CMS templates is disabled. To disable safe mode, set the `cms.enableSafeMode` configuration value to `false`.',
     ],
     'dashboard' => [
         'active_theme' => [

--- a/modules/cms/lang/en/lang.php
+++ b/modules/cms/lang/en/lang.php
@@ -11,7 +11,7 @@ return [
         'error_deleting' => "Error deleting the template file ':name'. Please check write permissions.",
         'delete_success' => 'Templates deleted: :count.',
         'file_name_required' => 'The File Name field is required.',
-        'safe_mode_enabled' => 'Safe mode is currently enabled. Editing the PHP code of CMS templates is disabled.'
+        'safe_mode_enabled' => 'Safe mode is currently enabled (editing the PHP section is disabled) to turn this off, edit the config file: \'cms/enableSafeMode\'.'
     ],
     'dashboard' => [
         'active_theme' => [


### PR DESCRIPTION
As per my comment here: https://github.com/octobercms/october/issues/4924

> Also the message is not the greatest, could it not mention to edit the config file: cms/enableSafeMode

Picture a newbie user using October CMS for the first time, my error message does the following:

1. Tell them the exact issue.
2. Tell them the exact solution.