### PR TITLE
Add sensitive field input

### DIFF
--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -80,6 +80,7 @@ class ServiceProvider extends ModuleServiceProvider
             $combiner->registerBundle('~/modules/backend/formwidgets/colorpicker/assets/less/colorpicker.less');
             $combiner->registerBundle('~/modules/backend/formwidgets/permissioneditor/assets/less/permissioneditor.less');
             $combiner->registerBundle('~/modules/backend/formwidgets/markdowneditor/assets/less/markdowneditor.less');
+            $combiner->registerBundle('~/modules/backend/formwidgets/sensitive/assets/less/sensitive.less');
 
             /*
              * Rich Editor is protected by DRM
@@ -199,6 +200,7 @@ class ServiceProvider extends ModuleServiceProvider
             $manager->registerFormWidget('Backend\FormWidgets\TagList', 'taglist');
             $manager->registerFormWidget('Backend\FormWidgets\MediaFinder', 'mediafinder');
             $manager->registerFormWidget('Backend\FormWidgets\NestedForm', 'nestedform');
+            $manager->registerFormWidget('Backend\FormWidgets\Sensitive', 'sensitive');
         });
     }
 

--- a/modules/backend/formwidgets/Sensitive.php
+++ b/modules/backend/formwidgets/Sensitive.php
@@ -1,0 +1,104 @@
+<?php namespace Backend\FormWidgets;
+
+use Input;
+use Backend\Classes\FormWidgetBase;
+
+/**
+ * Sensitive widget.
+ *
+ * Renders a password field that can be optionally made visible
+ *
+ * @package october\backend
+ */
+class Sensitive extends FormWidgetBase
+{
+    /**
+     * @var bool If true, the sensitive field cannot be edited, but can be toggled.
+     */
+    public $readOnly = false;
+
+    /**
+     * @var bool If true, the sensitive field is disabled.
+     */
+    public $disabled = false;
+
+    /**
+     * @inheritDoc
+     */
+    protected $defaultAlias = 'sensitive';
+
+    /**
+     * @var string The string that will be used as a placeholder for an unrevealed sensitive value.
+     */
+    protected $hiddenPlaceholder = '__hidden__';
+
+    /**
+     * @inheritDoc
+     */
+    public function init()
+    {
+        $this->fillFromConfig([
+            'readOnly',
+            'disabled',
+            'hiddenPlaceholder',
+        ]);
+
+        if ($this->formField->disabled || $this->formField->readOnly) {
+            $this->previewMode = true;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render()
+    {
+        $this->prepareVars();
+
+        return $this->makePartial('sensitive');
+    }
+
+    /**
+     * Prepares the view data for the widget partial.
+     */
+    public function prepareVars()
+    {
+        $this->vars['readOnly'] = $this->readOnly;
+        $this->vars['disabled'] = $this->disabled;
+        $this->vars['hasValue'] = !empty($this->getLoadValue());
+        $this->vars['hiddenPlaceholder'] = $this->hiddenPlaceholder;
+    }
+
+    /**
+     * Reveals the value of a hidden, unmodified sensitive field.
+     *
+     * @return array
+     */
+    public function onReveal()
+    {
+        return [
+            'value' => $this->getLoadValue()
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSaveValue($value)
+    {
+        if ($value === $this->hiddenPlaceholder) {
+            $value = $this->getLoadValue();
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function loadAssets()
+    {
+        $this->addCss('css/sensitive.css', 'core');
+        $this->addJs('js/sensitive.js', 'core');
+    }
+}

--- a/modules/backend/formwidgets/Sensitive.php
+++ b/modules/backend/formwidgets/Sensitive.php
@@ -1,6 +1,5 @@
 <?php namespace Backend\FormWidgets;
 
-use Input;
 use Backend\Classes\FormWidgetBase;
 
 /**
@@ -23,14 +22,19 @@ class Sensitive extends FormWidgetBase
     public $disabled = false;
 
     /**
+     * @var string The string that will be used as a placeholder for an unrevealed sensitive value.
+     */
+    public $hiddenPlaceholder = '__hidden__';
+
+    /**
+     * @var bool If true, the sensitive input will be hidden if the user changes to another tab in their browser.
+     */
+    public $hideOnTabChange = true;
+
+    /**
      * @inheritDoc
      */
     protected $defaultAlias = 'sensitive';
-
-    /**
-     * @var string The string that will be used as a placeholder for an unrevealed sensitive value.
-     */
-    protected $hiddenPlaceholder = '__hidden__';
 
     /**
      * @inheritDoc
@@ -41,6 +45,7 @@ class Sensitive extends FormWidgetBase
             'readOnly',
             'disabled',
             'hiddenPlaceholder',
+            'hideOnTabChange',
         ]);
 
         if ($this->formField->disabled || $this->formField->readOnly) {
@@ -67,6 +72,7 @@ class Sensitive extends FormWidgetBase
         $this->vars['disabled'] = $this->disabled;
         $this->vars['hasValue'] = !empty($this->getLoadValue());
         $this->vars['hiddenPlaceholder'] = $this->hiddenPlaceholder;
+        $this->vars['hideOnTabChange'] = $this->hideOnTabChange;
     }
 
     /**

--- a/modules/backend/formwidgets/Sensitive.php
+++ b/modules/backend/formwidgets/Sensitive.php
@@ -22,6 +22,11 @@ class Sensitive extends FormWidgetBase
     public $disabled = false;
 
     /**
+     * @var bool If true, a button will be available to copy the value.
+     */
+    public $allowCopy = false;
+
+    /**
      * @var string The string that will be used as a placeholder for an unrevealed sensitive value.
      */
     public $hiddenPlaceholder = '__hidden__';
@@ -44,6 +49,7 @@ class Sensitive extends FormWidgetBase
         $this->fillFromConfig([
             'readOnly',
             'disabled',
+            'allowCopy',
             'hiddenPlaceholder',
             'hideOnTabChange',
         ]);
@@ -71,6 +77,7 @@ class Sensitive extends FormWidgetBase
         $this->vars['readOnly'] = $this->readOnly;
         $this->vars['disabled'] = $this->disabled;
         $this->vars['hasValue'] = !empty($this->getLoadValue());
+        $this->vars['allowCopy'] = $this->allowCopy;
         $this->vars['hiddenPlaceholder'] = $this->hiddenPlaceholder;
         $this->vars['hideOnTabChange'] = $this->hideOnTabChange;
     }
@@ -80,7 +87,7 @@ class Sensitive extends FormWidgetBase
      *
      * @return array
      */
-    public function onReveal()
+    public function onShowValue()
     {
         return [
             'value' => $this->getLoadValue()

--- a/modules/backend/formwidgets/sensitive/assets/css/sensitive.css
+++ b/modules/backend/formwidgets/sensitive/assets/css/sensitive.css
@@ -1,3 +1,2 @@
-div[data-control="sensitive"] a[data-toggle] {box-shadow:none}
-div[data-control="sensitive"] a[data-toggle]:hover,
-div[data-control="sensitive"] a[data-toggle]:focus {border:1px solid #d1d6d9;border-left:0}
+div[data-control="sensitive"] a[data-toggle],
+div[data-control="sensitive"] a[data-copy] {box-shadow:none;border:1px solid #d1d6d9;border-left:0}

--- a/modules/backend/formwidgets/sensitive/assets/css/sensitive.css
+++ b/modules/backend/formwidgets/sensitive/assets/css/sensitive.css
@@ -1,0 +1,3 @@
+div[data-control="sensitive"] a[data-toggle] {box-shadow:none}
+div[data-control="sensitive"] a[data-toggle]:hover,
+div[data-control="sensitive"] a[data-toggle]:focus {border:1px solid #d1d6d9;border-left:0}

--- a/modules/backend/formwidgets/sensitive/assets/js/sensitive.js
+++ b/modules/backend/formwidgets/sensitive/assets/js/sensitive.js
@@ -7,7 +7,6 @@
  * JavaScript API:
  * $('div#someElement').sensitive({...})
  */
-
 +function ($) { "use strict";
     var Base = $.oc.foundation.base,
         BaseProto = Base.prototype

--- a/modules/backend/formwidgets/sensitive/assets/js/sensitive.js
+++ b/modules/backend/formwidgets/sensitive/assets/js/sensitive.js
@@ -1,0 +1,131 @@
+/*
+ * Sensitive field widget plugin.
+ *
+ * Data attributes:
+ * - data-control="sensitive" - enables the plugin on an element
+ *
+ * JavaScript API:
+ * $('div#someElement').sensitive({...})
+ */
+
++function ($) { "use strict";
+    var Base = $.oc.foundation.base,
+        BaseProto = Base.prototype
+
+    var Sensitive = function(element) {
+        this.$el = $(element)
+
+        Base.call(this)
+        this.init()
+    }
+
+    Sensitive.DEFAULTS = {
+        readOnly: false,
+        disabled: false
+    }
+
+    Sensitive.prototype = Object.create(BaseProto)
+    Sensitive.prototype.constructor = Sensitive
+
+    Sensitive.prototype.init = function() {
+        this.$input = this.$el.find('[data-input]').first()
+        this.$toggle = this.$el.find('[data-toggle]').first()
+        this.$icon = this.$el.find('[data-icon]').first()
+        this.$loader = this.$el.find('[data-loader]').first()
+
+        this.clean = Boolean(this.$el.data('clean'))
+
+        this.$input.on('keydown', this.proxy(this.onInput))
+        this.$toggle.on('click', this.proxy(this.onToggle))
+    }
+
+    Sensitive.prototype.dispose = function () {
+        this.$input.on('keydown', this.proxy(this.onInput))
+        this.$toggle.off('click', this.proxy(this.onToggle))
+
+        this.$input = this.$toggle = this.$icon = this.$loader = null
+        this.$el = null
+
+        BaseProto.dispose.call(this)
+    }
+
+    Sensitive.prototype.onInput = function() {
+        if (this.clean) {
+            this.clean = false
+            this.$input.val('')
+        }
+
+        return true
+    }
+
+    Sensitive.prototype.onToggle = function() {
+        if (this.$input.val() !== '' && this.clean) {
+            this.reveal()
+        } else {
+            this.toggleVisibility()
+        }
+
+        return true
+    }
+
+    Sensitive.prototype.toggleVisibility = function() {
+        if (this.$input.attr('type') === 'password') {
+            this.$input.attr('type', 'text')
+        } else {
+            this.$input.attr('type', 'password')
+        }
+
+        this.$icon.toggleClass('icon-eye icon-eye-slash')
+    }
+
+    Sensitive.prototype.reveal = function() {
+        var that = this
+        this.$icon.css({
+            visibility: 'hidden'
+        })
+        this.$loader.removeClass('hide')
+
+        this.$input.request(this.$input.data('eventHandler'), {
+            data: {
+                fieldId: this.$input.attr('id'),
+            },
+            success: function (data) {
+                that.$input.val(data.value)
+                that.clean = false
+
+                that.$icon.css({
+                    visibility: 'visible'
+                })
+                that.$loader.addClass('hide')
+
+                that.toggleVisibility()
+            }
+        })
+    }
+
+    var old = $.fn.sensitive
+
+    $.fn.sensitive = function (option) {
+        var args = Array.prototype.slice.call(arguments, 1), result
+        this.each(function () {
+            var $this   = $(this)
+            var data    = $this.data('oc.sensitive')
+            var options = $.extend({}, Sensitive.DEFAULTS, $this.data(), typeof option == 'object' && option)
+            if (!data) $this.data('oc.sensitive', (data = new Sensitive(this, options)))
+            if (typeof option == 'string') result = data[option].apply(data, args)
+            if (typeof result != 'undefined') return false
+        })
+
+        return result ? result : this
+    }
+
+    $.fn.sensitive.noConflict = function () {
+        $.fn.sensitive = old
+        return this
+    }
+
+    $(document).render(function () {
+        $('[data-control="sensitive"]').sensitive()
+    });
+
+}(window.jQuery);

--- a/modules/backend/formwidgets/sensitive/assets/js/sensitive.js
+++ b/modules/backend/formwidgets/sensitive/assets/js/sensitive.js
@@ -86,9 +86,6 @@
         this.$loader.removeClass('hide')
 
         this.$input.request(this.$input.data('eventHandler'), {
-            data: {
-                fieldId: this.$input.attr('id'),
-            },
             success: function (data) {
                 that.$input.val(data.value)
                 that.clean = false

--- a/modules/backend/formwidgets/sensitive/assets/less/sensitive.less
+++ b/modules/backend/formwidgets/sensitive/assets/less/sensitive.less
@@ -1,0 +1,13 @@
+@import "../../../../assets/less/core/boot.less";
+
+div[data-control="sensitive"] {
+    a[data-toggle] {
+        box-shadow: none;
+
+        &:hover,
+        &:focus {
+            border: 1px solid @input-group-addon-border-color;
+            border-left: 0;
+        }
+    }
+}

--- a/modules/backend/formwidgets/sensitive/assets/less/sensitive.less
+++ b/modules/backend/formwidgets/sensitive/assets/less/sensitive.less
@@ -1,13 +1,10 @@
 @import "../../../../assets/less/core/boot.less";
 
 div[data-control="sensitive"] {
-    a[data-toggle] {
+    a[data-toggle],
+    a[data-copy] {
         box-shadow: none;
-
-        &:hover,
-        &:focus {
-            border: 1px solid @input-group-addon-border-color;
-            border-left: 0;
-        }
+        border: 1px solid @input-group-addon-border-color;
+        border-left: 0;
     }
 }

--- a/modules/backend/formwidgets/sensitive/partials/_sensitive.htm
+++ b/modules/backend/formwidgets/sensitive/partials/_sensitive.htm
@@ -1,7 +1,7 @@
 <div
     data-control="sensitive"
     data-clean="true"
-    data-event-handler="<?= $this->getEventHandler('onReveal') ?>"
+    data-event-handler="<?= $this->getEventHandler('onShowValue') ?>"
     <?php if ($hideOnTabChange): ?>data-hide-on-tab-change="true"<?php endif ?>
 >
     <div class="loading-indicator-container size-form-field">
@@ -17,6 +17,15 @@
                 autocomplete="off"
                 data-input
             />
+            <?php if ($allowCopy): ?>
+            <a
+                href="javascript:;"
+                class="input-group-addon btn btn-secondary"
+                data-copy
+            >
+                <i class="icon-copy"></i>
+            </a>
+            <?php endif ?>
             <a
                 href="javascript:;"
                 class="input-group-addon btn btn-secondary"

--- a/modules/backend/formwidgets/sensitive/partials/_sensitive.htm
+++ b/modules/backend/formwidgets/sensitive/partials/_sensitive.htm
@@ -1,6 +1,8 @@
 <div
     data-control="sensitive"
     data-clean="true"
+    data-event-handler="<?= $this->getEventHandler('onReveal') ?>"
+    <?php if ($hideOnTabChange): ?>data-hide-on-tab-change="true"<?php endif ?>
 >
     <div class="loading-indicator-container size-form-field">
         <div class="input-group">
@@ -14,7 +16,6 @@
                 <?php if ($this->previewMode): ?>disabled="disabled"<?php endif ?>
                 autocomplete="off"
                 data-input
-                data-event-handler="<?= $this->getEventHandler('onReveal') ?>"
             />
             <a
                 href="javascript:;"

--- a/modules/backend/formwidgets/sensitive/partials/_sensitive.htm
+++ b/modules/backend/formwidgets/sensitive/partials/_sensitive.htm
@@ -1,0 +1,31 @@
+<div
+    data-control="sensitive"
+    data-clean="true"
+>
+    <div class="loading-indicator-container size-form-field">
+        <div class="input-group">
+            <input
+                type="password"
+                name="<?= $this->getFieldName() ?>"
+                id="<?= $this->getId() ?>"
+                value="<?= ($hasValue) ? $hiddenPlaceholder : '' ?>"
+                placeholder="<?= e(trans($this->formField->placeholder)) ?>"
+                class="form-control"
+                <?php if ($this->previewMode): ?>disabled="disabled"<?php endif ?>
+                autocomplete="off"
+                data-input
+                data-event-handler="<?= $this->getEventHandler('onReveal') ?>"
+            />
+            <a
+                href="javascript:;"
+                class="input-group-addon btn btn-secondary"
+                data-toggle
+            >
+                <i class="icon-eye" data-icon></i>
+            </a>
+        </div>
+        <div class="loading-indicator hide" data-loader>
+            <span class="p-a"></span>
+        </div>
+    </div>
+</div>

--- a/modules/system/models/mailsetting/fields.yaml
+++ b/modules/system/models/mailsetting/fields.yaml
@@ -79,6 +79,7 @@ tabs:
         smtp_password:
             label: system::lang.mail.smtp_password
             tab: system::lang.mail.general
+            type: sensitive
             span: right
             trigger:
                 action: show
@@ -107,6 +108,7 @@ tabs:
             label: system::lang.mail.mailgun_secret
             commentAbove: system::lang.mail.mailgun_secret_comment
             tab: system::lang.mail.general
+            type: sensitive
             trigger:
                 action: show
                 field: send_mode
@@ -116,6 +118,7 @@ tabs:
             label: system::lang.mail.mandrill_secret
             commentAbove: system::lang.mail.mandrill_secret_comment
             tab: system::lang.mail.general
+            type: sensitive
             trigger:
                 action: show
                 field: send_mode
@@ -135,6 +138,7 @@ tabs:
             label: system::lang.mail.ses_secret
             commentAbove: system::lang.mail.ses_secret_comment
             tab: system::lang.mail.general
+            type: sensitive
             span: right
             trigger:
                 action: show
@@ -154,6 +158,7 @@ tabs:
         sparkpost_secret:
             label: system::lang.mail.sparkpost_secret
             commentAbove: system::lang.mail.sparkpost_secret_comment
+            type: sensitive
             tab: system::lang.mail.general
             trigger:
                 action: show


### PR DESCRIPTION
Replaces #5062. Fixes #5061, #1850, perhaps #1061.

A field widget that allows for entering of sensitive information that can be revealed at the user's request - ie. API keys, secrets. The field initially presents as a password field, but using the attached visibility button allows the user to switch the field to a text field, thereby making the value visible, and vice versa.

When a sensitive field that has been previously populated is loaded again, a placeholder is used instead of the real value which masks the original value's content and length, until the user opts to reveal the value. The real value is loaded via AJAX.

### Screenshots

When the value is invisible:

![Screenshot_2020-07-08 Mail configuration myStockz(3)](https://user-images.githubusercontent.com/15900351/86877225-fa3e8a80-c118-11ea-9572-7d863497961e.png)

After toggling:

![Screenshot_2020-07-08 Mail configuration myStockz](https://user-images.githubusercontent.com/15900351/86877270-0f1b1e00-c119-11ea-8c6b-629407eb20d3.png)

Upon saving the form, and reloading the page, the field is loaded with a placeholder value that masks the original value.

![Screenshot_2020-07-08 Mail configuration myStockz(1)](https://user-images.githubusercontent.com/15900351/86877304-2d811980-c119-11ea-8e09-74a1b1a6461c.png)

Credit to @tomaszstrojny for the original implementation.
