### PR TITLE
MediaFinder modifications

### DIFF
--- a/modules/backend/formwidgets/MediaFinder.php
+++ b/modules/backend/formwidgets/MediaFinder.php
@@ -66,7 +66,11 @@ class MediaFinder extends FormWidgetBase
 
         $user = BackendAuth::getUser();
 
-        if ($this->formField->disabled || !$user || !$user->hasAccess('media.manage_media')) {
+        if ($this->formField->disabled
+            || $this->formField->readOnly
+            || !$user
+            || !$user->hasAccess('media.manage_media')
+        ) {
             $this->previewMode = true;
         }
     }

--- a/modules/backend/formwidgets/mediafinder/partials/_file_single.htm
+++ b/modules/backend/formwidgets/mediafinder/partials/_file_single.htm
@@ -2,6 +2,7 @@
     id="<?= $this->getId() ?>"
     class="field-mediafinder style-file-single <?= $value ? 'is-populated' : '' ?> <?= $this->previewMode ? 'is-preview' : '' ?>"
     data-control="mediafinder"
+    <?= $field->getAttributes() ?>
 >
 
     <!-- Find Button -->

--- a/modules/backend/formwidgets/mediafinder/partials/_image_single.htm
+++ b/modules/backend/formwidgets/mediafinder/partials/_image_single.htm
@@ -4,6 +4,7 @@
     data-control="mediafinder"
     data-thumbnail-width="<?= $imageWidth ?: '0' ?>"
     data-thumbnail-height="<?= $imageHeight ?: '0' ?>"
+    <?= $field->getAttributes() ?>
 >
 
     <!-- Find Button -->

--- a/modules/backend/formwidgets/mediafinder/partials/_mediafinder.htm
+++ b/modules/backend/formwidgets/mediafinder/partials/_mediafinder.htm
@@ -1,6 +1,6 @@
 <?php if ($this->previewMode && !$value): ?>
 
-    <span class="form-control"><?= e(trans('backend::lang.form.preview_no_media_message')) ?></span>
+    <span class="form-control" disabled="disabled"><?= e(trans('backend::lang.form.preview_no_media_message')) ?></span>
 
 <?php else: ?>
 

--- a/modules/backend/formwidgets/mediafinder/partials/_mediafinder.htm
+++ b/modules/backend/formwidgets/mediafinder/partials/_mediafinder.htm
@@ -1,6 +1,6 @@
 <?php if ($this->previewMode && !$value): ?>
 
-    <span class="form-control" <?= $field->getAttributes() ?>><?= e(trans('backend::lang.form.preview_no_media_message')) ?></span>
+    <span class="form-control"><?= e(trans('backend::lang.form.preview_no_media_message')) ?></span>
 
 <?php else: ?>
 

--- a/modules/backend/formwidgets/mediafinder/partials/_mediafinder.htm
+++ b/modules/backend/formwidgets/mediafinder/partials/_mediafinder.htm
@@ -1,6 +1,6 @@
 <?php if ($this->previewMode && !$value): ?>
 
-    <span class="form-control"><?= e(trans('backend::lang.form.preview_no_media_message')) ?></span>
+    <span class="form-control" <?= $field->getAttributes() ?>><?= e(trans('backend::lang.form.preview_no_media_message')) ?></span>
 
 <?php else: ?>
 


### PR DESCRIPTION
This PR modifies two things:

1. The form field attributes (as set by the fields.yaml) are added to the file, image and preview divs. (_I've included it in the preview version since the preview version is used for the disabled state as well_)
2. I've added the formfield readOnly value to the check if the preview mode should be rendered. By doing this the readOnly tag is now supported as well and works the same as the disabled state.

Consequences:
The formfield attributes array will also contained "disabled" and "readonly" attributes if they are set through their corresponding form field options. When `disabled="disabled"` is added to the preview  `span` the css will make it looklike a disabled form field (see before and after images).

Personally I don't think this change is a bad thing, but I thought I should mention.

Before:
![image](https://user-images.githubusercontent.com/3026259/77847170-59583f00-71bb-11ea-9092-e7208c95239e.png)

After:
![image](https://user-images.githubusercontent.com/3026259/77847165-4fced700-71bb-11ea-90a6-500392dd1397.png)
