### PR TITLE
Auto-detect correct postback handler for datatable widget.

### DIFF
--- a/modules/backend/widgets/Table.php
+++ b/modules/backend/widgets/Table.php
@@ -1,5 +1,7 @@
 <?php namespace Backend\Widgets;
 
+use Config;
+use Backend;
 use Lang;
 use Input;
 use Request;
@@ -123,7 +125,7 @@ class Table extends WidgetBase
         $this->vars['recordsKeyFrom'] = $this->recordsKeyFrom;
 
         $this->vars['recordsPerPage'] = $this->getConfig('recordsPerPage', false) ?: 'false';
-        $this->vars['postbackHandlerName'] = $this->getConfig('postbackHandlerName', 'onSave');
+        $this->vars['postbackHandlerName'] = $this->getConfig('postbackHandlerName');
         $this->vars['searching'] = $this->getConfig('searching', false);
         $this->vars['adding'] = $this->getConfig('adding', true);
         $this->vars['deleting'] = $this->getConfig('deleting', true);
@@ -153,7 +155,15 @@ class Table extends WidgetBase
     protected function loadAssets()
     {
         $this->addCss('css/table.css', 'core');
-        $this->addJs('js/build-min.js', 'core');
+
+        if (Config::get('develop.decompileBackendAssets', false)) {
+            $scripts = Backend::decompileAsset($this->getAssetPath('js/build.js'));
+            foreach ($scripts as $script) {
+                $this->addJs($script, 'core');
+            }
+        } else {
+            $this->addJs('js/build-min.js', 'core');
+        }
     }
 
     /**

--- a/modules/backend/widgets/table/assets/js/build-min.js
+++ b/modules/backend/widgets/table/assets/js/build-min.js
@@ -21,7 +21,8 @@ this.clickHandler=this.onClick.bind(this)
 this.keydownHandler=this.onKeydown.bind(this)
 this.documentClickHandler=this.onDocumentClick.bind(this)
 this.toolbarClickHandler=this.onToolbarClick.bind(this)
-if(this.options.postback&&this.options.clientDataSourceClass=='client'){if(!this.options.postbackHandlerName){var formHandler=this.$el.closest('form').data('request');this.options.postbackHandlerName=formHandler||'onSave';}
+if(this.options.postback&&this.options.clientDataSourceClass=='client'){if(!this.options.postbackHandlerName){var formHandler=this.$el.closest('form').data('request')
+this.options.postbackHandlerName=formHandler||'onSave'}
 this.formSubmitHandler=this.onFormSubmit.bind(this)}
 this.navigation=null
 this.search=null

--- a/modules/backend/widgets/table/assets/js/build-min.js
+++ b/modules/backend/widgets/table/assets/js/build-min.js
@@ -21,8 +21,8 @@ this.clickHandler=this.onClick.bind(this)
 this.keydownHandler=this.onKeydown.bind(this)
 this.documentClickHandler=this.onDocumentClick.bind(this)
 this.toolbarClickHandler=this.onToolbarClick.bind(this)
-if(this.options.postback&&this.options.clientDataSourceClass=='client')
-this.formSubmitHandler=this.onFormSubmit.bind(this)
+if(this.options.postback&&this.options.clientDataSourceClass=='client'){if(!this.options.postbackHandlerName){var formHandler=this.$el.closest('form').data('request');this.options.postbackHandlerName=formHandler||'onSave';}
+this.formSubmitHandler=this.onFormSubmit.bind(this)}
 this.navigation=null
 this.search=null
 this.recordsAddedOrDeleted=0
@@ -383,7 +383,7 @@ if(dataContainer.value!=value){dataContainer.value=value
 this.markCellRowDirty(cellElement)
 this.notifyRowProcessorsOnChange(cellElement)
 if(suppressEvents===undefined||!suppressEvents){this.$el.trigger('oc.tableCellChanged',[this.getCellColumnName(cellElement),value,this.getCellRowIndex(cellElement)])}}}
-Table.DEFAULTS={clientDataSourceClass:'client',keyColumn:'id',recordsPerPage:false,data:null,postback:true,postbackHandlerName:'onSave',adding:true,deleting:true,toolbar:true,searching:false,rowSorting:false,height:false,dynamicHeight:false}
+Table.DEFAULTS={clientDataSourceClass:'client',keyColumn:'id',recordsPerPage:false,data:null,postback:true,postbackHandlerName:null,adding:true,deleting:true,toolbar:true,searching:false,rowSorting:false,height:false,dynamicHeight:false}
 var old=$.fn.table
 $.fn.table=function(option){var args=Array.prototype.slice.call(arguments,1),result=undefined
 this.each(function(){var $this=$(this)

--- a/modules/backend/widgets/table/assets/js/table.js
+++ b/modules/backend/widgets/table/assets/js/table.js
@@ -69,8 +69,13 @@
         this.documentClickHandler = this.onDocumentClick.bind(this)
         this.toolbarClickHandler = this.onToolbarClick.bind(this)
 
-        if (this.options.postback && this.options.clientDataSourceClass == 'client')
+        if (this.options.postback && this.options.clientDataSourceClass == 'client') {
+            if (!this.options.postbackHandlerName) {
+                var formHandler = this.$el.closest('form').data('request');
+                this.options.postbackHandlerName = formHandler || 'onSave';
+            }
             this.formSubmitHandler = this.onFormSubmit.bind(this)
+        }
 
         // Navigation helper
         this.navigation = null
@@ -1112,7 +1117,7 @@
         recordsPerPage: false,
         data: null,
         postback: true,
-        postbackHandlerName: 'onSave',
+        postbackHandlerName: null,
         adding: true,
         deleting: true,
         toolbar: true,

--- a/modules/backend/widgets/table/assets/js/table.js
+++ b/modules/backend/widgets/table/assets/js/table.js
@@ -71,8 +71,8 @@
 
         if (this.options.postback && this.options.clientDataSourceClass == 'client') {
             if (!this.options.postbackHandlerName) {
-                var formHandler = this.$el.closest('form').data('request');
-                this.options.postbackHandlerName = formHandler || 'onSave';
+                var formHandler = this.$el.closest('form').data('request')
+                this.options.postbackHandlerName = formHandler || 'onSave'
             }
             this.formSubmitHandler = this.onFormSubmit.bind(this)
         }

--- a/modules/backend/widgets/table/partials/_table.htm
+++ b/modules/backend/widgets/table/partials/_table.htm
@@ -6,7 +6,9 @@
     data-data="<?= e($data) ?>"
     data-alias="<?= e($this->alias) ?>"
     data-field-name="<?= e($this->fieldName) ?>"
+    <?php if (!empty($postbackHandlerName)): ?>
     data-postback-handler-name="<?= e($postbackHandlerName) ?>"
+    <?php endif; ?>
     data-adding="<?= e($adding) ?>"
     data-searching="<?= e($searching) ?>"
     data-deleting="<?= e($deleting) ?>"


### PR DESCRIPTION
Fixes #4776.

This change removes the default postback handler for the datatable widget (`onSave`) and instead relies on the closest form's request handler. While `onSave` was a safe default, it did not take into account the relation widget using other handlers.

The table widget will use an explicitly specified handler first, then it will try and use the form's request handler, before using `onSave` as a fallback, although this should really never occur.

I have deployed an example to test with in the Test plugin:

- Navigate to Playground > Posts.
- Click on a Post in the list.
- Click on the Create Comment button in the Comments tab.
- Navigate to the Quotes tab to see a data-table example.