### PR TITLE
Allow default checked state for all checkboxes in checkboxlist

### DIFF
--- a/modules/backend/widgets/form/partials/_field_checkboxlist.htm
+++ b/modules/backend/widgets/form/partials/_field_checkboxlist.htm
@@ -4,7 +4,7 @@
     $isScrollable = count($fieldOptions) > 10;
     $readOnly = $this->previewMode || $field->readOnly || $field->disabled;
     $quickselectEnabled = $field->getConfig('quickselect', $isScrollable);
-    $defaultState = $field->getConfig('default', false)
+    $defaultState = (bool) $field->getConfig('default', false)
 ?>
 <!-- Checkbox List -->
 <?php if ($readOnly && $field->value): ?>

--- a/modules/backend/widgets/form/partials/_field_checkboxlist.htm
+++ b/modules/backend/widgets/form/partials/_field_checkboxlist.htm
@@ -4,6 +4,7 @@
     $isScrollable = count($fieldOptions) > 10;
     $readOnly = $this->previewMode || $field->readOnly || $field->disabled;
     $quickselectEnabled = $field->getConfig('quickselect', $isScrollable);
+    $defaultState = $field->getConfig('default', false)
 ?>
 <!-- Checkbox List -->
 <?php if ($readOnly && $field->value): ?>
@@ -72,6 +73,7 @@
                     $index++;
                     $checkboxId = 'checkbox_'.$field->getId().'_'.$index;
                     if (is_string($option)) $option = [$option];
+                    $isSelected = $defaultState || in_array($value, $checkedValues)
                 ?>
                 <div class="checkbox custom-checkbox">
                     <input
@@ -79,7 +81,7 @@
                         id="<?= $checkboxId ?>"
                         name="<?= $field->getName() ?>[]"
                         value="<?= e($value) ?>"
-                        <?= in_array($value, $checkedValues) ? 'checked="checked"' : '' ?>>
+                    <?= $isSelected ? 'checked="checked"' : '' ?>>
 
                     <label for="<?= $checkboxId ?>">
                         <?= e(trans($option[0])) ?>


### PR DESCRIPTION
This PR add the `default` option to the checkboxlist.
The option works the same as in a basic checkbox and change the state of all the checkboxes in the list.

```yaml
selected_primary_mixable_house_models:
    label: Choisissez les modèles de maisons à mixer
    type: checkboxlist
    default: true
```
render something like:
![image](https://user-images.githubusercontent.com/53976837/84178379-9e82d200-aa84-11ea-97a1-9877ca986151.png)

Not a huge update but could be useful in some cases...

If the PR is merged, I will update the docs to add the option.