### PR TITLE
Fix docbocks ListController behaviour.

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -204,7 +204,7 @@ class ListController extends ControllerBehavior
         if (isset($listConfig->toolbar)) {
             $toolbarConfig = $this->makeConfig($listConfig->toolbar);
             $toolbarConfig->alias = $widget->alias . 'Toolbar';
-            $toolbarWidget = $this->makeWidget('Backend\Widgets\Toolbar', $toolbarConfig);
+            $toolbarWidget = $this->makeWidget(\Backend\Widgets\Toolbar::class, $toolbarConfig);
             $toolbarWidget->bindToController();
             $toolbarWidget->cssClasses[] = 'list-header';
 
@@ -237,7 +237,7 @@ class ListController extends ControllerBehavior
 
             $filterConfig = $this->makeConfig($listConfig->filter);
             $filterConfig->alias = $widget->alias . 'Filter';
-            $filterWidget = $this->makeWidget('Backend\Widgets\Filter', $filterConfig);
+            $filterWidget = $this->makeWidget(\Backend\Widgets\Filter::class, $filterConfig);
             $filterWidget->bindToController();
 
             /*
@@ -564,8 +564,7 @@ class ListController extends ControllerBehavior
     public static function extendListColumns($callback)
     {
         $calledClass = self::getCalledExtensionClass();
-        Event::listen('backend.list.extendColumns', function ($widget) use ($calledClass, $callback) {
-            /** @var \Backend\Widgets\Lists $widget */
+        Event::listen('backend.list.extendColumns', function (\Backend\Widgets\Lists $widget) use ($calledClass, $callback) {
             if (!is_a($widget->getController(), $calledClass)) {
                 return;
             }
@@ -581,8 +580,7 @@ class ListController extends ControllerBehavior
     public static function extendListFilterScopes($callback)
     {
         $calledClass = self::getCalledExtensionClass();
-        Event::listen('backend.filter.extendScopes', function ($widget) use ($calledClass, $callback) {
-            /** @var \Backend\Widgets\Lists $widget */
+        Event::listen('backend.filter.extendScopes', function (\Backend\Widgets\Filter $widget) use ($calledClass, $callback) {
             if (!is_a($widget->getController(), $calledClass)) {
                 return;
             }

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -476,9 +476,9 @@ class ListController extends ControllerBehavior
 
     /**
      * Controller override: Extend supplied model
-     * @param \October\Rain\Database\Model|\October\Rain\Halcyon\Model $model
+     * @param \October\Rain\Database\Model $model
      * @param string|null $definition
-     * @return \October\Rain\Database\Model|\October\Rain\Halcyon\Model
+     * @return \October\Rain\Database\Model
      */
     public function listExtendModel($model, $definition = null)
     {
@@ -488,7 +488,7 @@ class ListController extends ControllerBehavior
     /**
      * Controller override: Extend the query used for populating the list
      * before the default query is processed.
-     * @param \October\Rain\Database\Builder|\October\Rain\Halcyon\Builder $query
+     * @param \October\Rain\Database\Builder $query
      * @param string|null $definition
      */
     public function listExtendQueryBefore($query, $definition = null)
@@ -498,7 +498,7 @@ class ListController extends ControllerBehavior
     /**
      * Controller override: Extend the query used for populating the list
      * after the default query is processed.
-     * @param \October\Rain\Database\Builder|\October\Rain\Halcyon\Builder $query
+     * @param \October\Rain\Database\Builder $query
      * @param string|null $definition
      */
     public function listExtendQuery($query, $definition = null)
@@ -527,7 +527,7 @@ class ListController extends ControllerBehavior
 
     /**
      * Returns a CSS class name for a list row (<tr class="...">).
-     * @param  \October\Rain\Database\Model|\October\Rain\Halcyon\Model $record The populated model used for the column
+     * @param  \October\Rain\Database\Model $record The populated model used for the column
      * @param  string|null $definition List definition (optional)
      * @return string|void CSS class name
      */
@@ -537,7 +537,7 @@ class ListController extends ControllerBehavior
 
     /**
      * Replace a table column value (<td>...</td>)
-     * @param  \October\Rain\Database\Model|\October\Rain\Halcyon\Model $record The populated model used for the column
+     * @param  \October\Rain\Database\Model $record The populated model used for the column
      * @param  string $columnName The column name to override
      * @param  string|null $definition List definition (optional)
      * @return string|void HTML view

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -165,7 +165,6 @@ class ListController extends ControllerBehavior
         /*
          * List Widget with extensibility
          */
-        /** @var \Backend\Widgets\Lists $widget */
         $widget = $this->makeWidget(\Backend\Widgets\Lists::class, $columnConfig);
 
         $widget->bindEvent('list.extendColumns', function () use ($widget) {

--- a/modules/backend/traits/WidgetMaker.php
+++ b/modules/backend/traits/WidgetMaker.php
@@ -19,7 +19,7 @@ trait WidgetMaker
      * Makes a widget object with the supplied configuration file.
      * @param string $class Widget class name
      * @param array $widgetConfig An array of config.
-     * @return \Backend\Classes\WidgetBase The widget object
+     * @return mixed|\Backend\Classes\WidgetBase The widget object
      */
     public function makeWidget($class, $widgetConfig = [])
     {


### PR DESCRIPTION
Add correct parameter, return type and exception docblocks for ListController behaviour.

I made `listOverrideColumnValue` return `string|void` like it is in the current codebase. In pr #4972 @bennothommo talked about strict typing for the future, so we could change those return `string|void` to `string|null`. This allows us to add a strict return type `: ?string` in the future. It would not lead to any breaking changes now, but in the future it will when strict return types are added.

Methods that can be changed from `string|void` to `string|null` in this behaviour are:
- `listInjectRowClass`
- `listOverrideColumnValue`
- `listOverrideHeaderValue`

I would like to get your thoughts on this.