### PR TITLE
Modify menu structure to objects

### DIFF
--- a/modules/backend/classes/MainMenuItem.php
+++ b/modules/backend/classes/MainMenuItem.php
@@ -1,0 +1,293 @@
+<?php namespace Backend\Classes;
+
+use October\Rain\Exception\SystemException;
+
+/**
+ * Class MainMenuItem
+ *
+ * @package Backend\Classes
+ */
+class MainMenuItem
+{
+    /**
+     * @var string
+     */
+    public $code;
+
+    /**
+     * @var string
+     */
+    public $owner;
+
+    /**
+     * @var string
+     */
+    public $label;
+
+    /**
+     * @var null|string
+     */
+    public $icon;
+
+    /**
+     * @var null|string
+     */
+    public $iconSvg;
+
+    /**
+     * @var mixed
+     */
+    public $counter;
+
+    /**
+     * @var null|string
+     */
+    public $counterLabel;
+
+    /**
+     * @var string
+     */
+    public $url;
+
+    /**
+     * @var array
+     */
+    public $permissions = [];
+
+    /**
+     * @var int
+     */
+    public $order = 500;
+
+    /**
+     * @var SideMenuItem[]
+     */
+    public $sideMenu = [];
+
+    /**
+     * @return string
+     */
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     */
+    public function setCode(string $code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOwner(): string
+    {
+        return $this->owner;
+    }
+
+    /**
+     * @param string $owner
+     */
+    public function setOwner(string $owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * @param string $label
+     */
+    public function setLabel(string $label)
+    {
+        $this->label = $label;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @param string|null $icon
+     */
+    public function setIcon($icon)
+    {
+        $this->icon = $icon;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIconSvg()
+    {
+        return $this->iconSvg;
+    }
+
+    /**
+     * @param string|null $iconSvg
+     */
+    public function setIconSvg($iconSvg)
+    {
+        $this->iconSvg = $iconSvg;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCounter()
+    {
+        return $this->counter;
+    }
+
+    /**
+     * @param mixed $counter
+     */
+    public function setCounter($counter)
+    {
+        $this->counter = $counter;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCounterLabel()
+    {
+        return $this->counterLabel;
+    }
+
+    /**
+     * @param string|null $counterLabel
+     */
+    public function setCounterLabel($counterLabel)
+    {
+        $this->counterLabel = $counterLabel;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function setUrl(string $url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPermissions(): array
+    {
+        return $this->permissions;
+    }
+
+    /**
+     * @param array $permissions
+     */
+    public function setPermissions(array $permissions)
+    {
+        $this->permissions = $permissions;
+    }
+
+    /**
+     * @param string $permission
+     * @param array $definition
+     */
+    public function addPermission(string $permission, array $definition)
+    {
+        $this->permissions[$permission] = $definition;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrder(): int
+    {
+        return $this->order;
+    }
+
+    /**
+     * @param int $order
+     */
+    public function setOrder(int $order)
+    {
+        $this->order = $order;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSideMenu(): array
+    {
+        return $this->sideMenu;
+    }
+
+    /**
+     * @param SideMenuItem $sideMenu
+     */
+    public function addSideMenuItem(SideMenuItem $sideMenu)
+    {
+        $this->sideMenu[$sideMenu->getCode()] = $sideMenu;
+    }
+
+    /**
+     * @param string $code
+     * @return SideMenuItem
+     * @throws SystemException
+     */
+    public function getSideMenuItem(string $code): SideMenuItem
+    {
+        if (!array_key_exists($code, $this->sideMenu)) {
+            throw new SystemException('No sidenavigation item available with code ' . $code);
+        }
+
+        return $this->sideMenu[$code];
+    }
+
+    /**
+     * @param string $code
+     */
+    public function removeSideMenuItem(string $code)
+    {
+        unset($this->sideMenu[$code]);
+    }
+
+    /**
+     * @param array $data
+     * @return static
+     */
+    public static function createFromArray(array $data): self
+    {
+        $instance = new self();
+        $instance->code = $data['code'];
+        $instance->owner = $data['owner'];
+        $instance->label = $data['label'];
+        $instance->url = $data['url'];
+        $instance->icon = $data['icon'] ?? null;
+        $instance->iconSvg = $data['iconSvg'] ?? null;
+        $instance->counter = $data['counter'] ?? null;
+        $instance->counterLabel = $data['counterLabel'] ?? null;
+        $instance->permissions = $data['permissions'] ?? $instance->permissions;
+        $instance->order = $data['order'] ?? $instance->order;
+        return $instance;
+    }
+}

--- a/modules/backend/classes/MainMenuItem.php
+++ b/modules/backend/classes/MainMenuItem.php
@@ -107,7 +107,7 @@ class MainMenuItem
      * @param array $data
      * @return static
      */
-    public static function createFromArray(array $data): self
+    public static function createFromArray(array $data)
     {
         $instance = new static();
         $instance->code = $data['code'];

--- a/modules/backend/classes/MainMenuItem.php
+++ b/modules/backend/classes/MainMenuItem.php
@@ -65,150 +65,6 @@ class MainMenuItem
     public $sideMenu = [];
 
     /**
-     * @return string
-     */
-    public function getCode(): string
-    {
-        return $this->code;
-    }
-
-    /**
-     * @param string $code
-     */
-    public function setCode(string $code)
-    {
-        $this->code = $code;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOwner(): string
-    {
-        return $this->owner;
-    }
-
-    /**
-     * @param string $owner
-     */
-    public function setOwner(string $owner)
-    {
-        $this->owner = $owner;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLabel(): string
-    {
-        return $this->label;
-    }
-
-    /**
-     * @param string $label
-     */
-    public function setLabel(string $label)
-    {
-        $this->label = $label;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getIcon()
-    {
-        return $this->icon;
-    }
-
-    /**
-     * @param string|null $icon
-     */
-    public function setIcon($icon)
-    {
-        $this->icon = $icon;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getIconSvg()
-    {
-        return $this->iconSvg;
-    }
-
-    /**
-     * @param string|null $iconSvg
-     */
-    public function setIconSvg($iconSvg)
-    {
-        $this->iconSvg = $iconSvg;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getCounter()
-    {
-        return $this->counter;
-    }
-
-    /**
-     * @param mixed $counter
-     */
-    public function setCounter($counter)
-    {
-        $this->counter = $counter;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getCounterLabel()
-    {
-        return $this->counterLabel;
-    }
-
-    /**
-     * @param string|null $counterLabel
-     */
-    public function setCounterLabel($counterLabel)
-    {
-        $this->counterLabel = $counterLabel;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrl(): string
-    {
-        return $this->url;
-    }
-
-    /**
-     * @param string $url
-     */
-    public function setUrl(string $url)
-    {
-        $this->url = $url;
-    }
-
-    /**
-     * @return array
-     */
-    public function getPermissions(): array
-    {
-        return $this->permissions;
-    }
-
-    /**
-     * @param array $permissions
-     */
-    public function setPermissions(array $permissions)
-    {
-        $this->permissions = $permissions;
-    }
-
-    /**
      * @param string $permission
      * @param array $definition
      */
@@ -218,35 +74,11 @@ class MainMenuItem
     }
 
     /**
-     * @return int
-     */
-    public function getOrder(): int
-    {
-        return $this->order;
-    }
-
-    /**
-     * @param int $order
-     */
-    public function setOrder(int $order)
-    {
-        $this->order = $order;
-    }
-
-    /**
-     * @return array
-     */
-    public function getSideMenu(): array
-    {
-        return $this->sideMenu;
-    }
-
-    /**
      * @param SideMenuItem $sideMenu
      */
     public function addSideMenuItem(SideMenuItem $sideMenu)
     {
-        $this->sideMenu[$sideMenu->getCode()] = $sideMenu;
+        $this->sideMenu[$sideMenu->code] = $sideMenu;
     }
 
     /**

--- a/modules/backend/classes/MainMenuItem.php
+++ b/modules/backend/classes/MainMenuItem.php
@@ -109,7 +109,7 @@ class MainMenuItem
      */
     public static function createFromArray(array $data): self
     {
-        $instance = new self();
+        $instance = new static();
         $instance->code = $data['code'];
         $instance->owner = $data['owner'];
         $instance->label = $data['label'];

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -157,7 +157,7 @@ class NavigationManager
             /*
              * Filter items user lacks permission for
              */
-            $item->sideMenu = $this->filterItemPermissions($user, $item->getSideMenu());
+            $item->sideMenu = $this->filterItemPermissions($user, $item->sideMenu);
         }
     }
 
@@ -377,23 +377,23 @@ class NavigationManager
         }
 
         foreach ($this->items as $item) {
-            if ($item->getCounter() === false) {
+            if ($item->counter === false) {
                 continue;
             }
 
-            if ($item->getCounter() !== null && is_callable($item->getCounter())) {
-                $item->setCounter(call_user_func($item->getCounter(), $item));
-            } elseif (!empty((int) $item->getCounter())) {
-                $item->setCounter((int) $item->getCounter());
-            } elseif (!empty($sideItems = $this->listSideMenuItems($item->getOwner(), $item->getCode()))) {
+            if ($item->counter !== null && is_callable($item->counter)) {
+                $item->counter = call_user_func($item->counter, $item);
+            } elseif (!empty((int) $item->counter)) {
+                $item->counter = (int) $item->counter;
+            } elseif (!empty($sideItems = $this->listSideMenuItems($item->owner, $item->code))) {
                 $item->counter = 0;
                 foreach ($sideItems as $sideItem) {
                     $item->counter += $sideItem->counter;
                 }
             }
 
-            if (empty($item->getCounter())) {
-                $item->setCounter(null);
+            if (empty($item->counter)) {
+                $item->counter = null;
             }
         }
 
@@ -427,13 +427,13 @@ class NavigationManager
             return [];
         }
 
-        $items = $activeItem->getSideMenu();
+        $items = $activeItem->sideMenu;
 
         foreach ($items as $item) {
-            if ($item->getCounter() !== null && is_callable($item->getCounter())) {
-                $item->setCounter(call_user_func($item->getCounter(), $item));
-                if (empty($item->getCounter())) {
-                    $item->setCounter(null);
+            if ($item->counter !== null && is_callable($item->counter)) {
+                $item->counter = call_user_func($item->counter, $item);
+                if (empty($item->counter)) {
+                    $item->counter = null;
                 }
             }
         }
@@ -507,7 +507,7 @@ class NavigationManager
      */
     public function isMainMenuItemActive($item): bool
     {
-        return $this->contextOwner === $item->getOwner() && $this->contextMainMenuItemCode === $item->getCode();
+        return $this->contextOwner === $item->owner && $this->contextMainMenuItemCode === $item->code;
     }
 
     /**
@@ -538,7 +538,7 @@ class NavigationManager
             return true;
         }
 
-        return $this->contextOwner === $item->getOwner() && $this->contextSideMenuItemCode === $item->getCode();
+        return $this->contextOwner === $item->owner && $this->contextSideMenuItemCode === $item->code;
     }
 
     /**
@@ -581,11 +581,11 @@ class NavigationManager
         }
 
         $items = array_filter($items, static function ($item) use ($user) {
-            if (!$item->getPermissions() || !count($item->getPermissions())) {
+            if (!$item->permissions || !count($item->permissions)) {
                 return true;
             }
 
-            return $user->hasAnyAccess($item->getPermissions());
+            return $user->hasAnyAccess($item->permissions);
         });
 
         return $items;

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -1,9 +1,7 @@
 <?php namespace Backend\Classes;
 
-use Backend\Models\User;
 use Event;
 use BackendAuth;
-use October\Rain\Support\Traits\Singleton;
 use System\Classes\PluginManager;
 use Validator;
 use SystemException;
@@ -18,7 +16,7 @@ use Config;
  */
 class NavigationManager
 {
-    use Singleton;
+    use \October\Rain\Support\Traits\Singleton;
 
     /**
      * @var array Cache of registration callbacks.
@@ -570,7 +568,7 @@ class NavigationManager
 
     /**
      * Removes menu items from an array if the supplied user lacks permission.
-     * @param User $user A user object
+     * @param \Backend\Models\User $user A user object
      * @param MainMenuItem[]|SideMenuItem[] $items A collection of menu items
      * @return array The filtered menu items
      */

--- a/modules/backend/classes/SideMenuItem.php
+++ b/modules/backend/classes/SideMenuItem.php
@@ -1,0 +1,279 @@
+<?php namespace Backend\Classes;
+
+/**
+ * Class SideMenuItem
+ *
+ * @package Backend\Classes
+ */
+class SideMenuItem
+{
+    /**
+     * @var string
+     */
+    public $code;
+
+    /**
+     * @var string
+     */
+    public $owner;
+
+    /**
+     * @var string
+     */
+    public $label;
+
+    /**
+     * @var null|string
+     */
+    public $icon;
+
+    /**
+     * @var null|string
+     */
+    public $iconSvg;
+
+    /**
+     * @var string
+     */
+    public $url;
+
+    /**
+     * @var null|int|callable
+     */
+    public $counter;
+
+    /**
+     * @var null|string
+     */
+    public $counterLabel;
+
+    /**
+     * @var int
+     */
+    public $order = -1;
+
+    /**
+     * @var array
+     */
+    public $attributes = [];
+
+    /**
+     * @var array
+     */
+    public $permissions = [];
+
+    /**
+     * @return string
+     */
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     */
+    public function setCode(string $code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOwner(): string
+    {
+        return $this->owner;
+    }
+
+    /**
+     * @param string $owner
+     */
+    public function setOwner(string $owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * @param string $label
+     */
+    public function setLabel(string $label)
+    {
+        $this->label = $label;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @param string|null $icon
+     */
+    public function setIcon($icon)
+    {
+        $this->icon = $icon;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIconSvg()
+    {
+        return $this->iconSvg;
+    }
+
+    /**
+     * @param string|null $iconSvg
+     */
+    public function setIconSvg($iconSvg)
+    {
+        $this->iconSvg = $iconSvg;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function setUrl(string $url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @return callable|int|null
+     */
+    public function getCounter()
+    {
+        return $this->counter;
+    }
+
+    /**
+     * @param callable|int|null $counter
+     */
+    public function setCounter($counter)
+    {
+        $this->counter = $counter;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCounterLabel()
+    {
+        return $this->counterLabel;
+    }
+
+    /**
+     * @param string|null $counterLabel
+     */
+    public function setCounterLabel($counterLabel)
+    {
+        $this->counterLabel = $counterLabel;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrder(): int
+    {
+        return $this->order;
+    }
+
+    /**
+     * @param int $order
+     */
+    public function setOrder(int $order)
+    {
+        $this->order = $order;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param array $attributes
+     */
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * @param null|string|int $attribute
+     * @param null|string|array $value
+     */
+    public function addAttribute($attribute, $value)
+    {
+        $this->attributes[$attribute] = $value;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPermissions(): array
+    {
+        return $this->permissions;
+    }
+
+    /**
+     * @param array $permissions
+     */
+    public function setPermissions(array $permissions)
+    {
+        $this->permissions = $permissions;
+    }
+
+    /**
+     * @param string $permission
+     * @param array $definition
+     */
+    public function addPermission(string $permission, array $definition)
+    {
+        $this->permissions[$permission] = $definition;
+    }
+
+    /**
+     * @param array $data
+     * @return static
+     */
+    public static function createFromArray(array $data): self
+    {
+        $instance = new self();
+        $instance->code = $data['code'];
+        $instance->owner = $data['owner'];
+        $instance->label = $data['label'];
+        $instance->url = $data['url'];
+        $instance->icon = $data['icon'] ?? null;
+        $instance->iconSvg = $data['iconSvg'] ?? null;
+        $instance->counter = $data['counter'] ?? null;
+        $instance->counterLabel = $data['counterLabel'] ?? null;
+        $instance->attributes = $data['attributes'] ?? $instance->attributes;
+        $instance->permissions = $data['permissions'] ?? $instance->permissions;
+        $instance->order = $data['order'] ?? $instance->order;
+        return $instance;
+    }
+}

--- a/modules/backend/classes/SideMenuItem.php
+++ b/modules/backend/classes/SideMenuItem.php
@@ -63,166 +63,6 @@ class SideMenuItem
     public $permissions = [];
 
     /**
-     * @return string
-     */
-    public function getCode(): string
-    {
-        return $this->code;
-    }
-
-    /**
-     * @param string $code
-     */
-    public function setCode(string $code)
-    {
-        $this->code = $code;
-    }
-
-    /**
-     * @return string
-     */
-    public function getOwner(): string
-    {
-        return $this->owner;
-    }
-
-    /**
-     * @param string $owner
-     */
-    public function setOwner(string $owner)
-    {
-        $this->owner = $owner;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLabel(): string
-    {
-        return $this->label;
-    }
-
-    /**
-     * @param string $label
-     */
-    public function setLabel(string $label)
-    {
-        $this->label = $label;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getIcon()
-    {
-        return $this->icon;
-    }
-
-    /**
-     * @param string|null $icon
-     */
-    public function setIcon($icon)
-    {
-        $this->icon = $icon;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getIconSvg()
-    {
-        return $this->iconSvg;
-    }
-
-    /**
-     * @param string|null $iconSvg
-     */
-    public function setIconSvg($iconSvg)
-    {
-        $this->iconSvg = $iconSvg;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrl(): string
-    {
-        return $this->url;
-    }
-
-    /**
-     * @param string $url
-     */
-    public function setUrl(string $url)
-    {
-        $this->url = $url;
-    }
-
-    /**
-     * @return callable|int|null
-     */
-    public function getCounter()
-    {
-        return $this->counter;
-    }
-
-    /**
-     * @param callable|int|null $counter
-     */
-    public function setCounter($counter)
-    {
-        $this->counter = $counter;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getCounterLabel()
-    {
-        return $this->counterLabel;
-    }
-
-    /**
-     * @param string|null $counterLabel
-     */
-    public function setCounterLabel($counterLabel)
-    {
-        $this->counterLabel = $counterLabel;
-    }
-
-    /**
-     * @return int
-     */
-    public function getOrder(): int
-    {
-        return $this->order;
-    }
-
-    /**
-     * @param int $order
-     */
-    public function setOrder(int $order)
-    {
-        $this->order = $order;
-    }
-
-    /**
-     * @return array
-     */
-    public function getAttributes(): array
-    {
-        return $this->attributes;
-    }
-
-    /**
-     * @param array $attributes
-     */
-    public function setAttributes(array $attributes)
-    {
-        $this->attributes = $attributes;
-    }
-
-    /**
      * @param null|string|int $attribute
      * @param null|string|array $value
      */
@@ -231,20 +71,9 @@ class SideMenuItem
         $this->attributes[$attribute] = $value;
     }
 
-    /**
-     * @return array
-     */
-    public function getPermissions(): array
+    public function removeAttribute($attribute)
     {
-        return $this->permissions;
-    }
-
-    /**
-     * @param array $permissions
-     */
-    public function setPermissions(array $permissions)
-    {
-        $this->permissions = $permissions;
+        unset($this->attributes[$attribute]);
     }
 
     /**
@@ -254,6 +83,15 @@ class SideMenuItem
     public function addPermission(string $permission, array $definition)
     {
         $this->permissions[$permission] = $definition;
+    }
+
+    /**
+     * @param string $permission
+     * @return void
+     */
+    public function removePermission(string $permission)
+    {
+        unset($this->permissions[$permission]);
     }
 
     /**

--- a/modules/backend/classes/SideMenuItem.php
+++ b/modules/backend/classes/SideMenuItem.php
@@ -100,7 +100,7 @@ class SideMenuItem
      */
     public static function createFromArray(array $data): self
     {
-        $instance = new self();
+        $instance = new static();
         $instance->code = $data['code'];
         $instance->owner = $data['owner'];
         $instance->label = $data['label'];


### PR DESCRIPTION
### Introduction
This PR simplifies some parts of the navigation manager items management.

### Issue
Recently I've ran into the issue where I wanted to modify the icon of an existing menu item. This was more complicated that I had expected and ended up copying the current definition of the menu item, removing it and then adding it again with my own icon.

### Changes
By creating 2 classes, `MainMenuItem` and `SideMenuItem`, that will be instantiated while registering the menu items, it  will be much clearer as to what objects we are dealing with and what information they hold (opposed to casting an array to object).

I've modified the `NavigationManager` to use the 2 new classes. All properties of the new classes have been made public to ensure backwards compatibility. The `NavigationManager` now has a new method `getMainMenuItem` to retrieve a `MainMenuItem` based on owner and code. This will simplify retrieving the proper main menu item to modify.

In addition to those changes I've cleaned up the `NavigationManager` class a bit. Adding missing DocBlocks and typehinting wherever possible.

### Example
So with these changed I could now do the following to remove the default svg of the dashboard menu item and have it fall back to the font-icon one.
```
\Event::listen('backend.menu.extendItems', static function (NavigationManager $navigationManager) {
    $item = $navigationManager->getMainMenuItem('october.backend', 'dashboard');
    $item->setIconSvg(null);
});
```