### PR TITLE
Fix the richeditor image uploading issue

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -153,9 +153,14 @@ class Controller extends ControllerBase
         /*
          * Media Manager widget is available on all back-end pages
          */
-        if ($this->user && $this->user->hasAccess('media.*')) {
-            $manager = new MediaManager($this, 'ocmediamanager');
-            $manager->bindToController();
+        if ($this->user) {
+            //RichEditor posts X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD when upload the image
+            $quickUploadMode = post('X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD');
+
+            if ($quickUploadMode || $this->user->hasAccess('media.*')) {
+                $manager = new MediaManager($this, 'ocmediamanager');
+                $manager->bindToController();
+            }
         }
 
         $this->extendableConstruct();


### PR DESCRIPTION
The richeditor.js sends the X_OCTOBER_MEDIA_MANAGER_QUICK_UPLOAD when uploading the image: https://github.com/octobercms/october/blob/da4f1705ca8c9fa93a0d56f4158737574116be18/modules/backend/formwidgets/richeditor/assets/js/richeditor.js#L160

The `MediaManager->checkUploadPostback()` can save the file_data.

So, we need to bind the `MediaManager` to the controller.