### PR TITLE
Allow to override a shared partial from the theme using only one file

### DIFF
--- a/modules/cms/classes/ComponentPartial.php
+++ b/modules/cms/classes/ComponentPartial.php
@@ -104,23 +104,31 @@ class ComponentPartial extends Extendable implements CmsObjectContract
         $partial = Partial::loadCached($theme, strtolower($component->alias) . '/' . $fileName);
 
         if ($partial === null) {
-            $pluginPath = 'plugins' . str_replace(
+            $partial = Partial::loadCached($theme, $component->alias . '/' . $fileName);
+        }
+
+        if ($partial === null) {
+            $partial = Partial::loadCached($theme, strtolower($component->name) . '/' . $fileName);
+        }
+
+        if ($partial === null) {
+            $partial = Partial::loadCached($theme, $component->name . '/' . $fileName);
+        }
+
+        if ($partial === null) {
+            $pluginPath = 'components-shared' . str_replace(
                 plugins_path(),
                 '',
                 $component->getPath()
             ) . '/' . $fileName;
 
             $sharedPath = str_replace(
-                [strtolower($component->alias), strtolower($component->name)],
-                'partials',
+                ['/components/' . strtolower($component->alias), '/components/' . strtolower($component->name) . '/'],
+                '',
                 $pluginPath
             );
 
             $partial = Partial::loadCached($theme, $sharedPath);
-        }
-
-        if ($partial === null) {
-            $partial = Partial::loadCached($theme, $component->alias . '/' . $fileName);
         }
 
         return $partial;

--- a/modules/cms/classes/ComponentPartial.php
+++ b/modules/cms/classes/ComponentPartial.php
@@ -104,6 +104,22 @@ class ComponentPartial extends Extendable implements CmsObjectContract
         $partial = Partial::loadCached($theme, strtolower($component->alias) . '/' . $fileName);
 
         if ($partial === null) {
+            $pluginPath = 'plugins' . str_replace(
+                plugins_path(),
+                '',
+                $component->getPath()
+            ) . '/' . $fileName;
+
+            $sharedPath = str_replace(
+                [strtolower($component->alias), strtolower($component->name)],
+                'partials',
+                $pluginPath
+            );
+
+            $partial = Partial::loadCached($theme, $sharedPath);
+        }
+
+        if ($partial === null) {
             $partial = Partial::loadCached($theme, $component->alias . '/' . $fileName);
         }
 

--- a/modules/cms/classes/ComponentPartial.php
+++ b/modules/cms/classes/ComponentPartial.php
@@ -128,10 +128,10 @@ class ComponentPartial extends Extendable implements CmsObjectContract
 
         if ($partial === null) {
             $pluginPath = 'components-shared' . str_replace(
-                    plugins_path(),
-                    '',
-                    $component->getPath()
-                ) . '/' . $fileName;
+                plugins_path(),
+                '',
+                $component->getPath()
+            ) . '/' . $fileName;
 
             $sharedPath = str_replace(
                 ['/components/' . strtolower($component->alias), '/components/' . strtolower($component->name) . '/'],

--- a/modules/cms/classes/ComponentPartial.php
+++ b/modules/cms/classes/ComponentPartial.php
@@ -112,10 +112,6 @@ class ComponentPartial extends Extendable implements CmsObjectContract
         }
 
         if ($partial === null) {
-            $partial = Partial::loadCached($theme, $component->name . '/' . $fileName);
-        }
-
-        if ($partial === null) {
             $pluginPath = 'components-shared' . str_replace(
                 plugins_path(),
                 '',


### PR DESCRIPTION
For now the only way to override a shared partial is to create a directory named with the component alias and create a file in it.

This is fine but an annoying thing happen when you use multiple components which use the same shared partial (it's definitely the goal of shared partial!). And it's worst if you use the same components multiple times in the same page using aliases!

This modification allow to directly override the shared partial using the path relative to the plugin in your theme folder with only one file:

`/themes/plugins/author-name/components/partials/file.htm`
will override:
`/plugins/author-name/components/partials/file.htm`

This is useful when using a shared partial multiple times, with many components alias.

As an example, my theme folder and how I figured out this functionnality was missing:
![image](https://user-images.githubusercontent.com/53976837/85734702-7e4a4880-b6fd-11ea-9fcb-1f55ea6ff09a.png)
and all the aliases are not presents yet in the theme folder, I still needed to add it more than 5 times... Annoying and useless ;/

Internally, each `tile.htm` file only contains a call for a unique partial:
`{% partial 'widgets/tile.htm' %}` to modify only one file if I need to modify the view but the theme folder is still unnecessary huge.


This functionality allows to do this:
![image](https://user-images.githubusercontent.com/53976837/85734985-b3ef3180-b6fd-11ea-8f2f-f0cc3839c299.png)

You still can override individually a component alias, the priority is:
- Components alias folder in theme directory
- Shared folder in theme directory (Using the path I used in example)
- Component folder in plugin directory
- Shared folder in plugin directory

The path can be more friendly if needed.

It could be something like:
`/themes/components/author-name/plugin-name/file-name.htm`

To go further, this functionality can be extended to override a component (non-shared) partial regardless to its alias:

```
[myComponent componentA]
[myComponent componentB]
[myComponent componentC]
```
We should be able to use the same partial located in `/themes/my-theme/partial/mycomponent/default.htm` without the need to create three directory (`componenta`, `componentb` and `componentc`) containing three exact same file including a fourth partial file to have only one html markup view file.

The creation of the file `/themes/my-theme/partial/componenta/default.htm` should still take the priority over the previous file path (and over the eventual shared partial if this PR is merged) if the developer wants to.    