### PR TITLE
Fix error when tab location could not be found

### DIFF
--- a/modules/system/assets/ui/js/tab.js
+++ b/modules/system/assets/ui/js/tab.js
@@ -89,7 +89,10 @@
         this.updateClasses()
 
         if (location.hash && this.$tabsContainer.is('[data-linkable]')) {
-            $('li > a[href=' + location.hash + ']', this.$tabsContainer).tab('show')
+            try {
+                $('li > a[href=' + location.hash + ']', this.$tabsContainer).tab('show')
+            } catch (e) {
+            }
         }
     }
 


### PR DESCRIPTION
I had a situation where the tab location couldn't be found and an exception is thrown. When the exception was thrown, the richeditor in de rainlab pages plugin didn't work anymore, see below:
![image](https://user-images.githubusercontent.com/15017400/91889515-395b0900-ec8e-11ea-950c-18fdd603da8c.png)

I added a try catch to solve this issue.