### PR TITLE
Issue #4979 - Remove only first and last quotes

### DIFF
--- a/modules/system/console/OctoberEnv.php
+++ b/modules/system/console/OctoberEnv.php
@@ -282,7 +282,7 @@ class OctoberEnv extends Command
      */
     private function stripQuotes($string)
     {
-        return strtr($string, ['"' => '', "'" => '']);
+        return preg_replace('/^(\'(.*)\'|"(.*)")$/', '$2$3', $string);
     }
 
     /**


### PR DESCRIPTION
# the issue
Issue #4979  

## following the issue step by step

I created a new install with **wip/laravel-6**. Edited the `config/database.php` file adding a password to the mysql database password line:

```php
\\ snipped for brevity
'mysql' => [
            'driver'     => 'mysql',
            'engine'     => 'InnoDB',
            'host'       => 'localhost',
            'port'       => 3306,
            'database'   => 'database',
            'username'   => 'root',
            'password'   => 'ThisPassword\'Has"Aquote ',
            'charset'    => 'utf8mb4',
            'collation'  => 'utf8mb4_unicode_ci',
            'prefix'     => '',
            'varcharmax' => 191,
        ],
```

The .env file generated from the command `php artisan october:env` had the password set as:

```
# snipped for brevity
DB_HOST=localhost
DB_PORT=3306
DB_DATABASE=database
DB_USERNAME=root
DB_PASSWORD=ThisPasswordHasAquote 
REDIS_HOST=127.0.0.1
```

## SOLUTION

I replaced the `strstr` in stripQuotes for a simple preg_replace that removes only the external pair of quotes.

After resetting the install and following the same process, the .env file generated from the command `php artisan october:env` will now have the password set with internal quotes.

```
# snipped for brevity
DB_HOST=localhost
DB_PORT=3306
DB_DATABASE=database
DB_USERNAME=root
DB_PASSWORD=ThisPassword'Has"Aquote 
REDIS_HOST=127.0.0.1
```


