### PR TITLE
Allow plugin autoloaders to load on restricted pages and actions

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -224,9 +224,9 @@ class PluginManager
         }
 
         /**
-         * Verify that the provided plugin should be registered
+         * Prevent autoloaders from loading if plugin is disabled
          */
-        if (!$plugin || $plugin->disabled || (self::$noInit && !$plugin->elevated)) {
+        if (!$plugin->disabled) {
             return;
         }
 
@@ -236,6 +236,13 @@ class PluginManager
         $autoloadPath = $pluginPath . '/vendor/autoload.php';
         if (File::isFile($autoloadPath)) {
             ComposerManager::instance()->autoload($pluginPath . '/vendor');
+        }
+
+        /**
+         * Disable plugin registration for restricted pages, unless elevated
+         */
+        if (self::$noInit && !$plugin->elevated) {
+            return;
         }
 
         /**

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -226,7 +226,7 @@ class PluginManager
         /**
          * Prevent autoloaders from loading if plugin is disabled
          */
-        if (!$plugin->disabled) {
+        if ($plugin->disabled) {
             return;
         }
 


### PR DESCRIPTION
Fixes #5110.

This allows (enabled) plugins to load their autoloaders on any pages, including restricted pages and action, to allow included scripts, classes and traits in migration files to be found and run.

This brings marketplace plugins more in line with plugins retrieved from Composer, as the dependencies of those plugins will already be included in the Composer autoloader, irrespective of whether the plugin is disabled or not.