### PR TITLE
Don't persist failed search terms

### DIFF
--- a/modules/backend/widgets/Search.php
+++ b/modules/backend/widgets/Search.php
@@ -128,7 +128,14 @@ class Search extends WidgetBase
          * Trigger class event, merge results as viewable array
          */
         $params = func_get_args();
-        $result = $this->fireEvent('search.submit', [$params]);
+        try {
+            $result = $this->fireEvent('search.submit', [$params]);
+        } catch (\Throwable $e) {
+            // Remove the search term from the session if the search has failed.
+            $this->setActiveTerm('');
+            throw $e;
+        }
+
         if ($result && is_array($result)) {
             return call_user_func_array('array_merge', $result);
         }


### PR DESCRIPTION
If a column is defined as searchable, that is not actually searchable (like a partial) and a user filters a list using the searchbox, an Exception is thrown.

Unfortunately, this errorenous search term has already been persisted to the session so on subsequent page loads, the user is presented with an Exception with no way to resolve it themselves.

This PR catches any exception that happens during the search and resets any persisted search terms so that the user can continue working after a page load.

The exception itself will still be thrown.

To reproduce the issue this PR solves:

* Set a partial column in any list as `searchable: true` 
* Submit a search query
* Hit F5