### PR TITLE
Number Field (_field_number.htm) - allow 0 value in preview mode

### DIFF
--- a/modules/backend/widgets/form/partials/_field_number.htm
+++ b/modules/backend/widgets/form/partials/_field_number.htm
@@ -1,6 +1,6 @@
 <!-- Number -->
 <?php if ($this->previewMode): ?>
-    <span class="form-control"><?= $field->value ? e($field->value) : '&nbsp;' ?></span>
+    <span class="form-control"><?= isset($field->value) ? e($field->value) : '&nbsp;' ?></span>
 <?php else: ?>
     <?php
         $min = isset($field->config['min']) ? $field->config['min'] : false;


### PR DESCRIPTION
In preview mode, you get empty field if you have 0 value in your database. Often we use number field to store 0 (for example: discount = 0;) and we would like to see the value.