### PR TITLE
Send button value with AJAX requests

### DIFF
--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -127,7 +127,9 @@ if (window.jQuery.request !== undefined) {
         }
         else {
             var submitButtonValue,
-                ae = $(document.activeElement)
+                ae = $(document.activeElement),
+                submits,
+                submitValue
 
             /*
              * A specific submit button was clicked, so add that value
@@ -140,8 +142,14 @@ if (window.jQuery.request !== undefined) {
             /*
              * No specific button was clicked, so use the value from the first submit button
              */
-            else if ($el.find("[type=submit]").length !== 0 && $el.find("[type=submit]").first().attr("name") !== undefined) {
-                submitButtonValue = encodeURIComponent($el.find("[type=submit]").first().attr("name")) + "=" + encodeURIComponent($el.find("[type=submit]").first().attr("value"))
+            else {
+                submits = $el.find("[type=submit],button:not([type])")
+
+                if (submits.length !== 0 && submits.first().attr("name") !== undefined) {
+                    submitValue = (submits.first().attr("value") !== undefined) ? submits.first().attr("value") : ""
+
+                    submitButtonValue = encodeURIComponent(submits.first().attr("name")) + "=" + encodeURIComponent(submitValue)
+                }
             }
 
             requestData = [$form.serialize(), $.param(data), submitButtonValue].filter(Boolean).join('&')

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -136,7 +136,8 @@ if (window.jQuery.request !== undefined) {
              */
             if (ae.attr('type') == "submit" || ae.is("button")) {
                 if (typeof ae.attr("name") !== undefined) {
-                    submitButtonValue = encodeURIComponent(ae.attr("name")) + "=" + encodeURIComponent(ae.attr("value"))
+                    submitValue = (ae.attr("value") !== undefined) ? ae.attr("value") : ""
+                    submitButtonValue = encodeURIComponent(ae.attr("name")) + "=" + encodeURIComponent(submitValue)
                 }
             }
             /*
@@ -147,7 +148,6 @@ if (window.jQuery.request !== undefined) {
 
                 if (submits.length !== 0 && submits.first().attr("name") !== undefined) {
                     submitValue = (submits.first().attr("value") !== undefined) ? submits.first().attr("value") : ""
-
                     submitButtonValue = encodeURIComponent(submits.first().attr("name")) + "=" + encodeURIComponent(submitValue)
                 }
             }

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -126,7 +126,25 @@ if (window.jQuery.request !== undefined) {
             })
         }
         else {
-            requestData = [$form.serialize(), $.param(data)].filter(Boolean).join('&')
+            var submitButtonValue,
+                ae = $(document.activeElement)
+
+            /*
+             * A specific submit button was clicked, so add that value
+             */
+            if (ae.attr('type') == "submit" || ae.is("button")) {
+                if (typeof ae.attr("name") !== undefined) {
+                    submitButtonValue = encodeURIComponent(ae.attr("name")) + "=" + encodeURIComponent(ae.attr("value"))
+                }
+            }
+            /*
+             * No specific button was clicked, so use the value from the first submit button
+             */
+            else if ($el.find("[type=submit]").length !== 0 && $el.find("[type=submit]").first().attr("name") !== undefined) {
+                submitButtonValue = encodeURIComponent($el.find("[type=submit]").first().attr("name")) + "=" + encodeURIComponent($el.find("[type=submit]").first().attr("value"))
+            }
+
+            requestData = [$form.serialize(), $.param(data), submitButtonValue].filter(Boolean).join('&')
         }
 
         /*


### PR DESCRIPTION
Fixes #5107

This changes the behavior of the AJAX framework to act more like a standard HTML `<form>` element. 

For regular, non-AJAX form submissions, if the form is submitted by clicking on a specific submit button, the name/value attributes of that button are sent along with the form data. If the form is submitted without clicking on a submit button (e.g. by pushing enter on an `<input type="text">` field), the name/value pair of the **first** submit button to appear in the DOM are sent. In either case, if there is no `name` attribute, then nothing is added to the form data that sent. 

This PR mimics this behavior for AJAX requests.