### PR TITLE
Add formGetRedirectUrl method. Fixes #4946

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -441,19 +441,6 @@ class FormController extends ControllerBehavior
     }
 
     /**
-     * Returns a URL based on supplied context. Relative URLs are treated as
-     * backend URLs.
-     *
-     * @param string $context Redirect context, eg: create, update, delete
-     * @param Model $model The active model.
-     * @return string
-     */
-    public function formGetRedirectUrl($context = null, $model = null)
-    {
-        return '';
-    }
-
-    /**
      * Internal method used to prepare the form model object.
      *
      * @return October\Rain\Database\Model
@@ -484,16 +471,11 @@ class FormController extends ControllerBehavior
         }
 
         if (post('redirect', true)) {
-            $redirectUrl = $this->getRedirectUrl($context);
+            $redirectUrl = $this->controller->formGetRedirectUrl($context, $model);
         }
 
         if ($model && $redirectUrl) {
             $redirectUrl = RouterHelper::replaceParameters($model, $redirectUrl);
-        }
-
-        $url = $this->controller->formGetRedirectUrl($context, $model);
-        if ($url) {
-            $redirectUrl = $url;
         }
 
         if (starts_with($redirectUrl, 'http://') || starts_with($redirectUrl, 'https://')) {
@@ -508,13 +490,15 @@ class FormController extends ControllerBehavior
     }
 
     /**
-     * Internal method that returns a redirect URL from the config based on
-     * supplied context. Otherwise the default redirect is used.
+     * Returns a redirect URL from the config based on supplied context.
+     * Otherwise the default redirect is used. Relative URLs are treated as
+     * backend URLs.
      *
      * @param string $context Redirect context, eg: create, update, delete.
+     * @param Model $model The active model.
      * @return string
      */
-    protected function getRedirectUrl($context = null)
+    public function formGetRedirectUrl($context = null, $model = null)
     {
         $redirectContext = explode('-', $context, 2)[0];
         $redirectSource = ends_with($context, '-close') ? 'redirectClose' : 'redirect';

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -441,6 +441,19 @@ class FormController extends ControllerBehavior
     }
 
     /**
+     * Returns a URL based on supplied context. Relative URLs are treated as
+     * backend URLs.
+     *
+     * @param string $context Redirect context, eg: create, update, delete
+     * @param Model $model The active model.
+     * @return string
+     */
+    public function formGetRedirectUrl($context = null, $model = null)
+    {
+        return '';
+    }
+
+    /**
      * Internal method used to prepare the form model object.
      *
      * @return October\Rain\Database\Model
@@ -476,6 +489,11 @@ class FormController extends ControllerBehavior
 
         if ($model && $redirectUrl) {
             $redirectUrl = RouterHelper::replaceParameters($model, $redirectUrl);
+        }
+
+        $url = $this->controller->formGetRedirectUrl($context, $model);
+        if ($url) {
+            $redirectUrl = $url;
         }
 
         if (starts_with($redirectUrl, 'http://') || starts_with($redirectUrl, 'https://')) {


### PR DESCRIPTION
Implementation of what was discussed in #4946.

Adds a `formGetRedirectUrl` method to `FormController` overrideable through a controller method of the same name. This method returns a URL to redirect to upon save. 

This PR is backwards compatible.