### PR TITLE
Add adaptive popup size options to Storm UI docs

### DIFF
--- a/modules/system/assets/ui/docs/popup.md
+++ b/modules/system/assets/ui/docs/popup.md
@@ -140,7 +140,8 @@ The partial for your rendered popup should follow this structure:
 - data-handler="onLoadContent" - October ajax request name
 - data-keyboard="false" - Allow popup to be closed with the keyboard
 - data-extra-data="file_id: 1" - October ajax request data
-- data-size="large" - Popup size, available sizes: giant, huge, large, small, tiny
+- data-size="large" - Popup size, available sizes: giant, huge, large, small, tiny, adaptive (will scale to fit the window)
+- data-adaptive-height="false" - Allow the popup to fill the height of the screen
 
 ### JavaScript API
 


### PR DESCRIPTION
Popups can be "adaptive" meaning they fill the width and/or height of the screen. This PR adds this information to the docs to make it better known.

This is useful when popups may contain a form, or some other large amount of information that the current listed sizes will not accomodate.