### PR TITLE
Get correct model when not using ID for "keyFrom" in Record Finder

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -252,7 +252,7 @@ class RecordFinder extends FormWidgetBase
                 $value = $model->{$attribute};
             }
         } else {
-            $value = $this->modelClass::find(parent::getLoadValue());
+            $value = $this->modelClass::where($this->keyFrom, parent::getLoadValue())->first();
         }
 
         return $value;


### PR DESCRIPTION
`getLoadValue()` was previously using the `find` method for getting the selected model on load when not using the Record Finder in relation mode.

This means it was searching by the primary key, regardless of whether the `keyFrom` setting on the Record Finder widget was changed. This has the effect of the `keyFrom` setting being correctly used to determine the value of the record finder field when a model is selected, but the widget being unable to find the model when it refreshes or reloads.

This change instead searches for the field's value in the column specified for the `keyFrom` setting, allowing us to use a different identifying column for loading the selected record.