### PR TITLE
Change default https redirect from 302 to 301

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -16,7 +16,7 @@
     ## Uncomment following lines to force HTTPS.
     ##
     # RewriteCond %{HTTPS} off
-    # RewriteRule (.*) https://%{SERVER_NAME}/$1 [R,L]
+    # RewriteRule (.*) https://%{SERVER_NAME}/$1 [L,R=301]
 
     ##
     ## Black listed folders


### PR DESCRIPTION
Changing default redirect from http to https to 301 (permamently moved) from 302 (temporary moved).

Reason: every website in nowadays must be working through https protocol, and 302 status is wrong for this type of redirect, because protocol redirect is not temporary, it's permamently.