### PR TITLE
Add "Install themes" button on updates page

### DIFF
--- a/modules/system/controllers/updates/_list_toolbar.htm
+++ b/modules/system/controllers/updates/_list_toolbar.htm
@@ -7,14 +7,14 @@
         <?= e(trans('system::lang.updates.check_label')) ?>
     </a>
     <a
-        href="<?= Backend::url('system/updates/install') ?>"
-        class="btn btn-success oc-icon-plus">
-        <?= e(trans('system::lang.plugins.install')) ?>
-    </a>
-    <a
         href="<?= Backend::url('system/updates/install/themes') ?>"
         class="btn btn-success oc-icon-plus">
         <?= e(trans('system::lang.themes.install')) ?>
+    </a>
+    <a
+        href="<?= Backend::url('system/updates/install') ?>"
+        class="btn btn-success oc-icon-plus">
+        <?= e(trans('system::lang.plugins.install')) ?>
     </a>
     <a
         href="<?= Backend::url('system/updates/manage') ?>"

--- a/modules/system/controllers/updates/_list_toolbar.htm
+++ b/modules/system/controllers/updates/_list_toolbar.htm
@@ -12,6 +12,11 @@
         <?= e(trans('system::lang.plugins.install')) ?>
     </a>
     <a
+        href="<?= Backend::url('system/updates/install/themes') ?>"
+        class="btn btn-success oc-icon-plus">
+        <?= e(trans('system::lang.themes.install')) ?>
+    </a>
+    <a
         href="<?= Backend::url('system/updates/manage') ?>"
         class="btn btn-default oc-icon-puzzle-piece">
         <?= e(trans('system::lang.plugins.manage')) ?>


### PR DESCRIPTION
Very oftenly in our community people asking question:"How do i install theme from marketplace?" 
And to answer that question we should say "Just press Install plugins button!"
That's not very intuitive for beginners. This PR adds one button that leads right to themes installation page.