### PR TITLE
Add missing translation for 'extensions' rule

### DIFF
--- a/modules/system/lang/en/validation.php
+++ b/modules/system/lang/en/validation.php
@@ -40,6 +40,7 @@ return [
     'distinct'             => 'The :attribute field has a duplicate value.',
     'email'                => 'The :attribute must be a valid email address.',
     'exists'               => 'The selected :attribute is invalid.',
+    'extensions'           => 'The :attribute must be one of the following types: :value',
     'file'                 => 'The :attribute must be a file.',
     'filled'               => 'The :attribute field must have a value.',
     'image'                => 'The :attribute must be an image.',


### PR DESCRIPTION
FIX #4844 
As far as I can understand, 
```validation.php``` contains errors in case of something fails.
```FileUpload.php``` contains validationRules array which will have possible / valid fileType or extensions which are allowed.
and
```:attribute``` will be the translated name of the attribute in a particular language
```:values``` will have the data passed from the validationRules[] array

so based on above assumptions I've written the translation.
Tell me if something is incorrect. 
I will update it