### PR TITLE
Explain to people how deal with security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
@@ -1,6 +1,6 @@
 ---
 name: "🐛 Bug Report"
-about: 'Report a general OctoberCMS issue "FOR SECURITY ISSUES PLEASE CONTACT THE ADMINS IN PRIVATE AND DONT OPEN AN ISSUE HERE"'
+about: 'Report a general OctoberCMS issue'
 labels: 'Status: Review Needed, Type: Unconfirmed Bug'
 ---
 

--- a/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
@@ -1,6 +1,6 @@
 ---
 name: "🐛 Bug Report"
-about: 'Report a general OctoberCMS issue "FOR SECURITY ISSUES PLEASE CONTACT THE ADMINS IN PRIVATE AND DONT OPEN AN ISSUE HERE"'
+about: 'Report a general OctoberCMS issue "CONTACT THE ADMINS IN PRIVATE FOR SECURITY ISSUES DO NOT OPEN HERE"'
 labels: 'Status: Review Needed, Type: Unconfirmed Bug'
 ---
 

--- a/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
@@ -1,6 +1,6 @@
 ---
 name: "🐛 Bug Report"
-about: 'Report a general OctoberCMS issue "CONTACT THE ADMINS IN PRIVATE FOR SECURITY ISSUES DO NOT OPEN HERE"'
+about: 'Report a general OctoberCMS issue "CONTACT THE ADMINS IN PRIVATE FOR SECURITY ISSUES DO NOT OPEN HERE" see here: https://github.com/octobercms/october/blob/develop/SECURITY.md'
 labels: 'Status: Review Needed, Type: Unconfirmed Bug'
 ---
 

--- a/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/1_BUG_REPORT.md
@@ -1,6 +1,6 @@
 ---
 name: "🐛 Bug Report"
-about: 'Report a general OctoberCMS issue'
+about: 'Report a general OctoberCMS issue "FOR SECURITY ISSUES PLEASE CONTACT THE ADMINS IN PRIVATE AND DONT OPEN AN ISSUE HERE"'
 labels: 'Status: Review Needed, Type: Unconfirmed Bug'
 ---
 


### PR DESCRIPTION
I've got an issue with how this repo deals with security issues!

A person opens an issue and says it's a security issue. Then an admin tells the person they should not open an issue and they should tell them in private. The problem I have with this is that people are not mind readers and should be told before they try to open an issue.

This pr tries to fix this problem and be a bit more open to the community and let them understand the process a bit better.

### Before

![image](https://user-images.githubusercontent.com/57409060/84035644-f68ddb80-a993-11ea-84d0-e1cf7aecd97c.png)

### After

![image](https://user-images.githubusercontent.com/57409060/84038694-24751f00-a998-11ea-9088-d2678f88282f.png)

