### PR TITLE
Allow dot-notation for specifying external parameters for a component

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1538,7 +1538,7 @@ class Controller
                     $newPropertyValue = $routerParameters[$routeParamName] ?? null;
                 }
                 else {
-                    $newPropertyValue = $parameters[$paramName] ?? null;
+                    $newPropertyValue = array_get($parameters, $paramName, null);
                 }
 
                 $component->setProperty($propertyName, $newPropertyValue);


### PR DESCRIPTION
This is a minor change to allow users to specify deeper-level external parameters for component parameters.

My case was providing a "content" array to a partial:

```
{% partial 'content/blog-list' content=content %}
```

But being unable to use a singular key in that array for component parameters, eg. the below doesn't currently work without this fix:

```
[blogPosts]
pageNumber = "{{ :page }}"
categoryFilter = "{{ content.category }}"
postsPerPage = "{{ content.postsPerPage }}"
noPostsMessage = "No posts found"
sortOrder = "published_at desc"
categoryPage = 404
postPage = "{{ content.postPage }}"
```