### PR TITLE
Unbind event handlers upon destruction of the form widget

### DIFF
--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -160,7 +160,7 @@
             })
         })
 
-        return fieldMap;
+        return fieldMap
     }
 
     /*

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -129,7 +129,7 @@
         var fieldMap = this._getDependants()
 
         $.each(fieldMap, function(fieldName, toRefresh) {
-            $(document).off('change.oc.formwidget', '[data-field-name="' + fieldName + '"]');
+            $(document).off('change.oc.formwidget', '[data-field-name="' + fieldName + '"]')
         })
     }
 

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -242,7 +242,7 @@
     FormWidget.prototype.unbindLazyTabs = function() {
         var tabControl = $('[data-control=tab]', this.$el)
 
-        $('.nav-tabs', tabControl).off('click', '.tab-lazy [data-toggle="tab"]');
+        $('.nav-tabs', tabControl).off('click', '.tab-lazy [data-toggle="tab"]')
     }
 
     /*

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -39,6 +39,7 @@
 
         this.$el.on('oc.triggerOn.afterUpdate', this.proxy(this.toggleEmptyTabs))
         this.$el.one('dispose-control', this.proxy(this.dispose))
+        this.$form.closest('.modal').on('hidden.oc.popup', this.proxy(this.dispose))
     }
 
     FormWidget.prototype.dispose = function() {

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -43,10 +43,10 @@
     }
 
     FormWidget.prototype.dispose = function() {
-        this.unbindDependants();
-        this.unbindCheckboxList();
-        this.unbindLazyTabs();
-        this.unbindCollapsibleSections();
+        this.unbindDependants()
+        this.unbindCheckboxList()
+        this.unbindLazyTabs()
+        this.unbindCollapsibleSections()
 
         this.$el.off('dispose-control', this.proxy(this.dispose))
         this.$el.removeData('oc.formwidget')

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -85,8 +85,8 @@
      * Unbind checkboxlist handlers
      */
     FormWidget.prototype.unbindCheckboxList = function() {
-        this.$el.off('click', '[data-field-checkboxlist-all]');
-        this.$el.off('click', '[data-field-checkboxlist-none]');
+        this.$el.off('click', '[data-field-checkboxlist-all]')
+        this.$el.off('click', '[data-field-checkboxlist-none]')
     }
 
     /*

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -112,7 +112,7 @@
             fieldMap = this._getDependants()
 
         /*
-         * When a master is updated, refresh its slaves
+         * When a field is updated, refresh its dependents
          */
         $.each(fieldMap, function(fieldName, toRefresh) {
             $(document).on('change.oc.formwidget',

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -118,7 +118,7 @@
             $(document).on('change.oc.formwidget',
                 '[data-field-name="' + fieldName + '"]',
                 $.proxy(self.onRefreshDependants, self, fieldName, toRefresh)
-            );
+            )
         })
     }
 

--- a/modules/backend/widgets/form/assets/js/october.form.js
+++ b/modules/backend/widgets/form/assets/js/october.form.js
@@ -308,7 +308,7 @@
      * Unbinds collapsible section handlers
      */
     FormWidget.prototype.unbindCollapsibleSections = function() {
-        $('.section-field[data-field-collapsible]', this.$form).off('click');
+        $('.section-field[data-field-collapsible]', this.$form).off('click')
     }
 
     FormWidget.DEFAULTS = {


### PR DESCRIPTION
This PR unbinds various event handlers of the form widget when an instance of it is destroyed.

The current implementation does not perform proper clean up in the `dispose` method. This results in lingering event handlers when the form widget is destroyed.

The problem is especially apparent in use cases where a form widget is created and destroyed multiple times without reloading the page, e.g. when loading the form inside a popup via AJAX. If the form has any field dependencies, the JS handler `onRefreshDependants` which is responsible for refreshing those fields will get registered each time the form is constructed and it will **not** be unregistered when the form object is disposed of.

Calling the `dispose()` method in order to manually destroy the form widget [sets `this.$el` to `null`](https://github.com/octobercms/october/blob/develop/modules/backend/widgets/form/assets/js/october.form.js#L48) but it does not unbind the refresh handlers. Because of this they are executed when the form is rebuilt and a field is refreshed. This results in the following error:
```
TypeError: form is null
```
...at `october.form.js:88:28`, which breaks the refresh handlers altogether. From what I gather, this happens because the old handlers are attempting to [access `this.$el`](https://github.com/octobercms/october/blob/develop/modules/backend/widgets/form/assets/js/october.form.js#L88). However, since it has already been `null`'ed when calling `dispose()`, they get no reference to the element and a `TypeError` is returned.

This PR fixes this by properly unbinding the event handlers when the form widget is destroyed with the `dispose()` method.