### PR TITLE
Generalize validation namespaces (Allow global localization of validation messages for custom rules)

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -7,6 +7,7 @@ use Event;
 use Config;
 use Backend;
 use Request;
+use Lang;
 use BackendMenu;
 use BackendAuth;
 use Twig\Environment as TwigEnvironment;
@@ -95,6 +96,9 @@ class ServiceProvider extends ModuleServiceProvider
         }
 
         Paginator::defaultSimpleView('system::pagination.simple-default');
+
+        // Register system validation messages
+        Lang::addValidationNamespace('system');
 
         /*
          * Boot plugins

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -221,6 +221,7 @@ class PluginManager
         $langPath = $pluginPath . '/lang';
         if (File::isDirectory($langPath)) {
             Lang::addNamespace($pluginNamespace, $langPath);
+            Lang::addValidationNamespace($pluginNamespace);
         }
 
         /**


### PR DESCRIPTION
**This PR is associated and requires PR octobercms/library#506**

These PRs generalize the mechanism that makes validation messages stored under the `system::validation` namespace accessible through the `::validation` namespace. That way, plugins can register validation messages for custom rules they introduce.

Previously, there were no proper way for plugins to register a custom rule with their own localized messages. Either, a custom message array must be passed to every Validator instance that uses a custom rule (which is repetitive and not always feasible). Another way is to create a Rule class, with a `message()` method, but this method is not called when the Rule is registered with `Validator::extend`.

When a Validator instance is looking for a validation message, it will only look under the `validation` namespace. In the current October implementation, this behavior has been changed so that a query in the `validation` namespace is replaced by a query in the `system::validation` namespace.

With these two PRs, if the query in `system::validation` failed, it will query every plugin that has a lang directory, until the string is found.
