### PR TITLE
Remove dotted line focus ring in firefox and have a standard one across browsers

### DIFF
--- a/modules/system/assets/ui/less/site.reset.less
+++ b/modules/system/assets/ui/less/site.reset.less
@@ -60,10 +60,6 @@ a {
         color: @link-hover-color;
         text-decoration: underline;
     }
-
-    &:focus {
-        .tab-focus();
-    }
 }
 
 

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -89,7 +89,6 @@ textarea {background-image:none}
 a {color:#0181b9;text-decoration:none}
 a:hover,
 a:focus {color:#001721;text-decoration:underline}
-a:focus {outline:thin dotted;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
 img {vertical-align:middle}
 .img-responsive {display:block;max-width:100%;height:auto}
 .img-rounded {-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}


### PR DESCRIPTION
See github issue: https://github.com/octobercms/october/issues/4964

Notes: In v465 we added a blue focus ring to remove the black focus ring in Google Chrome (as Chrome changed their default). The blue focus ring was decided to work in all cross-browsers. Therefore no need the `second` dotted line focus ring (which only displays in Firefox).