### PR TITLE
Add persistent state for list checkboxes

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -4,6 +4,7 @@ use Db;
 use Html;
 use Lang;
 use Backend;
+use Request;
 use DbDongle;
 use Carbon\Carbon;
 use October\Rain\Html\Helper as HtmlHelper;
@@ -227,7 +228,7 @@ class Lists extends WidgetBase
         $this->validateModel();
         $this->validateTree();
 
-        if (!$this->isAjaxRequest()) {
+        if (!Request::ajax() || Request::method() !== 'POST') {
             $this->resetCheckedState();
         }
     }
@@ -1822,16 +1823,6 @@ class Lists extends WidgetBase
         }
 
         return true;
-    }
-
-    /**
-     * Determines if an AJAX request is occurring within the list
-     *
-     * @return bool
-     */
-    public function isAjaxRequest()
-    {
-        return !is_null($this->getController()->getAjaxHandler());
     }
 
     /**

--- a/modules/backend/widgets/lists/partials/_list.htm
+++ b/modules/backend/widgets/lists/partials/_list.htm
@@ -15,6 +15,9 @@
             <?php endif ?>
         </tbody>
     </table>
+
+    <?= $this->makePartial('list_data') ?>
+
     <?php if ($showPagination): ?>
         <div class="list-footer">
             <div class="list-pagination">

--- a/modules/backend/widgets/lists/partials/_list.htm
+++ b/modules/backend/widgets/lists/partials/_list.htm
@@ -20,6 +20,12 @@
 
     <?php if ($showPagination): ?>
         <div class="list-footer">
+            <?php if ($showCheckboxes): ?>
+                <div class="list-selection">
+                    <?= $this->makePartial('list_selection') ?>
+                </div>
+            <?php endif ?>
+
             <div class="list-pagination">
                 <?php if ($showPageNumbers): ?>
                     <?= $this->makePartial('list_pagination') ?>

--- a/modules/backend/widgets/lists/partials/_list_body_checkbox.htm
+++ b/modules/backend/widgets/lists/partials/_list_body_checkbox.htm
@@ -5,7 +5,9 @@
             name="checked[]"
             id="<?= $this->getId('checkbox-' . $record->getKey()) ?>"
             value="<?= $record->getKey() ?>"
-            autocomplete="off"/>
+            autocomplete="off"
+            <?php if ($this->isChecked($record->getKey())): ?>checked<?php endif ?>
+        />
         <label for="<?= $this->getId('checkbox-' . $record->getKey()) ?>"><?= e(trans('backend::lang.list.check')) ?></label>
     </div>
 </td>

--- a/modules/backend/widgets/lists/partials/_list_data.htm
+++ b/modules/backend/widgets/lists/partials/_list_data.htm
@@ -1,0 +1,5 @@
+<?php if (count($otherChecked)): ?>
+    <?php foreach ($otherChecked as $id): ?>
+        <input name="checked[]" type="hidden" value="<?= $id ?>" data-other-checked>
+    <?php endforeach ?>
+<?php endif ?>

--- a/modules/backend/widgets/lists/partials/_list_selection.htm
+++ b/modules/backend/widgets/lists/partials/_list_selection.htm
@@ -1,0 +1,29 @@
+<div class="loading-indicator-container size-small">
+    <div class="control-selection">
+        <span class="select-iteration">
+            <?= e(trans('backend::lang.list.select')) ?>
+        </span>
+
+        <span class="select-options">
+            <a
+                href="javascript:;"
+                class="select-all"
+                data-request="<?= $this->getEventHandler('onSelectAll') ?>"
+                data-load-indicator="<?= e(trans('backend::lang.list.loading')) ?>"
+                title="<?= e(trans('backend::lang.list.select_all_title')) ?>"
+            >
+                <?= e(trans('backend::lang.list.select_all')) ?>
+            </a>
+            <a
+                href="javascript:;"
+                class="select-none"
+                data-request="<?= $this->getEventHandler('onSelectNone') ?>"
+                data-request-data="page: 1"
+                data-load-indicator="<?= e(trans('backend::lang.list.loading')) ?>"
+                title="<?= e(trans('backend::lang.list.select_none_title')) ?>"
+            >
+                <?= e(trans('backend::lang.list.select_none')) ?>
+            </a>
+        </span>
+    </div>
+</div>

--- a/modules/system/assets/ui/less/list.less
+++ b/modules/system/assets/ui/less/list.less
@@ -11,6 +11,7 @@
 
 @import "list.rowlink.less";
 @import "list.base.less";
+@import "list.selection.less";
 
 //
 // List Data Table
@@ -531,6 +532,22 @@ table.table.data {
         text-decoration: none;
     }
 
+    .list-selection {
+        font-size: 13px;
+        text-align: left;
+        padding-top: 10px;
+        overflow: hidden; /* clearfix */
+        float: left;
+        width: 50%;
+
+        .loading-indicator {
+            div {
+                margin-left: 20px;
+                font-size: 12px;
+            }
+        }
+    }
+
     .list-pagination {
         font-size: 14px;
         text-align: right;
@@ -543,6 +560,11 @@ table.table.data {
                 font-size: 12px;
             }
         }
+    }
+
+    .list-selection + .list-pagination {
+        float: right;
+        width: 50%;
     }
 }
 

--- a/modules/system/assets/ui/less/list.selection.less
+++ b/modules/system/assets/ui/less/list.selection.less
@@ -1,0 +1,14 @@
+//
+// Dependencies
+// --------------------------------------------------
+
+@import "global.less";
+
+//
+// Pagination
+// --------------------------------------------------
+
+@color-selection-link:                      #666666;
+@color-selection-hover:                     @link-color;
+@color-selection-inactive:                  #b6b6b6;
+@color-selection:                           #98a7a8;

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4603,8 +4603,11 @@ table.table.data tr.list-tree-level-10 td.list-cell-index-1 {padding-left:115px}
 .list-header h3 {font-size:14px;color:#7e8c8d;text-transform:uppercase;font-weight:600;margin-top:0;margin-bottom:15px}
 .list-footer {padding:10px 15px}
 .list-footer a {color:#666;text-decoration:none}
+.list-footer .list-selection {font-size:13px;text-align:left;padding-top:10px;overflow:hidden;float:left;width:50%}
+.list-footer .list-selection .loading-indicator div {margin-left:20px;font-size:12px}
 .list-footer .list-pagination {font-size:14px;text-align:right;padding-top:10px;overflow:hidden}
 .list-footer .list-pagination .loading-indicator div {margin-left:20px;font-size:12px}
+.list-footer .list-selection + .list-pagination {float:right;width:50%}
 .report-widget .table-container {margin:-15px}
 .report-widget .table-container table.table.data {margin-bottom:0}
 .report-widget .table-container table.table.data thead tr th {border-top:none !important}


### PR DESCRIPTION
Fixes https://github.com/octobercms/october/issues/2282

This will allow checkboxes to remember state when switching pages or filtering lists, allowing users to select items for deletion or modification across multiple pages. This state is kept for all AJAX requests made on the page, but will be forgotten/reset if the user leaves the page.

This already works for the deletion of records, but needs to be tested with other actions. There should also be some quality-of-life features such as indicating if records on other pages are checked, allowing all items to be unchecked or checked regardless of page and perhaps having a way of just showing checked items.