### PR TITLE
disable Rocket Loader for all assets added with addJs() method

### DIFF
--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -90,6 +90,7 @@ trait AssetMaker
             foreach ($this->assets['js'] as $asset) {
                 $attributes = Html::attributes(array_merge(
                     [
+                        'data-cfasync' => "false",
                         'src' => $this->getAssetEntryBuildPath($asset)
                     ],
                     array_except($asset['attributes'], $reserved)


### PR DESCRIPTION
fixes https://github.com/rainlab/translate-plugin/issues/536