### PR TITLE
Provide an accessor for the form widget of the Settings controller

### DIFF
--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -219,7 +219,7 @@ class Settings extends Controller
     }
 
     /**
-     * Auto-guesses the requested setting item by URL segments from the Request object.
+     * Guesses the requested setting item by URL segments from the Request object.
      *
      * @return array
      */

--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -219,7 +219,7 @@ class Settings extends Controller
     }
 
     /**
-     * Guesses the requested setting item by URL segments from the Request object.
+     * Guesses the requested setting item from the current URL segments provided by the Request object.
      *
      * @return array
      */

--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -1,9 +1,9 @@
 <?php namespace System\Controllers;
 
-use Config;
-use Request;
 use Lang;
 use Flash;
+use Config;
+use Request;
 use Backend;
 use BackendMenu;
 use System\Classes\SettingsManager;
@@ -200,7 +200,7 @@ class Settings extends Controller
     protected function findSettingItem($author = null, $plugin = null, $code = null)
     {
         if (is_null($author) || is_null($plugin)) {
-            [$author, $plugin, $code] = $this->autoGuessSettingItem();
+            [$author, $plugin, $code] = $this->guessSettingItem();
         }
 
         $manager = SettingsManager::instance();
@@ -223,7 +223,7 @@ class Settings extends Controller
      *
      * @return array
      */
-    protected function autoGuessSettingItem()
+    protected function guessSettingItem()
     {
         $segments = Request::segments();
 


### PR DESCRIPTION
Replacement for #5209.

The Settings controller does not currently have any method to get the form widget or its data through normal means as the form widget is protected and does not use the normal FormController behavior.

This prevents extensions to the controller from being able to manipulate the form.

This adds a `formGetWidget` method (similar to the FormController behavior) that allows people to access the widget. As the form widget in the Settings controller is dependent on the URL to determine which plugin or module is being configured, a method to auto-guess the current model has also been added.