### PR TITLE
Backend theme localization

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -1,11 +1,14 @@
 <?php namespace Cms;
 
 use App;
+use Lang;
+use File;
 use Event;
 use Backend;
 use BackendMenu;
 use BackendAuth;
 use Backend\Models\UserRole;
+use Cms\Classes\Theme as CmsTheme;
 use Backend\Classes\WidgetManager;
 use October\Rain\Support\ModuleServiceProvider;
 use System\Classes\SettingsManager;
@@ -40,6 +43,7 @@ class ServiceProvider extends ModuleServiceProvider
             $this->registerBackendPermissions();
             $this->registerBackendWidgets();
             $this->registerBackendSettings();
+            $this->registerBackendLocalization();
         }
     }
 
@@ -282,6 +286,20 @@ class ServiceProvider extends ModuleServiceProvider
                 ]
             ]);
         });
+    }
+
+    /**
+     * Registers localization from an active theme for backend items.
+     */
+    protected function registerBackendLocalization()
+    {
+        $theme = CmsTheme::getActiveTheme();
+
+        $langPath = $theme->getPath() . '/lang';
+
+        if (File::isDirectory($langPath)) {
+            Lang::addNamespace("theme.{$theme->getId()}", $langPath);
+        }
     }
 
     /**

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -1,8 +1,11 @@
 <?php namespace Cms\Controllers;
 
+use File;
+use Lang;
 use Backend;
 use BackendMenu;
 use ApplicationException;
+use Cms\Classes\Theme;
 use Cms\Models\ThemeData;
 use Cms\Classes\Theme as CmsTheme;
 use System\Classes\SettingsManager;
@@ -43,6 +46,7 @@ class ThemeOptions extends Controller
         parent::__construct();
 
         $this->pageTitle = 'cms::lang.theme.settings_menu';
+        $this->registerLocalization($this->getDirName());
 
         BackendMenu::setContext('October.System', 'system', 'settings');
         SettingsManager::setContext('October.Cms', 'theme');
@@ -103,8 +107,12 @@ class ThemeOptions extends Controller
 
     /**
      * Default to the active theme if user doesn't have access to manage all themes
+     *
+     * @param string $dirName
+     *
+     * @return string
      */
-    protected function getDirName($dirName = null)
+    protected function getDirName(string $dirName = null): string
     {
         /*
          * Only the active theme can be managed without this permission
@@ -142,5 +150,23 @@ class ThemeOptions extends Controller
         }
 
         return $theme;
+    }
+
+    /**
+     * Register language namespace if available for the theme
+     *
+     * @param string $dirName
+     *
+     * @throws ApplicationException
+     */
+    protected function registerLocalization(string $dirName)
+    {
+        /** @var Theme $theme */
+        $theme = $this->findThemeObject($dirName);
+
+        $langPath = $theme->getPath() . '/lang';
+        if (File::isDirectory($langPath)) {
+            Lang::addNamespace("theme.$dirName", $langPath);
+        }
     }
 }

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -109,7 +109,6 @@ class ThemeOptions extends Controller
      * Default to the active theme if user doesn't have access to manage all themes
      *
      * @param string $dirName
-     *
      * @return string
      */
     protected function getDirName(string $dirName = null): string

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -159,7 +159,6 @@ class ThemeOptions extends Controller
      */
     protected function registerLocalization(string $dirName)
     {
-        /** @var Theme $theme */
         $theme = $this->findThemeObject($dirName);
 
         $langPath = $theme->getPath() . '/lang';

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -155,7 +155,7 @@ class ThemeOptions extends Controller
      * Register language namespace if available for the theme
      *
      * @param string $dirName
-     * @throws ApplicationException
+     * @throws ApplicationException if the theme object cannot be loaded
      */
     protected function registerLocalization(string $dirName)
     {

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -163,7 +163,7 @@ class ThemeOptions extends Controller
 
         $langPath = $theme->getPath() . '/lang';
         if (File::isDirectory($langPath)) {
-            Lang::addNamespace("theme.$dirName", $langPath);
+            Lang::addNamespace("theme.{$theme->getId()}", $langPath);
         }
     }
 }

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -155,7 +155,6 @@ class ThemeOptions extends Controller
      * Register language namespace if available for the theme
      *
      * @param string $dirName
-     *
      * @throws ApplicationException
      */
     protected function registerLocalization(string $dirName)

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -111,7 +111,7 @@ class ThemeOptions extends Controller
      * @param string $dirName
      * @return string
      */
-    protected function getDirName(string $dirName = null): string
+    protected function getDirName(string $dirName = null)
     {
         /*
          * Only the active theme can be managed without this permission

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -46,7 +46,6 @@ class ThemeOptions extends Controller
         parent::__construct();
 
         $this->pageTitle = 'cms::lang.theme.settings_menu';
-        $this->registerLocalization($this->getDirName());
 
         BackendMenu::setContext('October.System', 'system', 'settings');
         SettingsManager::setContext('October.Cms', 'theme');
@@ -149,21 +148,5 @@ class ThemeOptions extends Controller
         }
 
         return $theme;
-    }
-
-    /**
-     * Register language namespace if available for the theme
-     *
-     * @param string $dirName
-     * @throws ApplicationException if the theme object cannot be loaded
-     */
-    protected function registerLocalization(string $dirName)
-    {
-        $theme = $this->findThemeObject($dirName);
-
-        $langPath = $theme->getPath() . '/lang';
-        if (File::isDirectory($langPath)) {
-            Lang::addNamespace("theme.{$theme->getId()}", $langPath);
-        }
     }
 }

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -1,11 +1,8 @@
 <?php namespace Cms\Controllers;
 
-use File;
-use Lang;
 use Backend;
 use BackendMenu;
 use ApplicationException;
-use Cms\Classes\Theme;
 use Cms\Models\ThemeData;
 use Cms\Classes\Theme as CmsTheme;
 use System\Classes\SettingsManager;


### PR DESCRIPTION
Fixes https://github.com/octobercms/october/issues/4308

I utilized the existing logic for plugin backend translations with no changes. Therefore language files must be located in a `lang` directory inside the theme directory. As for me, it is a good point because there are no surprises  for developers.

Translations are populated only for active theme when the theme options are opened. 

Here's the example.

Language file in the theme directory:
![image](https://user-images.githubusercontent.com/3897579/75607679-b30d1100-5b0a-11ea-83db-ff06b3db2dbe.png)

Theme settings:

```
tabs:
  fields:
    website_name:
      tab: Info
      label: theme.ginopane-mdblog::lang.options.website_name.label
      type: text
      default: Gino Pane - MDBlog
      translatable: true
```

The result:
![image](https://user-images.githubusercontent.com/3897579/75607630-3aa65000-5b0a-11ea-8c64-da81fdd6fd97.png)

Works nicely.

If everything is fine I'll make a PR for docs.