### PR TITLE
Add option to ignore timestamps for date range filters

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -622,6 +622,7 @@ class Filter extends WidgetBase
                         'maxDate'   => '2099-12-31',
                         'firstDay'  => 0,
                         'yearRange' => 10,
+                        'ignoreTimezone' => false,
                     ];
 
                     break;

--- a/modules/backend/widgets/filter/partials/_scope_daterange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_daterange.htm
@@ -10,7 +10,7 @@
         'firstDay' => $scope->firstDay,
         'yearRange' => $scope->yearRange,
     ])) ?>"
-    <?php if ($scope->ignoreTimezone): ?>data-ignore-timezone<?php endif ?>
+    <?php $scope->ignoreTimezone ? 'data-ignore-timezone' : ''; ?>
 >
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
     <span class="filter-setting"><?= isset($afterStr) && isset($beforeStr) ? ($afterStr . ' → ' . $beforeStr) : e(trans('backend::lang.filter.date_all')) ?></span>

--- a/modules/backend/widgets/filter/partials/_scope_daterange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_daterange.htm
@@ -9,9 +9,9 @@
         'maxDate' => $scope->maxDate,
         'firstDay' => $scope->firstDay,
         'yearRange' => $scope->yearRange,
-    ]))
-    ?>"
-    <?php if ($scope->ignoreTimezone): ?>data-ignore-timezone<?php endif ?>>
+    ])) ?>"
+    <?php if ($scope->ignoreTimezone): ?>data-ignore-timezone<?php endif ?>
+>
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
     <span class="filter-setting"><?= isset($afterStr) && isset($beforeStr) ? ($afterStr . ' → ' . $beforeStr) : e(trans('backend::lang.filter.date_all')) ?></span>
 </a>

--- a/modules/backend/widgets/filter/partials/_scope_daterange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_daterange.htm
@@ -10,7 +10,8 @@
         'firstDay' => $scope->firstDay,
         'yearRange' => $scope->yearRange,
     ]))
-    ?>">
+    ?>"
+    <?php if ($scope->ignoreTimezone): ?>data-ignore-timezone<?php endif ?>>
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
     <span class="filter-setting"><?= isset($afterStr) && isset($beforeStr) ? ($afterStr . ' → ' . $beforeStr) : e(trans('backend::lang.filter.date_all')) ?></span>
 </a>

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -29,6 +29,8 @@
     FilterWidget.prototype.init = function () {
         overloaded_init.apply(this)
 
+        this.ignoreTimezone = this.$el.children().get(0).hasAttribute('data-ignore-timezone');
+
         this.initRegion()
         this.initFilterDate()
     }
@@ -394,6 +396,12 @@
         }
 
         if (!this.timezone) {
+            this.timezone = 'UTC'
+        }
+
+        // Set both timezones to UTC to disable converting between them
+        if (this.ignoreTimezone) {
+            this.appTimezone = 'UTC'
             this.timezone = 'UTC'
         }
     }

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3243,7 +3243,7 @@ $.fn.filterWidget.Constructor=FilterWidget
 $.fn.filterWidget.noConflict=function(){$.fn.filterWidget=old
 return this}
 $(document).render(function(){$('[data-control="filterwidget"]').filterWidget();})}(window.jQuery);+function($){"use strict";var FilterWidget=$.fn.filterWidget.Constructor;var overloaded_init=FilterWidget.prototype.init;FilterWidget.prototype.init=function(){overloaded_init.apply(this)
-this.initRegion()
+this.ignoreTimezone=this.$el.children().get(0).hasAttribute('data-ignore-timezone');this.initRegion()
 this.initFilterDate()}
 FilterWidget.prototype.initFilterDate=function(){var self=this
 this.$el.on('show.oc.popover','a.filter-scope-date',function(event){self.initDatePickers($(this).hasClass('range'))
@@ -3378,7 +3378,9 @@ FilterWidget.prototype.initRegion=function(){this.locale=$('meta[name="backend-l
 this.timezone=$('meta[name="backend-timezone"]').attr('content')
 this.appTimezone=$('meta[name="app-timezone"]').attr('content')
 if(!this.appTimezone){this.appTimezone='UTC'}
-if(!this.timezone){this.timezone='UTC'}}}(window.jQuery);+function($){"use strict";var FilterWidget=$.fn.filterWidget.Constructor;var overloaded_init=FilterWidget.prototype.init;FilterWidget.prototype.init=function(){overloaded_init.apply(this)
+if(!this.timezone){this.timezone='UTC'}
+if(this.ignoreTimezone){this.appTimezone='UTC'
+this.timezone='UTC'}}}(window.jQuery);+function($){"use strict";var FilterWidget=$.fn.filterWidget.Constructor;var overloaded_init=FilterWidget.prototype.init;FilterWidget.prototype.init=function(){overloaded_init.apply(this)
 this.initFilterNumber()}
 FilterWidget.prototype.initFilterNumber=function(){var self=this
 this.$el.on('show.oc.popover','a.filter-scope-number',function(event){self.initNumberInputs($(this).hasClass('range'))


### PR DESCRIPTION
Date columns and form fields have the option to ignore timezones, which displays the true value from the database in the column or form field. This PR adds the option for date and daterange filters to support the same feature.

The current behavior of daterange filters can be misleading, especially if the user has a backend timezone set in their preferences. For example, setting the timezone to America/Chicago can cause the date range filter to return values outside of the selected date range. 

![image](https://user-images.githubusercontent.com/28734844/75830035-56f9f500-5d75-11ea-8620-457079ae68a9.png)
![image](https://user-images.githubusercontent.com/28734844/75830094-75f88700-5d75-11ea-88dd-c8f0a461e2fc.png)

Inspecting the scope values shows different dates than what are selected: 
![image](https://user-images.githubusercontent.com/28734844/75830135-932d5580-5d75-11ea-88b4-21c1e5047e06.png)

We can confirm these values are being passed from the client side by inspecting the network request:
![image](https://user-images.githubusercontent.com/28734844/75830158-a2ac9e80-5d75-11ea-8d3c-de5289968298.png)

I have confirmed that this change produces the desired results by testing with the Test plugin:
![image](https://user-images.githubusercontent.com/28734844/75830190-bfe16d00-5d75-11ea-977c-eac3c0051739.png)
![image](https://user-images.githubusercontent.com/28734844/75830233-e30c1c80-5d75-11ea-8fed-6633cec0c546.png)
![image](https://user-images.githubusercontent.com/28734844/75830255-f15a3880-5d75-11ea-8c1f-7d193d8f80de.png)
![image](https://user-images.githubusercontent.com/28734844/75830273-f9b27380-5d75-11ea-92a4-b70793b6c044.png)
