### PR TITLE
implement image/file attachMany field types to theme data

### DIFF
--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -46,6 +46,7 @@ class ThemeData extends Model
      * @var array Relations
      */
     public $attachOne = [];
+    public $attachMany = [];
 
     /**
      * @var ThemeData Cached array of objects
@@ -125,7 +126,11 @@ class ThemeData extends Model
                 $this->jsonable[] = $id;
             }
             elseif ($field['type'] === 'fileupload') {
-                $this->attachOne[$id] = File::class;
+                if (str_contains($field['mode'], '-multi')) {
+                    $this->attachMany[$id] = File::class;
+                } else {
+                    $this->attachOne[$id] = File::class;
+                }
                 unset($data[$id]);
             }
         }


### PR DESCRIPTION
If a field type is `image-multi` or `file-multi` in the theme form fields, it will be added to $attachMany[] relation instead of $attachOne[]