### PR TITLE
Removal of custom fallback image feature

### DIFF
--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -450,6 +450,8 @@ return [
         'logo_description' => 'Upload a custom logo to use in the back-end.',
         'favicon' => 'Favicon',
         'favicon_description' => 'Upload a custom favicon to use in the back-end',
+        'fallback_image' => 'Fallback Image',
+        'fallback_image_description' => 'Upload a custom fallback image to show as a broken image',
         'app_name' => 'App Name',
         'app_name_description' => 'This name is shown in the title area of the back-end.',
         'app_tagline' => 'App Tagline',

--- a/modules/backend/models/BrandSetting.php
+++ b/modules/backend/models/BrandSetting.php
@@ -41,7 +41,8 @@ class BrandSetting extends Model
 
     public $attachOne = [
         'favicon' => \System\Models\File::class,
-        'logo' => \System\Models\File::class
+        'logo' => \System\Models\File::class,
+        'fallback_image' => \System\Models\File::class,
     ];
 
     /**
@@ -113,6 +114,17 @@ class BrandSetting extends Model
         }
 
         return self::getDefaultLogo() ?: null;
+    }
+
+    public static function getFallbackImage()
+    {
+        $settings = self::instance();
+
+        if ($settings->fallback_image) {
+            return $settings->fallback_image->getDiskPath();
+        }
+
+        return null;
     }
 
     public static function renderCss()

--- a/modules/backend/models/brandsetting/fields.yaml
+++ b/modules/backend/models/brandsetting/fields.yaml
@@ -39,6 +39,15 @@ tabs:
             span: right
             fileTypes: jpg,jpeg,bmp,png,webp,gif,svg,ico
 
+        fallback_image:
+            label: backend::lang.branding.fallback_image
+            type: fileupload
+            commentAbove: backend::lang.branding.fallback_image_description
+            mode: image
+            tab: backend::lang.branding.brand
+            span: right
+            fileTypes: jpg,jpeg,bmp,png,webp,gif,svg,ico
+
         primary_color:
             label: backend::lang.branding.primary_color
             type: colorpicker


### PR DESCRIPTION
Added a form field under the customize backend page to allow addition of a custom fallback image when an image is missing. Support code to fix #5150.