### PR TITLE
Clear input after creating tag in taglist

### DIFF
--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -127,7 +127,7 @@
                  */
                 if ($element.hasClass('select-no-dropdown')) {
                     extraOptions.selectOnClose = true
-                    extraOptions.closeOnSelect = false
+                    extraOptions.closeOnSelect = true
                     extraOptions.minimumInputLength = 1
 
                     $element.on('select2:closing', function() {


### PR DESCRIPTION
When using the taglist field type, the input isn't cleared after a tag has been created. This problem is described here: https://github.com/select2/select2/issues/4698
This change fixes that issue.