### PR TITLE
Allow blob files naming in AJAX request

### DIFF
--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -25,7 +25,7 @@ if(options.data!==undefined&&!$.isEmptyObject(options.data)){$.extend(data,optio
 if(useFiles){requestData=new FormData($form.length?$form.get(0):undefined)
 if($el.is(':file')&&inputName){$.each($el.prop('files'),function(){requestData.append(inputName,this)})
 delete data[inputName]}
-$.each(data,function(key){requestData.append(key,this)})}
+$.each(data,function(key){if(typeof Blob!=="undefined"&&this instanceof Blob&&this.filename){requestData.append(key,this,this.filename)}else{requestData.append(key,this)}})}
 else{requestData=[$form.serialize(),$.param(data)].filter(Boolean).join('&')}
 var requestOptions={url:url,crossDomain:false,global:options.ajaxGlobal,context:context,headers:requestHeaders,success:function(data,textStatus,jqXHR){if(this.options.beforeUpdate.apply(this,[data,textStatus,jqXHR])===false)return
 if(options.evalBeforeUpdate&&eval('(function($el, context, data, textStatus, jqXHR) {'+options.evalBeforeUpdate+'}.call($el.get(0), $el, context, data, textStatus, jqXHR))')===false)return

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -25,7 +25,7 @@ if(options.data!==undefined&&!$.isEmptyObject(options.data)){$.extend(data,optio
 if(useFiles){requestData=new FormData($form.length?$form.get(0):undefined)
 if($el.is(':file')&&inputName){$.each($el.prop('files'),function(){requestData.append(inputName,this)})
 delete data[inputName]}
-$.each(data,function(key){requestData.append(key,this)})}
+$.each(data,function(key){if(typeof Blob!=="undefined"&&this instanceof Blob&&this.filename){requestData.append(key,this,this.filename)}else{requestData.append(key,this)}})}
 else{requestData=[$form.serialize(),$.param(data)].filter(Boolean).join('&')}
 var requestOptions={url:url,crossDomain:false,global:options.ajaxGlobal,context:context,headers:requestHeaders,success:function(data,textStatus,jqXHR){if(this.options.beforeUpdate.apply(this,[data,textStatus,jqXHR])===false)return
 if(options.evalBeforeUpdate&&eval('(function($el, context, data, textStatus, jqXHR) {'+options.evalBeforeUpdate+'}.call($el.get(0), $el, context, data, textStatus, jqXHR))')===false)return

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -118,7 +118,11 @@ if (window.jQuery.request !== undefined) {
             }
 
             $.each(data, function(key) {
-                requestData.append(key, this)
+                if (typeof Blob !== "undefined" && this instanceof Blob && this.filename) {
+                    requestData.append(key, this, this.filename)
+                } else {
+                    requestData.append(key, this)
+                }
             })
         }
         else {


### PR DESCRIPTION
This change adds an opportunity to set the filename of BLOB files in AJAX requests (this is useful for instance for setting the file extension).

Usage:

```js
// blob_file is a Blob object.
// We set a filename property, which the framework will read to set the filename.
blob_file.filename = "avatar.png"

$(e).request('onBlobUpload', {
   data: {"avatar": blob_file},
   files: true
})

```

This is a non-breaking change, because "filename" is not a property of Blob objects. We create it specifically for this use case.