### PR TITLE
Fix for dropdown field with multidimensional array as options

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -6,16 +6,18 @@
 <!-- Dropdown -->
 <?php if ($this->previewMode || $field->readOnly): ?>
     <div class="form-control" <?= $field->readOnly ? 'disabled="disabled"' : ''; ?>>
-        <?php if (is_array($fieldOptions[$field->value])): ?>
+        <?php if (isset($fieldOptions[$field->value]) && is_array($fieldOptions[$field->value])): ?>
             <?php if (strpos($fieldOptions[$field->value][1], '.')): ?>
                 <img src="<?= $fieldOptions[$field->value][1] ?>" alt="">
-                <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value][0])) : '' ?>
+                <?= e(trans($fieldOptions[$field->value][0])) ?>
             <?php else: ?>
                 <i class="<?= $fieldOptions[$field->value][1] ?>"></i>
-                <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value][0])) : '' ?>
+                <?= e(trans($fieldOptions[$field->value][0])) ?>
             <?php endif ?>
+        <?php elseif (isset($fieldOptions[$field->value]) && !is_array($fieldOptions[$field->value])): ?>
+            <?= e(trans($fieldOptions[$field->value])) ?>
         <?php else: ?>
-            <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value])) : '' ?>
+            <?= '' ?>
         <?php endif ?>
     </div>
     <?php if ($field->readOnly): ?>

--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -6,7 +6,17 @@
 <!-- Dropdown -->
 <?php if ($this->previewMode || $field->readOnly): ?>
     <div class="form-control" <?= $field->readOnly ? 'disabled="disabled"' : ''; ?>>
-        <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value])) : '' ?>
+        <?php if (is_array($fieldOptions[$field->value])): ?>
+            <?php if (strpos($fieldOptions[$field->value][1], '.')): ?>
+                <img src="<?= $fieldOptions[$field->value][1] ?>" alt="">
+                <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value][0])) : '' ?>
+            <?php else: ?>
+                <i class="<?= $fieldOptions[$field->value][1] ?>"></i>
+                <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value][0])) : '' ?>
+            <?php endif ?>
+        <?php else: ?>
+            <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value])) : '' ?>
+        <?php endif ?>
     </div>
     <?php if ($field->readOnly): ?>
         <input


### PR DESCRIPTION
The dropdown field has a "hidden" function, you can define multidimensional array for options. For example:

		return [
			'folyamatban'	        => ['folyamatban', 'icon-clock-o'],
			'elkeszult'		=> ['elkészült', 'oc-icon-thumbs-o-up'],
			'lezart'		        => ['lezárt', 'oc-icon-check'],
		];

Here you can add an icon class or an image to array as the second element and it will be displayed in the dropdown field. But if you use preview mode this throws an error: "substr() expects parameter 1 to be string, array given"