### PR TITLE
add missing "showPagination" to overridable config_list.yaml settings

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -146,6 +146,7 @@ class ListController extends ControllerBehavior
             'recordOnClick',
             'recordsPerPage',
             'showPageNumbers',
+            'showPagination',
             'noRecordsMessage',
             'defaultSort',
             'showSorting',


### PR DESCRIPTION
Somehow the `showPagination` was not read from ListController Behavior's config file.