### PR TITLE
Add configuration for throttling authentication attemptsAuth config

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+
+    'throttle' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Enable throttling of Backend authentication attempts
+        |--------------------------------------------------------------------------
+        |
+        | If set to true, users will be given a limited number of attempts to sign
+        | in to the Backend before being blocked for a specified number of minutes.
+        |
+         */
+        'enabled' => true,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Failed Authentication Attempt Limit
+        |--------------------------------------------------------------------------
+        |
+        | Number of failed attemps allowed while trying to authenticate a user.
+        |
+         */
+        'attemptLimit' => 5,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Suspension Time
+        |--------------------------------------------------------------------------
+        |
+        | The number of minutes to suspend further attempts on authentication once
+        | the attempt limit is reached.
+        |
+         */
+        'suspensionTime' => 15,
+    ],
+
+];

--- a/modules/backend/classes/AuthManager.php
+++ b/modules/backend/classes/AuthManager.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\Classes;
 
+use Config;
 use System\Classes\PluginManager;
 use October\Rain\Auth\Manager as RainAuthManager;
 use October\Rain\Exception\SystemException;
@@ -55,6 +56,11 @@ class AuthManager extends RainAuthManager
      * @var array Cache of registered permissions.
      */
     protected $permissionCache = false;
+
+    protected function init()
+    {
+        $this->useThrottle = Config::get('auth.throttle.enabled', true);
+    }
 
     /**
      * Registers a callback function that defines authentication permissions.

--- a/modules/backend/models/UserThrottle.php
+++ b/modules/backend/models/UserThrottle.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\Models;
 
+use Config;
 use October\Rain\Auth\Models\Throttle as ThrottleBase;
 
 /**
@@ -21,4 +22,12 @@ class UserThrottle extends ThrottleBase
     public $belongsTo = [
         'user' => User::class
     ];
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        static::$attemptLimit = Config::get('auth.throttle.attemptLimit', 5);
+        static::$suspensionTime = Config::get('auth.throttle.suspensionTime', 15);
+    }
 }


### PR DESCRIPTION
The backend AuthManager behavior is currently hard-coded.

This adds config/auth.php with the following settings under 'throttle' section to adjust default behavior:

- enabled
- attemptLimit
- suspensionTime
￼
Replaces #4936 