### PR TITLE
Prevent browser caching of checkbox in lists

### DIFF
--- a/modules/backend/widgets/lists/partials/_list_body_checkbox.htm
+++ b/modules/backend/widgets/lists/partials/_list_body_checkbox.htm
@@ -4,7 +4,8 @@
             type="checkbox"
             name="checked[]"
             id="<?= $this->getId('checkbox-' . $record->getKey()) ?>"
-            value="<?= $record->getKey() ?>" />
+            value="<?= $record->getKey() ?>"
+            autocomplete="off"/>
         <label for="<?= $this->getId('checkbox-' . $record->getKey()) ?>"><?= e(trans('backend::lang.list.check')) ?></label>
     </div>
 </td>


### PR DESCRIPTION
This prevents browser to cache checkbox state but display state wasnt checked after refresh. Unchecking checkboxes is handled by JS.