### PR TITLE
Fix docblocks and imports in FormController behaviour.

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -1,16 +1,16 @@
 <?php namespace Backend\Behaviors;
 
+use Db;
+use Str;
+use Lang;
+use Flash;
+use Event;
+use Redirect;
+use Backend;
 use Backend\Classes\ControllerBehavior;
-use Backend\Facades\Backend;
-use Exception;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Redirect;
-use October\Rain\Exception\ApplicationException;
 use October\Rain\Router\Helper as RouterHelper;
-use October\Rain\Support\Facades\Flash;
-use October\Rain\Support\Str;
+use ApplicationException;
+use Exception;
 
 /**
  * Adds features for working with backend forms. This behavior

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -303,7 +303,7 @@ class FormController extends ControllerBehavior
      * @param int $recordId Record identifier
      * @param string $context Form context
      * @return \Illuminate\Http\RedirectResponse|void
-     * @throws \October\Rain\Exception\ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException if the provided recordId is not found
      */
     public function update_onSave($recordId = null, $context = null)
     {
@@ -340,8 +340,8 @@ class FormController extends ControllerBehavior
      *
      * @param int $recordId Record identifier
      * @return \Illuminate\Http\RedirectResponse|void
-     * @throws \October\Rain\Exception\ApplicationException
-     * @throws Exception
+     * @throws \October\Rain\Exception\ApplicationException if the provided recordId is not found
+     * @throws Exception if there is no primary key on the model
      */
     public function update_onDelete($recordId = null)
     {
@@ -408,7 +408,7 @@ class FormController extends ControllerBehavior
      * @see \Backend\Widgets\Form
      * @param array $options Render options
      * @return string Rendered HTML for the form.
-     * @throws \October\Rain\Exception\ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException if the Form Widget isn't set
      */
     public function formRender($options = [])
     {
@@ -560,7 +560,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPreview() ?>
      *
      * @return string The form HTML markup.
-     * @throws \October\Rain\Exception\ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException if the Form Widget isn't set
      */
     public function formRenderPreview()
     {
@@ -589,7 +589,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderOutsideFields() ?>
      *
      * @return string HTML markup
-     * @throws \October\Rain\Exception\ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException if the Form Widget isn't set
      */
     public function formRenderOutsideFields()
     {
@@ -618,7 +618,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPrimaryTabs() ?>
      *
      * @return string HTML markup
-     * @throws \October\Rain\Exception\ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException if the Form Widget isn't set
      */
     public function formRenderPrimaryTabs()
     {
@@ -647,7 +647,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPrimaryTabs() ?>
      *
      * @return string HTML markup
-     * @throws \October\Rain\Exception\ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException if the Form Widget isn't set
      */
     public function formRenderSecondaryTabs()
     {
@@ -758,7 +758,7 @@ class FormController extends ControllerBehavior
      * can be changed by overriding it in the controller.
      * @param string $recordId
      * @return \October\Rain\Database\Model|\October\Rain\Halcyon\Model
-     * @throws \October\Rain\Exception\ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException if the provided recordId is not found
      */
     public function formFindModelObject($recordId)
     {

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -771,10 +771,8 @@ class FormController extends ControllerBehavior
         /*
          * Prepare query and find model record
          */
-        /** @var \October\Rain\Database\Builder|\October\Rain\Halcyon\Builder $query */
         $query = $model->newQuery();
         $this->controller->formExtendQuery($query);
-        /** @var \October\Rain\Database\Model|\October\Rain\Halcyon\Model $result */
         $result = $query->find($recordId);
 
         if (!$result) {
@@ -860,7 +858,7 @@ class FormController extends ControllerBehavior
     /**
      * Extend the query used for finding the form model. Extra conditions
      * can be applied to the query, for example, $query->withTrashed();
-     * @param \October\Rain\Database\Builder $query
+     * @param \October\Rain\Database\Builder|\October\Rain\Halcyon\Builder $query
      * @return void
      */
     public function formExtendQuery($query)

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -1,17 +1,16 @@
 <?php namespace Backend\Behaviors;
 
-use Db;
-use Str;
-use Lang;
-use Flash;
-use Event;
-use Redirect;
-use Backend;
 use Backend\Classes\ControllerBehavior;
-use October\Rain\Html\Helper as HtmlHelper;
-use October\Rain\Router\Helper as RouterHelper;
-use ApplicationException;
+use Backend\Facades\Backend;
 use Exception;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Redirect;
+use October\Rain\Exception\ApplicationException;
+use October\Rain\Router\Helper as RouterHelper;
+use October\Rain\Support\Facades\Flash;
+use October\Rain\Support\Str;
 
 /**
  * Adds features for working with backend forms. This behavior
@@ -90,13 +89,13 @@ class FormController extends ControllerBehavior
     protected $context;
 
     /**
-     * @var Model The initialized model used by the form.
+     * @var \October\Rain\Database\Model The initialized model used by the form.
      */
     protected $model;
 
     /**
      * Behavior constructor
-     * @param Backend\Classes\Controller $controller
+     * @param \Backend\Classes\Controller $controller
      */
     public function __construct($controller)
     {
@@ -116,8 +115,8 @@ class FormController extends ControllerBehavior
      * actually rendering the form. The model used by this form is passed
      * to this behavior via this method as the first argument.
      *
-     * @see Backend\Widgets\Form
-     * @param October\Rain\Database\Model $model
+     * @see \Backend\Widgets\Form
+     * @param \October\Rain\Database\Model $model
      * @param string $context Form context
      * @return void
      */
@@ -187,7 +186,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Prepares commonly used view data.
-     * @param October\Rain\Database\Model $model
+     * @param \October\Rain\Database\Model $model
      */
     protected function prepareVars($model)
     {
@@ -233,7 +232,7 @@ class FormController extends ControllerBehavior
      * `formBeforeCreate` and `formAfterCreate`.
      *
      * @param string $context Form context
-     * @return mixed
+     * @return \Illuminate\Http\RedirectResponse|void
      */
     public function create_onSave($context = null)
     {
@@ -303,7 +302,8 @@ class FormController extends ControllerBehavior
      *
      * @param int $recordId Record identifier
      * @param string $context Form context
-     * @return mixed
+     * @return \Illuminate\Http\RedirectResponse|void
+     * @throws ApplicationException
      */
     public function update_onSave($recordId = null, $context = null)
     {
@@ -339,7 +339,9 @@ class FormController extends ControllerBehavior
      * `formAfterDelete`.
      *
      * @param int $recordId Record identifier
-     * @return mixed
+     * @return \Illuminate\Http\RedirectResponse|void
+     * @throws ApplicationException
+     * @throws Exception
      */
     public function update_onDelete($recordId = null)
     {
@@ -403,9 +405,10 @@ class FormController extends ControllerBehavior
      *
      *     <?= $this->formRender(['preview' => true, section' => 'primary']) ?>
      *
-     * @see Backend\Widgets\Form
+     * @see \Backend\Widgets\Form
      * @param array $options Render options
      * @return string Rendered HTML for the form.
+     * @throws ApplicationException
      */
     public function formRender($options = [])
     {
@@ -421,7 +424,7 @@ class FormController extends ControllerBehavior
      * The model will be provided by one of the page actions or AJAX
      * handlers via the `initForm` method.
      *
-     * @return October\Rain\Database\Model
+     * @return \October\Rain\Database\Model
      */
     public function formGetModel()
     {
@@ -443,7 +446,7 @@ class FormController extends ControllerBehavior
     /**
      * Internal method used to prepare the form model object.
      *
-     * @return October\Rain\Database\Model
+     * @return \October\Rain\Database\Model
      */
     protected function createModel()
     {
@@ -456,8 +459,8 @@ class FormController extends ControllerBehavior
      * the model primary key.
      *
      * @param string $context Redirect context, eg: create, update, delete
-     * @param Model $model The active model to parse in it's ID and attributes.
-     * @return Redirect
+     * @param \October\Rain\Database\Model $model The active model to parse in it's ID and attributes.
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function makeRedirect($context = null, $model = null)
     {
@@ -557,6 +560,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPreview() ?>
      *
      * @return string The form HTML markup.
+     * @throws ApplicationException
      */
     public function formRenderPreview()
     {
@@ -585,6 +589,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderOutsideFields() ?>
      *
      * @return string HTML markup
+     * @throws ApplicationException
      */
     public function formRenderOutsideFields()
     {
@@ -613,6 +618,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPrimaryTabs() ?>
      *
      * @return string HTML markup
+     * @throws ApplicationException
      */
     public function formRenderPrimaryTabs()
     {
@@ -641,6 +647,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPrimaryTabs() ?>
      *
      * @return string HTML markup
+     * @throws ApplicationException
      */
     public function formRenderSecondaryTabs()
     {
@@ -650,7 +657,7 @@ class FormController extends ControllerBehavior
     /**
      * Returns the form widget used by this behavior.
      *
-     * @return Backend\Widgets\Form
+     * @return \Backend\Widgets\Form
      */
     public function formGetWidget()
     {
@@ -692,7 +699,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the creation or updating form is saved.
-     * @param Model
+     * @param \October\Rain\Database\Model
      */
     public function formBeforeSave($model)
     {
@@ -700,7 +707,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the creation or updating form is saved.
-     * @param Model
+     * @param \October\Rain\Database\Model
      */
     public function formAfterSave($model)
     {
@@ -708,7 +715,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the creation form is saved.
-     * @param Model
+     * @param \October\Rain\Database\Model
      */
     public function formBeforeCreate($model)
     {
@@ -716,7 +723,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the creation form is saved.
-     * @param Model
+     * @param \October\Rain\Database\Model
      */
     public function formAfterCreate($model)
     {
@@ -724,7 +731,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the updating form is saved.
-     * @param Model
+     * @param \October\Rain\Database\Model
      */
     public function formBeforeUpdate($model)
     {
@@ -732,7 +739,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the updating form is saved.
-     * @param Model
+     * @param \October\Rain\Database\Model
      */
     public function formAfterUpdate($model)
     {
@@ -740,7 +747,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the form model is deleted.
-     * @param Model
+     * @param \October\Rain\Database\Model
      */
     public function formAfterDelete($model)
     {
@@ -750,7 +757,8 @@ class FormController extends ControllerBehavior
      * Finds a Model record by its primary identifier, used by update actions. This logic
      * can be changed by overriding it in the controller.
      * @param string $recordId
-     * @return Model
+     * @return \October\Rain\Database\Model
+     * @throws ApplicationException
      */
     public function formFindModelObject($recordId)
     {
@@ -763,8 +771,10 @@ class FormController extends ControllerBehavior
         /*
          * Prepare query and find model record
          */
+        /** @var \October\Rain\Database\Builder $query */
         $query = $model->newQuery();
         $this->controller->formExtendQuery($query);
+        /** @var \October\Rain\Database\Model $result */
         $result = $query->find($recordId);
 
         if (!$result) {
@@ -781,7 +791,7 @@ class FormController extends ControllerBehavior
     /**
      * Creates a new instance of a form model. This logic can be changed
      * by overriding it in the controller.
-     * @return Model
+     * @return \October\Rain\Database\Model
      */
     public function formCreateModelObject()
     {
@@ -790,7 +800,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the form fields are defined.
-     * @param Backend\Widgets\Form $host The hosting form widget
+     * @param \Backend\Widgets\Form $host The hosting form widget
      * @return void
      */
     public function formExtendFieldsBefore($host)
@@ -799,7 +809,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the form fields are defined.
-     * @param Backend\Widgets\Form $host The hosting form widget
+     * @param \Backend\Widgets\Form $host The hosting form widget
      * @param array $fields Array of all defined form field objects (\Backend\Classes\FormField)
      * @return void
      */
@@ -809,9 +819,9 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the form is refreshed, should return an array of additional save data.
-     * @param Backend\Widgets\Form $host The hosting form widget
+     * @param \Backend\Widgets\Form $host The hosting form widget
      * @param array $saveData Current save data
-     * @return array
+     * @return array|void
      */
     public function formExtendRefreshData($host, $saveData)
     {
@@ -819,9 +829,9 @@ class FormController extends ControllerBehavior
 
     /**
      * Called when the form is refreshed, giving the opportunity to modify the form fields.
-     * @param Backend\Widgets\Form $host The hosting form widget
+     * @param \Backend\Widgets\Form $host The hosting form widget
      * @param array $fields Current form fields
-     * @return array
+     * @return array|void
      */
     public function formExtendRefreshFields($host, $fields)
     {
@@ -829,9 +839,9 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the form is refreshed, should return an array of additional result parameters.
-     * @param Backend\Widgets\Form $host The hosting form widget
+     * @param \Backend\Widgets\Form $host The hosting form widget
      * @param array $result Current result parameters.
-     * @return array
+     * @return array|void
      */
     public function formExtendRefreshResults($host, $result)
     {
@@ -840,8 +850,8 @@ class FormController extends ControllerBehavior
     /**
      * Extend supplied model used by create and update actions, the model can
      * be altered by overriding it in the controller.
-     * @param Model $model
-     * @return Model
+     * @param \October\Rain\Database\Model $model
+     * @return \October\Rain\Database\Model|void
      */
     public function formExtendModel($model)
     {
@@ -850,7 +860,7 @@ class FormController extends ControllerBehavior
     /**
      * Extend the query used for finding the form model. Extra conditions
      * can be applied to the query, for example, $query->withTrashed();
-     * @param October\Rain\Database\Builder $query
+     * @param \October\Rain\Database\Builder $query
      * @return void
      */
     public function formExtendQuery($query)

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -771,7 +771,7 @@ class FormController extends ControllerBehavior
         /*
          * Prepare query and find model record
          */
-        /** @var \October\Rain\Database\Builder $query */
+        /** @var \October\Rain\Database\Builder|\October\Rain\Halcyon\Builder $query */
         $query = $model->newQuery();
         $this->controller->formExtendQuery($query);
         /** @var \October\Rain\Database\Model|\October\Rain\Halcyon\Model $result */

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -303,7 +303,7 @@ class FormController extends ControllerBehavior
      * @param int $recordId Record identifier
      * @param string $context Form context
      * @return \Illuminate\Http\RedirectResponse|void
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      */
     public function update_onSave($recordId = null, $context = null)
     {
@@ -340,7 +340,7 @@ class FormController extends ControllerBehavior
      *
      * @param int $recordId Record identifier
      * @return \Illuminate\Http\RedirectResponse|void
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      * @throws Exception
      */
     public function update_onDelete($recordId = null)
@@ -408,7 +408,7 @@ class FormController extends ControllerBehavior
      * @see \Backend\Widgets\Form
      * @param array $options Render options
      * @return string Rendered HTML for the form.
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      */
     public function formRender($options = [])
     {
@@ -560,7 +560,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPreview() ?>
      *
      * @return string The form HTML markup.
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      */
     public function formRenderPreview()
     {
@@ -589,7 +589,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderOutsideFields() ?>
      *
      * @return string HTML markup
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      */
     public function formRenderOutsideFields()
     {
@@ -618,7 +618,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPrimaryTabs() ?>
      *
      * @return string HTML markup
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      */
     public function formRenderPrimaryTabs()
     {
@@ -647,7 +647,7 @@ class FormController extends ControllerBehavior
      *     <?= $this->formRenderPrimaryTabs() ?>
      *
      * @return string HTML markup
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      */
     public function formRenderSecondaryTabs()
     {
@@ -758,7 +758,7 @@ class FormController extends ControllerBehavior
      * can be changed by overriding it in the controller.
      * @param string $recordId
      * @return \October\Rain\Database\Model
-     * @throws ApplicationException
+     * @throws \October\Rain\Exception\ApplicationException
      */
     public function formFindModelObject($recordId)
     {

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -89,7 +89,7 @@ class FormController extends ControllerBehavior
     protected $context;
 
     /**
-     * @var \October\Rain\Database\Model The initialized model used by the form.
+     * @var \October\Rain\Database\Model|\October\Rain\Halcyon\Model The initialized model used by the form.
      */
     protected $model;
 
@@ -116,7 +116,7 @@ class FormController extends ControllerBehavior
      * to this behavior via this method as the first argument.
      *
      * @see \Backend\Widgets\Form
-     * @param \October\Rain\Database\Model $model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model $model
      * @param string $context Form context
      * @return void
      */
@@ -186,7 +186,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Prepares commonly used view data.
-     * @param \October\Rain\Database\Model $model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model $model
      */
     protected function prepareVars($model)
     {
@@ -424,7 +424,7 @@ class FormController extends ControllerBehavior
      * The model will be provided by one of the page actions or AJAX
      * handlers via the `initForm` method.
      *
-     * @return \October\Rain\Database\Model
+     * @return \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formGetModel()
     {
@@ -446,7 +446,7 @@ class FormController extends ControllerBehavior
     /**
      * Internal method used to prepare the form model object.
      *
-     * @return \October\Rain\Database\Model
+     * @return \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     protected function createModel()
     {
@@ -459,7 +459,7 @@ class FormController extends ControllerBehavior
      * the model primary key.
      *
      * @param string $context Redirect context, eg: create, update, delete
-     * @param \October\Rain\Database\Model $model The active model to parse in it's ID and attributes.
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model $model The active model to parse in it's ID and attributes.
      * @return \Illuminate\Http\RedirectResponse
      */
     public function makeRedirect($context = null, $model = null)
@@ -699,7 +699,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the creation or updating form is saved.
-     * @param \October\Rain\Database\Model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formBeforeSave($model)
     {
@@ -707,7 +707,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the creation or updating form is saved.
-     * @param \October\Rain\Database\Model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formAfterSave($model)
     {
@@ -715,7 +715,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the creation form is saved.
-     * @param \October\Rain\Database\Model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formBeforeCreate($model)
     {
@@ -723,7 +723,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the creation form is saved.
-     * @param \October\Rain\Database\Model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formAfterCreate($model)
     {
@@ -731,7 +731,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called before the updating form is saved.
-     * @param \October\Rain\Database\Model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formBeforeUpdate($model)
     {
@@ -739,7 +739,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the updating form is saved.
-     * @param \October\Rain\Database\Model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formAfterUpdate($model)
     {
@@ -747,7 +747,7 @@ class FormController extends ControllerBehavior
 
     /**
      * Called after the form model is deleted.
-     * @param \October\Rain\Database\Model
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formAfterDelete($model)
     {
@@ -757,7 +757,7 @@ class FormController extends ControllerBehavior
      * Finds a Model record by its primary identifier, used by update actions. This logic
      * can be changed by overriding it in the controller.
      * @param string $recordId
-     * @return \October\Rain\Database\Model
+     * @return \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      * @throws \October\Rain\Exception\ApplicationException
      */
     public function formFindModelObject($recordId)
@@ -774,7 +774,7 @@ class FormController extends ControllerBehavior
         /** @var \October\Rain\Database\Builder $query */
         $query = $model->newQuery();
         $this->controller->formExtendQuery($query);
-        /** @var \October\Rain\Database\Model $result */
+        /** @var \October\Rain\Database\Model|\October\Rain\Halcyon\Model $result */
         $result = $query->find($recordId);
 
         if (!$result) {
@@ -791,7 +791,7 @@ class FormController extends ControllerBehavior
     /**
      * Creates a new instance of a form model. This logic can be changed
      * by overriding it in the controller.
-     * @return \October\Rain\Database\Model
+     * @return \October\Rain\Database\Model|\October\Rain\Halcyon\Model
      */
     public function formCreateModelObject()
     {
@@ -850,8 +850,8 @@ class FormController extends ControllerBehavior
     /**
      * Extend supplied model used by create and update actions, the model can
      * be altered by overriding it in the controller.
-     * @param \October\Rain\Database\Model $model
-     * @return \October\Rain\Database\Model|void
+     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model $model
+     * @return \October\Rain\Database\Model|\October\Rain\Halcyon\Model|void
      */
     public function formExtendModel($model)
     {


### PR DESCRIPTION
Add correct parameter, return type and exception docblocks for FormController behaviour.
Import whole namespace for facade so we can follow the code in the editor.