### PR TITLE
Richeditor modifications

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/css/richeditor.css
+++ b/modules/backend/formwidgets/richeditor/assets/css/richeditor.css
@@ -565,3 +565,41 @@ body .fr-popup .fr-checkbox span {border-color:#d1d6d9}
 .control-richeditor figure[data-video]:before {font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f03d"}
 .control-richeditor figure[data-audio]:before {font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f028"}
 .fr-quick-insert a.fr-floating-btn {color:rgba(64,82,97,0.8);text-decoration:none}
+
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command {
+    cursor: not-allowed;
+}
+
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:hover,
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus {
+    color: #bdbdbd;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:hover::after,
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus::after {
+    border-top-color: #bdbdbd!important;
+}
+
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover {
+    color: #bdbdbd;
+    background: transparent;
+}
+
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover::after {
+    border-top-color: #bdbdbd !important;
+}
+
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options:hover,
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options:focus {
+    border-left: solid 1px transparent;
+}
+
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options.fr-btn-hover {
+    border-left: solid 1px transparent;
+}
+
+.fr-box.fr-basic .fr-element.fr-disabled {
+    cursor: not-allowed;
+}

--- a/modules/backend/formwidgets/richeditor/assets/css/richeditor.css
+++ b/modules/backend/formwidgets/richeditor/assets/css/richeditor.css
@@ -565,41 +565,14 @@ body .fr-popup .fr-checkbox span {border-color:#d1d6d9}
 .control-richeditor figure[data-video]:before {font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f03d"}
 .control-richeditor figure[data-audio]:before {font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f028"}
 .fr-quick-insert a.fr-floating-btn {color:rgba(64,82,97,0.8);text-decoration:none}
-
-.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command {
-    cursor: not-allowed;
-}
-
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command {cursor:not-allowed}
 .fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:hover,
-.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus {
-    color: #bdbdbd;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-}
-
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus {color:#bdbdbd;-webkit-box-shadow:none;box-shadow:none}
 .fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:hover::after,
-.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus::after {
-    border-top-color: #bdbdbd!important;
-}
-
-.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover {
-    color: #bdbdbd;
-    background: transparent;
-}
-
-.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover::after {
-    border-top-color: #bdbdbd !important;
-}
-
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus::after {border-top-color:#bdbdbd !important}
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover {color:#bdbdbd;background:transparent}
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover::after {border-top-color:#bdbdbd !important}
 .fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options:hover,
-.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options:focus {
-    border-left: solid 1px transparent;
-}
-
-.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options.fr-btn-hover {
-    border-left: solid 1px transparent;
-}
-
-.fr-box.fr-basic .fr-element.fr-disabled {
-    cursor: not-allowed;
-}
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options:focus {border-left:solid 1px transparent}
+.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options.fr-btn-hover {border-left:solid 1px transparent}
+.fr-box.fr-basic .fr-element.fr-disabled {cursor:not-allowed}

--- a/modules/backend/formwidgets/richeditor/assets/less/richeditor.less
+++ b/modules/backend/formwidgets/richeditor/assets/less/richeditor.less
@@ -266,7 +266,6 @@
 
     // Content
     .fr-element.fr-disabled {
-        color: #bdbdbd;
         cursor: not-allowed;
     }
 }

--- a/modules/backend/formwidgets/richeditor/assets/less/richeditor.less
+++ b/modules/backend/formwidgets/richeditor/assets/less/richeditor.less
@@ -224,3 +224,49 @@
         text-decoration: none;
     }
 }
+
+//
+// Additions to disabled state
+//
+
+.fr-box.fr-basic {
+    // Toolbar
+    .fr-toolbar.fr-disabled {
+        .fr-command {
+            cursor: not-allowed;
+
+            &:hover, &:focus {
+                color: #bdbdbd;
+                -webkit-box-shadow: none;
+                box-shadow: none;
+
+                &::after {
+                    border-top-color: #bdbdbd!important;
+                }
+            }
+
+            &.fr-btn-hover {
+                color: #bdbdbd; background: transparent;
+
+                &::after {
+                    border-top-color:#bdbdbd !important
+                }
+            }
+
+            &.fr-btn.fr-options {
+                &:hover, &:focus {
+                    border-left:solid 1px transparent;
+                }
+                &.fr-btn-hover {
+                    border-left:solid 1px transparent;
+                }
+            }
+        }
+    }
+
+    // Content
+    .fr-element.fr-disabled {
+        color: #bdbdbd;
+        cursor: not-allowed;
+    }
+}

--- a/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
+++ b/modules/backend/formwidgets/richeditor/partials/_richeditor.htm
@@ -23,7 +23,8 @@
         <?php if (isset($tableCellStyles)): ?>data-table-cell-styles="<?= e(json_encode($tableCellStyles)) ?>"<?php endif ?>
         data-links-handler="<?= $this->getEventHandler('onLoadPageLinksForm') ?>"
         data-ace-vendor-path="<?= Url::asset('/modules/backend/formwidgets/codeeditor/assets/vendor/ace') ?>"
-        data-control="richeditor">
+        data-control="richeditor"
+        <?= $field->getAttributes() ?>>
             <textarea
                 placeholder="<?= e(trans($field->placeholder)) ?>"
                 name="<?= $name ?>"


### PR DESCRIPTION
This PR modifies two things:

The form field attributes (as set by the fields.yaml) are added Richeditor div.
I've modified the styling of the disabled / readonly state of the richeditor to give a better visual representation that it's in disabled / readonly mode.
These changes include counteracting hover effects to give the "greyed out disabled" feeling to both the toolbar and the editor content. These changes are the same as changes I made for the  Markdown formwidget (https://github.com/octobercms/october/pull/5004) and use the same colors.

P.S. Although I'm aware the styling changes to the markdown editor haven't been approved I found myself with some spare time and went ahead and made these changes for the Richeditor anyway. They're all in 1 commit and can easily be reverted.

P.P.S The Richeditor is protected by a DRM. I've made the modifications in the LESS file but someone with the DRM file will need to actually compile it to the .css file. I've tested my code by using an online compiler. I'll add the css below. To test this PR without the froala drm you will need to add this css to `modules/backend/formwidgets/richeditor/assets/css/richeditor.css`

```
.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command {
    cursor: not-allowed;
}

.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:hover,
.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus {
    color: #bdbdbd;
    -webkit-box-shadow: none;
    box-shadow: none;
}

.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:hover::after,
.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command:focus::after {
    border-top-color: #bdbdbd!important;
}

.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover {
    color: #bdbdbd;
    background: transparent;
}

.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn-hover::after {
    border-top-color: #bdbdbd !important;
}

.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options:hover,
.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options:focus {
    border-left: solid 1px transparent;
}

.fr-box.fr-basic .fr-toolbar.fr-disabled .fr-command.fr-btn.fr-options.fr-btn-hover {
    border-left: solid 1px transparent;
}

.fr-box.fr-basic .fr-element.fr-disabled {
    color: #bdbdbd;
    cursor: not-allowed;
}
```

Before:
![image](https://user-images.githubusercontent.com/3026259/77847339-bc96a100-71bc-11ea-983f-c719ea839a11.png)

After:
![image](https://user-images.githubusercontent.com/3026259/77847353-c91af980-71bc-11ea-8cce-b7ef82aee368.png)
