### PR TITLE
Add support for html attributes to the codeditor formwidget

### DIFF
--- a/modules/backend/formwidgets/codeeditor/partials/_codeeditor.htm
+++ b/modules/backend/formwidgets/codeeditor/partials/_codeeditor.htm
@@ -24,7 +24,8 @@
         data-read-only="<?= $readOnly ? 'true' : 'false' ?>"
         data-language="<?= $language ?>"
         data-margin="<?= $margin ?>"
-        data-vendor-path="<?= Url::asset('/modules/backend/formwidgets/codeeditor/assets/vendor/ace') ?>">
+        data-vendor-path="<?= Url::asset('/modules/backend/formwidgets/codeeditor/assets/vendor/ace') ?>"
+        <?= $this->formField->getAttributes() ?>>
         <div class="editor-toolbar">
             <ul>
                 <li class="searchbox-enable">


### PR DESCRIPTION
This PR will modify the codeeditor formfield to add html attributes to its main html tag.

This will be particulary usefull for adding extra classes or data attributes to be handled by custom javascript.