### PR TITLE
Check for any other flash messages before flashing a success message.

### DIFF
--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -104,8 +104,9 @@ class Settings extends Controller
         }
         $model->save(null, $this->formWidget->getSessionKey());
 
-        Flash::success(Lang::get('system::lang.settings.update_success', ['name' => Lang::get($item->label)]));
-
+        if(!Flash::check()){
+            Flash::success(Lang::get('system::lang.settings.update_success', ['name' => Lang::get($item->label)]));
+        }
         /*
          * Handle redirect
          */

--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -104,7 +104,7 @@ class Settings extends Controller
         }
         $model->save(null, $this->formWidget->getSessionKey());
 
-        if(!Flash::check()){
+        if (!Flash::check()) {
             Flash::success(Lang::get('system::lang.settings.update_success', ['name' => Lang::get($item->label)]));
         }
         /*


### PR DESCRIPTION
Inside of my settings model, I am listening to the save event and I am making a API Call to a server and setting some flash messages in the session.

```php
public function afterSave()
{
   App::make('zoho_client');
   try {
       $oAuthClient = ZohoOAuth::getClientInstance();
       $oAuthClient->generateAccessToken(self::get('grant_token'));
       Flash::success('Access Token Generated Successfully');
    } catch (\Throwable $th) {
       Flash::error($th->getMessage());
    }
}
```
The problem here is that neither of this flash messages get displayed as there is another message [here](https://github.com/octobercms/october/blob/15ca68c22df788397b2e84a9abfa5ecbc579b3ff/modules/system/controllers/Settings.php#L107) which is overriding the earlier messages.

So I have just checked if there are any existing messages then do not flash the success message. Please let me know if there is any other way to achieve this.