### PR TITLE
Allow translations of default column values

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1077,7 +1077,7 @@ class Lists extends WidgetBase
          * Apply default value.
          */
         if ($value === '' || $value === null) {
-            $value = $column->defaults;
+            $value = Lang::get($column->defaults);
         }
 
         /**

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1076,7 +1076,7 @@ class Lists extends WidgetBase
         /*
          * Apply default value.
          */
-        if ($value === '' || $value === null) {
+        if (($value === '' || is_null($value)) && !empty($column->defaults)) {
             $value = Lang::get($column->defaults);
         }
 


### PR DESCRIPTION
Currently the default column values does not support localization. This change will allow us to translate them.
