### PR TITLE
Fix client side validation

### DIFF
--- a/modules/backend/controllers/preferences/index.htm
+++ b/modules/backend/controllers/preferences/index.htm
@@ -11,6 +11,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="redirect:0"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"

--- a/modules/backend/controllers/usergroups/create.htm
+++ b/modules/backend/controllers/usergroups/create.htm
@@ -19,14 +19,16 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.creating')) ?>"
                     class="btn btn-primary">
                     <?= e(trans('backend::lang.form.create')) ?>
                 </button>
-                <button 
+                <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.creating')) ?>"

--- a/modules/backend/controllers/usergroups/update.htm
+++ b/modules/backend/controllers/usergroups/update.htm
@@ -19,6 +19,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="redirect:0"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
@@ -28,6 +29,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"

--- a/modules/backend/controllers/userroles/create.htm
+++ b/modules/backend/controllers/userroles/create.htm
@@ -19,14 +19,16 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.creating')) ?>"
                     class="btn btn-primary">
                     <?= e(trans('backend::lang.form.create')) ?>
                 </button>
-                <button 
+                <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.creating')) ?>"

--- a/modules/backend/controllers/userroles/update.htm
+++ b/modules/backend/controllers/userroles/update.htm
@@ -19,6 +19,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="redirect:0"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
@@ -28,6 +29,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"

--- a/modules/backend/controllers/users/create.htm
+++ b/modules/backend/controllers/users/create.htm
@@ -20,6 +20,7 @@
                     <button
                         type="submit"
                         data-request="onSave"
+                        data-request-validate
                         data-hotkey="ctrl+s, cmd+s"
                         data-load-indicator="<?= e(trans('backend::lang.form.creating')) ?>"
                         class="btn btn-primary">
@@ -28,6 +29,7 @@
                     <button
                         type="button"
                         data-request="onSave"
+                        data-request-validate
                         data-request-data="close:1"
                         data-hotkey="ctrl+enter, cmd+enter"
                         data-load-indicator="<?= e(trans('backend::lang.form.creating')) ?>"

--- a/modules/backend/controllers/users/myaccount.htm
+++ b/modules/backend/controllers/users/myaccount.htm
@@ -22,6 +22,7 @@
                     <button
                         type="submit"
                         data-request="onSave"
+                        data-request-validate
                         data-request-data="redirect:0"
                         data-hotkey="ctrl+s, cmd+s"
                         data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
@@ -32,6 +33,7 @@
                         <button
                             type="button"
                             data-request="onSave"
+                            data-request-validate
                             data-request-data="close:1"
                             data-hotkey="ctrl+enter, cmd+enter"
                             data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"

--- a/modules/backend/controllers/users/update.htm
+++ b/modules/backend/controllers/users/update.htm
@@ -24,6 +24,7 @@
                     <button
                         type="submit"
                         data-request="onSave"
+                        data-request-validate
                         data-request-data="redirect:0"
                         data-hotkey="ctrl+s, cmd+s"
                         data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
@@ -33,6 +34,7 @@
                     <button
                         type="button"
                         data-request="onSave"
+                        data-request-validate
                         data-request-data="close:1"
                         data-hotkey="ctrl+enter, cmd+enter"
                         data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"

--- a/modules/cms/controllers/themeoptions/update.htm
+++ b/modules/cms/controllers/themeoptions/update.htm
@@ -19,6 +19,7 @@
                     <button
                         type="submit"
                         data-request="onSave"
+                        data-request-validate
                         data-request-data="redirect:0"
                         data-hotkey="ctrl+s, cmd+s"
                         data-load-indicator="<?= e(trans('cms::lang.theme.saving')) ?>"
@@ -28,6 +29,7 @@
                     <button
                         type="button"
                         data-request="onSave"
+                        data-request-validate
                         data-request-data="close:1"
                         data-hotkey="ctrl+enter, cmd+enter"
                         data-load-indicator="<?= e(trans('cms::lang.theme.saving')) ?>"

--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -4,7 +4,7 @@ if(window.jQuery.request!==undefined){throw new Error('The OctoberCMS framework 
 +function($){"use strict";var Request=function(element,handler,options){var $el=this.$el=$(element);this.options=options||{};if(handler===undefined){throw new Error('The request handler name is not specified.')}
 if(!handler.match(/^(?:\w+\:{2})?on*/)){throw new Error('Invalid handler name. The correct handler name format is: "onEvent".')}
 var $form=options.form?$(options.form):$el.closest('form'),$triggerEl=!!$form.length?$form:$el,context={handler:handler,options:options}
-if(typeof document.createElement('input').reportValidity=='function'&&$form&&$form[0]&&!$form[0].checkValidity()){$form[0].reportValidity();return false;}
+if((options.validate!==undefined)&&typeof document.createElement('input').reportValidity=='function'&&$form&&$form[0]&&!$form[0].checkValidity()){$form[0].reportValidity();return false;}
 $el.trigger('ajaxSetup',[context])
 var _event=jQuery.Event('oc.beforeRequest')
 $triggerEl.trigger(_event,context)
@@ -103,7 +103,7 @@ return result.join('&')}
 var old=$.fn.request
 $.fn.request=function(handler,option){var args=arguments
 var $this=$(this).first()
-var data={evalBeforeUpdate:$this.data('request-before-update'),evalSuccess:$this.data('request-success'),evalError:$this.data('request-error'),evalComplete:$this.data('request-complete'),ajaxGlobal:$this.data('request-ajax-global'),confirm:$this.data('request-confirm'),redirect:$this.data('request-redirect'),loading:$this.data('request-loading'),flash:$this.data('request-flash'),files:$this.data('request-files'),form:$this.data('request-form'),url:$this.data('request-url'),update:paramToObj('data-request-update',$this.data('request-update')),data:paramToObj('data-request-data',$this.data('request-data'))}
+var data={evalBeforeUpdate:$this.data('request-before-update'),evalSuccess:$this.data('request-success'),evalError:$this.data('request-error'),evalComplete:$this.data('request-complete'),ajaxGlobal:$this.data('request-ajax-global'),confirm:$this.data('request-confirm'),redirect:$this.data('request-redirect'),loading:$this.data('request-loading'),flash:$this.data('request-flash'),files:$this.data('request-files'),validate:$this.data('request-validate'),form:$this.data('request-form'),url:$this.data('request-url'),update:paramToObj('data-request-update',$this.data('request-update')),data:paramToObj('data-request-data',$this.data('request-data'))}
 if(!handler)handler=$this.data('request')
 var options=$.extend(true,{},Request.DEFAULTS,data,typeof option=='object'&&option)
 return new Request($this,handler,options)}

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -4,7 +4,7 @@ if(window.jQuery.request!==undefined){throw new Error('The OctoberCMS framework 
 +function($){"use strict";var Request=function(element,handler,options){var $el=this.$el=$(element);this.options=options||{};if(handler===undefined){throw new Error('The request handler name is not specified.')}
 if(!handler.match(/^(?:\w+\:{2})?on*/)){throw new Error('Invalid handler name. The correct handler name format is: "onEvent".')}
 var $form=options.form?$(options.form):$el.closest('form'),$triggerEl=!!$form.length?$form:$el,context={handler:handler,options:options}
-if(typeof document.createElement('input').reportValidity=='function'&&$form&&$form[0]&&!$form[0].checkValidity()){$form[0].reportValidity();return false;}
+if((options.validate!==undefined)&&typeof document.createElement('input').reportValidity=='function'&&$form&&$form[0]&&!$form[0].checkValidity()){$form[0].reportValidity();return false;}
 $el.trigger('ajaxSetup',[context])
 var _event=jQuery.Event('oc.beforeRequest')
 $triggerEl.trigger(_event,context)
@@ -103,7 +103,7 @@ return result.join('&')}
 var old=$.fn.request
 $.fn.request=function(handler,option){var args=arguments
 var $this=$(this).first()
-var data={evalBeforeUpdate:$this.data('request-before-update'),evalSuccess:$this.data('request-success'),evalError:$this.data('request-error'),evalComplete:$this.data('request-complete'),ajaxGlobal:$this.data('request-ajax-global'),confirm:$this.data('request-confirm'),redirect:$this.data('request-redirect'),loading:$this.data('request-loading'),flash:$this.data('request-flash'),files:$this.data('request-files'),form:$this.data('request-form'),url:$this.data('request-url'),update:paramToObj('data-request-update',$this.data('request-update')),data:paramToObj('data-request-data',$this.data('request-data'))}
+var data={evalBeforeUpdate:$this.data('request-before-update'),evalSuccess:$this.data('request-success'),evalError:$this.data('request-error'),evalComplete:$this.data('request-complete'),ajaxGlobal:$this.data('request-ajax-global'),confirm:$this.data('request-confirm'),redirect:$this.data('request-redirect'),loading:$this.data('request-loading'),flash:$this.data('request-flash'),files:$this.data('request-files'),validate:$this.data('request-validate'),form:$this.data('request-form'),url:$this.data('request-url'),update:paramToObj('data-request-update',$this.data('request-update')),data:paramToObj('data-request-data',$this.data('request-data'))}
 if(!handler)handler=$this.data('request')
 var options=$.extend(true,{},Request.DEFAULTS,data,typeof option=='object'&&option)
 return new Request($this,handler,options)}

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -39,7 +39,7 @@ if (window.jQuery.request !== undefined) {
         /*
          * Validate the form client-side
          */
-        if (typeof document.createElement('input').reportValidity == 'function' && $form && $form[0] && !$form[0].checkValidity()) {
+        if ((options.validate !== undefined) && typeof document.createElement('input').reportValidity == 'function' && $form && $form[0] && !$form[0].checkValidity()) {
             $form[0].reportValidity();
             return false;
         }
@@ -446,6 +446,7 @@ if (window.jQuery.request !== undefined) {
             loading: $this.data('request-loading'),
             flash: $this.data('request-flash'),
             files: $this.data('request-files'),
+            validate: $this.data('request-validate'),
             form: $this.data('request-form'),
             url: $this.data('request-url'),
             update: paramToObj('data-request-update', $this.data('request-update')),

--- a/modules/system/controllers/mailbrandsettings/index.htm
+++ b/modules/system/controllers/mailbrandsettings/index.htm
@@ -19,6 +19,7 @@
                     <button
                         type="submit"
                         data-request="onSave"
+                        data-request-validate
                         data-request-data="redirect:0"
                         data-hotkey="ctrl+s, cmd+s"
                         data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"

--- a/modules/system/controllers/maillayouts/create.htm
+++ b/modules/system/controllers/maillayouts/create.htm
@@ -18,6 +18,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.creating_layout')) ?>"
                     class="btn btn-primary">
@@ -26,6 +27,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.creating_layout')) ?>"

--- a/modules/system/controllers/maillayouts/update.htm
+++ b/modules/system/controllers/maillayouts/update.htm
@@ -29,6 +29,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="redirect:0"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.saving_layout')) ?>"
@@ -38,6 +39,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.saving_layout')) ?>"

--- a/modules/system/controllers/mailpartials/create.htm
+++ b/modules/system/controllers/mailpartials/create.htm
@@ -18,6 +18,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.creating_partial')) ?>"
                     class="btn btn-primary">
@@ -26,6 +27,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.creating_partial')) ?>"

--- a/modules/system/controllers/mailpartials/update.htm
+++ b/modules/system/controllers/mailpartials/update.htm
@@ -29,6 +29,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="redirect:0"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.saving_layout')) ?>"
@@ -38,6 +39,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.saving_layout')) ?>"

--- a/modules/system/controllers/mailtemplates/create.htm
+++ b/modules/system/controllers/mailtemplates/create.htm
@@ -18,6 +18,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.creating')) ?>"
                     class="btn btn-primary">
@@ -26,6 +27,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.creating')) ?>"

--- a/modules/system/controllers/mailtemplates/update.htm
+++ b/modules/system/controllers/mailtemplates/update.htm
@@ -29,6 +29,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="redirect:0"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.saving')) ?>"
@@ -38,6 +39,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('system::lang.mail_templates.saving')) ?>"

--- a/modules/system/controllers/settings/update.htm
+++ b/modules/system/controllers/settings/update.htm
@@ -11,6 +11,7 @@
                 <button
                     type="submit"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="redirect:0"
                     data-hotkey="ctrl+s, cmd+s"
                     data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
@@ -20,6 +21,7 @@
                 <button
                     type="button"
                     data-request="onSave"
+                    data-request-validate
                     data-request-data="close:1"
                     data-hotkey="ctrl+enter, cmd+enter"
                     data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"


### PR DESCRIPTION
Adds `data-request-validate` option to only execute client side validation when explicitly requested. Fixes #5076. Related: #4804.