### PR TITLE
ImportExportBehavior: Add iconv fallback support for import

### DIFF
--- a/modules/backend/behaviors/importexportcontroller/TranscodeFilter.php
+++ b/modules/backend/behaviors/importexportcontroller/TranscodeFilter.php
@@ -20,11 +20,19 @@ class TranscodeFilter extends php_user_filter
     public function filter($in, $out, &$consumed, $closing)
     {
         while ($resource = stream_bucket_make_writeable($in)) {
-            $resource->data = @mb_convert_encoding(
-                $resource->data,
-                $this->encodingTo,
-                $this->encodingFrom
-            );
+            if (in_array($this->encodingFrom, mb_list_encodings())) {
+                $resource->data = @mb_convert_encoding(
+                    $resource->data,
+                    $this->encodingTo,
+                    $this->encodingFrom
+                );
+            } else {
+                $resource->data = @iconv(
+                    $this->encodingFrom,
+                    $this->encodingTo,
+                    $resource->data
+                );
+            }
 
             $consumed += $resource->datalen;
 

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -550,6 +550,7 @@ return [
             'iso_8859_13' => 'ISO-8859-13 (Latin-7, Baltic Rim)',
             'iso_8859_14' => 'ISO-8859-14 (Latin-8, Celtic)',
             'iso_8859_15' => 'ISO-8859-15 (Latin-9, Western European revision with euro sign)',
+            'windows_1250' => 'Windows-1250 (CP1250, Central and Eastern European)',
             'windows_1251' => 'Windows-1251 (CP1251)',
             'windows_1252' => 'Windows-1252 (CP1252)',
         ],

--- a/modules/backend/models/ImportModel.php
+++ b/modules/backend/models/ImportModel.php
@@ -231,6 +231,7 @@ abstract class ImportModel extends Model
             'iso-8859-13',
             'iso-8859-14',
             'iso-8859-15',
+            'Windows-1250',
             'Windows-1251',
             'Windows-1252'
         ];


### PR DESCRIPTION
There are still many ERPs that are able to export CSV only with Windows-1250 encoding in our country, so I made proposal of simple solution for other possible encodings that are not supported by mbstring lib.