### PR TITLE
Allow add or remove field on form.refreshFields event

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -383,6 +383,7 @@ class Form extends WidgetBase
         $this->setFormValues($saveData);
         $this->prepareVars();
 
+        $fieldsBeforeRefresh = $this->allFields;
         /**
          * @event backend.form.refreshFields
          * Called when the form is refreshed, giving the opportunity to modify the form fields
@@ -402,6 +403,13 @@ class Form extends WidgetBase
          */
         $this->fireSystemEvent('backend.form.refreshFields', [$this->allFields]);
 
+        $fieldsStructureModifications = array_merge(array_diff_key($fieldsBeforeRefresh, $this->allFields), array_diff_key($this->allFields, $fieldsBeforeRefresh));
+        /**
+         * Does any fields has been removed or added?
+         */
+        $formStructureModified = (bool)$fieldsStructureModifications;
+        
+
         /*
          * If an array of fields is supplied, update specified fields individually.
          */
@@ -420,7 +428,7 @@ class Form extends WidgetBase
         /*
          * Update the whole form
          */
-        if (empty($result)) {
+        if (empty($result) || $formStructureModified) {
             $result = ['#'.$this->getId() => $this->makePartial('form')];
         }
 


### PR DESCRIPTION
This allow the developper to add or remove fields naturally using addFields or removeField on the backend.form.refreshFields event.

A use case is to display some additionnal fields pre-filled(using `default` field properties) with another model data (which is my actual case).

Here is an example of  use:
```php
// plugins/romainmazb/realestate/controllers/Lands.php
Event::listen('backend.form.refreshFields', function ($formWidget, $allFields) {
    $formWidget->removeField('tile_front');
    $formWidget->removeField('tile_back');
    $formWidget->addFields([
        'my_field1' => [
            'label'   => 'My Field 1',
            'comment' => 'This is a custom field I have added.',
            'default' => 'Some custom value'
        ],
    ]);
    $formWidget->addFields([
        'my_field2' => [
            'label'   => 'My Field 2',
            'comment' => 'This is a custom field I have added.',
            'default' => 'Some other value'
        ],
    ]);
});
```
And here is the result which can't be done without this changes since the actual source code only trigger makePartial on the field who are linked with dependsOn and don't even look if the $this->allFields changed:
![ezgif com-optimize](https://user-images.githubusercontent.com/53976837/77651244-c629ca00-6f6c-11ea-8749-b60e5100576b.gif)

Hope it will be helpful to the community.