### PR TITLE
Enable nested repeaters inside an initial repeater group

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -450,10 +450,10 @@ class Repeater extends FormWidgetBase
 
         if ($group && isset($group->{$code}['type']) && $group->{$code}['type'] === 'repeater') {
             $fields = [
-                $code => $group->{$code}
+                $code => $group->{$code},
             ];
         } else {
-            $fields = array_get($this->groupDefinitions, $code.'.fields');
+            $fields = array_get($this->groupDefinitions, $code . '.fields');
         }
 
         if (!$fields) {

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -442,7 +442,19 @@ class Repeater extends FormWidgetBase
             return null;
         }
 
-        $fields = array_get($this->groupDefinitions, $code.'.fields');
+        // Bring the config in to use all attributes in repeater
+        $group = $this->getConfig('groups', []);
+        if (is_string($group)) {
+            $group = $this->makeConfig($group);
+        }
+
+        if ($group && isset($group->{$code}['type']) && $group->{$code}['type'] === 'repeater') {
+            $fields = [
+                $code => $group->{$code}
+            ];
+        } else {
+            $fields = array_get($this->groupDefinitions, $code.'.fields');
+        }
 
         if (!$fields) {
             return null;


### PR DESCRIPTION
This update allows a repeater group to include additional 'nested repeaters'.
Previously the repeater widget would directly add 'fields'.  
This update checks the field type of the group element first.  If it is a repeater type then the entire config is loaded.