### PR TITLE
Update check for '.git' when using 'php artisan october:util git pull'

### DIFF
--- a/modules/system/console/OctoberUtil.php
+++ b/modules/system/console/OctoberUtil.php
@@ -313,7 +313,7 @@ class OctoberUtil extends Command
     {
         foreach (File::directories(plugins_path()) as $authorDir) {
             foreach (File::directories($authorDir) as $pluginDir) {
-                if (!File::isDirectory($pluginDir.'/.git')) {
+                if (!File::exists($pluginDir.'/.git')) {
                     continue;
                 }
 
@@ -325,7 +325,7 @@ class OctoberUtil extends Command
         }
 
         foreach (File::directories(themes_path()) as $themeDir) {
-            if (!File::isDirectory($themeDir.'/.git')) {
+            if (!File::exists($themeDir.'/.git')) {
                 continue;
             }
 


### PR DESCRIPTION
When using the `php artisan october:util git pull` command it only checks if `.git` is a directory in the plugin or theme folder, however if plugins have been added as git submodules `.git` is a file not a directory so the command was not running `git pull`. This PR just changes the check to account for files or directories.