### PR TITLE
add getPluginUrl() method

### DIFF
--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use SystemException;
 use Yaml;
 use Backend;
+use Config;
 
 /**
  * Plugin base class
@@ -301,5 +302,16 @@ class PluginBase extends ServiceProviderBase
         }
 
         return $this->loadedYamlConfiguration;
+    }
+
+    /**
+     * Return Plugin's relative URL
+     *
+     * @return string
+     */
+    public function getPluginUrl()
+    {
+       $parts = array_slice(explode('\\', strtolower(get_class($this))), 0, -1);
+       return Config::get('cms.pluginsPath') . '/' . implode('/', $parts);
     }
 }

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -311,7 +311,7 @@ class PluginBase extends ServiceProviderBase
      */
     public function getPluginUrl()
     {
-       $parts = array_slice(explode('\\', strtolower(get_class($this))), 0, -1);
-       return Config::get('cms.pluginsPath') . '/' . implode('/', $parts);
+        $parts = array_slice(explode('\\', strtolower(get_class($this))), 0, -1);
+        return Config::get('cms.pluginsPath') . '/' . implode('/', $parts);
     }
 }


### PR DESCRIPTION
Instead of manually specifying the URL to link to resources for this plugin, we can have it auto-generated.

So if your plugin holds a new css asset, instead of the following call:
```
...addCss('/plugins/author/plugin/assets/css/myCssFile.css');
```

You can now use:
```
...addCss($this->getPluginUrl() . '/assets/css/myCssFile.css');
```