### PR TITLE
Fix: Rollback plugins

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -327,7 +327,7 @@ class UpdateManager
         /*
          * Rollback plugins
          */
-        $plugins = $this->pluginManager->getPlugins();
+        $plugins = array_reverse($this->pluginManager->getPlugins());
         foreach ($plugins as $name => $plugin) {
             $this->rollbackPlugin($name);
         }


### PR DESCRIPTION
Plugin's rollback fail: rollback functions is calling in the direct order like migrations. But rollback order must be reversed.