### PR TITLE
Add `&` to arguments to make it consistent with the examples.

### DIFF
--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -208,7 +208,7 @@ trait AssetMaker
              *
              * Example usage:
              *
-             *     Event::listen('system.assets.beforeAddAsset', function (string $type, string $path, array $attributes) {
+             *     Event::listen('system.assets.beforeAddAsset', function (string &$type, string &$path, array &$attributes) {
              *         if (in_array($path, $blockedAssets)) {
              *             return false;
              *         }
@@ -216,7 +216,7 @@ trait AssetMaker
              *
              * Or
              *
-             *     $this->bindEvent('assets.beforeAddAsset', function (string $type, string $path, array $attributes) {
+             *     $this->bindEvent('assets.beforeAddAsset', function (string &$type, string &$path, array &$attributes) {
              *         $attributes['special_cdn_flag'] = false;
              *     });
              *


### PR DESCRIPTION
This is intended for the [docs](https://octobercms.com/docs/api/system/assets/beforeaddasset) - The doc says `All the parameters are provided by reference for modification` which is clear enough but may help someone like myself not familiar with the term passing by reference.