### PR TITLE
app name configured from env

### DIFF
--- a/modules/system/console/OctoberEnv.php
+++ b/modules/system/console/OctoberEnv.php
@@ -355,6 +355,7 @@ class OctoberEnv extends Command
         return [
             'app' => [
                 'APP_DEBUG' => 'debug',
+                'APP_NAME' => 'name',
                 'APP_URL' => 'url',
                 'APP_KEY' => 'key',
             ],


### PR DESCRIPTION
In continues for our conversation on #5262. This will let you change app name from env after run php artisan `october:env`