### PR TITLE
Add possibility to render record list inside side panel

### DIFF
--- a/modules/backend/assets/css/october.css
+++ b/modules/backend/assets/css/october.css
@@ -825,6 +825,7 @@ html.mobile #layout-sidenav ul {overflow:auto;-webkit-overflow-scrolling:touch}
 .touch #layout-sidenav.layout-sidenav li:not(.active) a:hover i {color:rgba(255,255,255,0.6) !important}
 #layout-sidenav.layout-sidenav ul.drag li:not(.active) a:hover:after,
 .touch #layout-sidenav.layout-sidenav li:not(.active) a:hover:after {display:none !important}
+#layout-side-panel {background:#ecf0f1}
 #layout-side-panel .fix-button {position:absolute;right:-25px;top:0;display:none;width:25px;height:25px;font-size:13px;background:#ecf0f1;z-index:120;opacity:0.5;filter:alpha(opacity=50);-webkit-border-radius:0 4px 4px 0;-moz-border-radius:0 4px 4px 0;border-radius:0 4px 4px 0}
 #layout-side-panel .fix-button i {display:block;text-align:center;margin-top:5px;color:#aaa}
 #layout-side-panel .fix-button:hover {text-decoration:none;display:block;opacity:1 !important;filter:alpha(opacity=100) !important}
@@ -832,6 +833,14 @@ html.mobile #layout-sidenav ul {overflow:auto;-webkit-overflow-scrolling:touch}
 #layout-side-panel .fix-button-content-header .fix-button {top:46px}
 #layout-side-panel .sidepanel-content-header {background:#d35400;color:white;font-size:15px;padding:12px 20px 13px;position:relative}
 #layout-side-panel .sidepanel-content-header:after {content:'';display:block;width:0;height:0;border-left:7.5px solid transparent;border-right:7.5px solid transparent;border-top:8px solid #d35400;border-bottom-width:0;position:absolute;left:14px;bottom:-8px}
+#layout-side-panel .list-header {padding:0}
+#layout-side-panel table.table.data {font-size:14px;border-bottom:0}
+#layout-side-panel table.table.data thead {display:none}
+#layout-side-panel table.table.data tbody td {border-top:0;background-color:#fff;color:#2b3e50;border-bottom:1px solid #ecf0f1}
+#layout-side-panel table.table.data tbody tr:hover td,
+#layout-side-panel table.table.data tbody tr.active td {background:#ddd !important;color:inherit}
+#layout-side-panel table.table.data tbody tr td:first-child,
+#layout-side-panel table.table.data tbody tr.active td:first-child {border-left-width:4px;padding-left:21px}
 body.side-panel-not-fixed #layout-side-panel {display:none}
 body.side-panel-not-fixed #layout-side-panel .fix-button {opacity:0.5;filter:alpha(opacity=50)}
 body.display-side-panel #layout-side-panel {display:block;position:absolute;z-index:600;width:350px;-webkit-box-shadow:3px 0 3px 0 rgba(0,0,0,0.1);box-shadow:3px 0 3px 0 rgba(0,0,0,0.1)}

--- a/modules/backend/assets/js/october-min.js
+++ b/modules/backend/assets/js/october-min.js
@@ -1024,7 +1024,7 @@ if(Modernizr.touchevents&&$(window).width()<self.options.breakpoint){if($(this).
 return}
 else{self.displaySidePanel()}}
 self.displayTab(this)
-return false})
+if(Modernizr.touchevents){return false;}})
 if(!Modernizr.touchevents){self.$sideNav.mouseleave(function(){clearTimeout(self.panelOpenTimeout)})
 self.$el.mouseleave(function(){self.hideSidePanel()})
 self.$sideNavItems.mouseenter(function(){if($(window).width()<self.options.breakpoint||!self.panelFixed()){if($(this).data('no-side-panel')){self.hideSidePanel()

--- a/modules/backend/assets/js/october.sidepaneltab.js
+++ b/modules/backend/assets/js/october.sidepaneltab.js
@@ -47,7 +47,9 @@
 
             self.displayTab(this)
 
-            return false
+            if (Modernizr.touchevents) {
+                return false;
+            }
         })
 
         if (!Modernizr.touchevents) {

--- a/modules/backend/assets/less/layout/sidepanel.less
+++ b/modules/backend/assets/less/layout/sidepanel.less
@@ -3,6 +3,8 @@
 // --------------------------------------------------
 
 #layout-side-panel {
+    background: #ecf0f1;
+
     .fix-button {
         position: absolute;
         right: -25px;
@@ -52,6 +54,42 @@
             position: absolute;
             left: 14px;
             bottom: -8px;
+        }
+    }
+
+    /***********************************************/
+    /* Side Panel List styles                      */
+    /***********************************************/
+
+    .list-header {
+        padding: 0;
+    }
+
+    table.table.data {
+        font-size: 14px;
+        border-bottom: 0;
+
+        thead {
+            display: none;
+        }
+
+        tbody td {
+            border-top:0;
+            background-color: #ffffff;
+            color: #2b3e50;
+            border-bottom: 1px solid #ecf0f1;
+        }
+
+        tbody tr:hover td, 
+        tbody tr.active td {
+            background: #dddddd !important; 
+            color: inherit;
+        }
+
+        tbody tr td:first-child,
+        tbody tr.active td:first-child {
+            border-left-width: 4px; 
+            padding-left: 21px; 
         }
     }
 }

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -218,6 +218,8 @@ class FormController extends ControllerBehavior
             $model = $this->controller->formExtendModel($model) ?: $model;
 
             $this->initForm($model);
+
+            $this->initializeSidePanelList();
         }
         catch (Exception $ex) {
             $this->controller->handleError($ex);
@@ -287,6 +289,7 @@ class FormController extends ControllerBehavior
 
             $model = $this->controller->formFindModelObject($recordId);
             $this->initForm($model);
+            $this->initializeSidePanelList($recordId);
         }
         catch (Exception $ex) {
             $this->controller->handleError($ex);
@@ -384,6 +387,8 @@ class FormController extends ControllerBehavior
 
             $model = $this->controller->formFindModelObject($recordId);
             $this->initForm($model);
+
+            $this->initializeSidePanelList($recordId);
         }
         catch (Exception $ex) {
             $this->controller->handleError($ex);
@@ -881,5 +886,20 @@ class FormController extends ControllerBehavior
             }
             call_user_func_array($callback, [$widget, $widget->model, $widget->getContext()]);
         });
+    }
+
+    /**
+     * Initialize Side Panel list
+     */
+    public function initializeSidePanelList($recordId = null)
+    {
+        try {
+            $this->controller->makeLists();
+            if ($recordId) {
+                $this->controller->listSetRecordAsActive($recordId);
+            }
+        }
+        catch (Exception $ex) {
+        }
     }
 }

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -591,7 +591,7 @@ class ListController extends ControllerBehavior
      * Set record as active on side panel list
      * @return void
      */
-    public function listSetRecordAsActive($recordId, $definition = null)   
+    public function listSetRecordAsActive($recordId, $definition = null)
     {
         if (!$definition || !isset($this->listDefinitions[$definition])) {
             $definition = $this->primaryDefinition;
@@ -600,6 +600,6 @@ class ListController extends ControllerBehavior
         $widget = $this->listWidgets[$definition];
         $widget->bindEvent('list.injectRowClass', function ($record) use ($recordId) {
             return $record->getKey() == $recordId ? 'active' : '';
-        });  
+        });
     }
 }

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -587,7 +587,6 @@ class ListController extends ControllerBehavior
         });
     }
 
-
     /**
      * Set record as active on side panel list
      * @return void

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -586,4 +586,21 @@ class ListController extends ControllerBehavior
             call_user_func_array($callback, [$widget]);
         });
     }
+
+
+    /**
+     * Set record as active on side panel list
+     * @return void
+     */
+    public function listSetRecordAsActive($recordId, $definition = null)   
+    {
+        if (!$definition || !isset($this->listDefinitions[$definition])) {
+            $definition = $this->primaryDefinition;
+        }
+
+        $widget = $this->listWidgets[$definition];
+        $widget->bindEvent('list.injectRowClass', function ($record) use ($recordId) {
+            return $record->getKey() == $recordId ? 'active' : '';
+        });  
+    }
 }


### PR DESCRIPTION
**What**
Add possibility to render record list (using List controller behavior) inside backend side-panel.

**Why**
Sometimes it may be useful to place the record list inside the side-panel. This would allow to create interface similar to the one that we know from CMS module, where the page list is inside the side-panel, next to the form, always present in index, create and update actions.
The idea is to be able to use List controller behavior with all its configuration options to define and render the list inside the side-panel.

**How**
The list would be rendered inside side-panel by placing the following code inside the template files (index.htm, create.htm, update.htm, preview.htm):
```
<?php Block::put('sidepanel') ?>
    <?= $this->listRender() ?>
<?php Block::endPut() ?>
```
To simplify the list, list header will be always hidden inside the side-panel. 
In config_list.yaml it is possible to simplify the list more using the following options:
```
recordsPerPage: 0 - will hide the list footer
showCheckboxes: false
```
The final result looks like this:

![Screenshot 2020-04-25 at 15 07 20](https://user-images.githubusercontent.com/1902023/80286022-3e7cda00-8729-11ea-87cc-164295cd8a42.jpg)

I have provided en example in test plugin:
https://github.com/octoberrain/test-plugin/pull/86

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->