### PR TITLE
Sortable Relations

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -154,6 +154,7 @@ class ListController extends ControllerBehavior
             'showCheckboxes',
             'showTree',
             'treeExpanded',
+            'sortable',
             'customViewPath',
         ];
 
@@ -428,13 +429,17 @@ class ListController extends ControllerBehavior
     /**
      * Returns the sort order value for a specific record.
      */
-    public function getRecordSortOrder($record, $relation)
+    public function getRecordSortOrder($record, $relation = '')
     {
-        /** @var SortableRelation $modelInstance */
-        $modelInstance = new $this->config->modelClass;
-        $reorderColumn = $modelInstance->getRelationSortOrderColumn($relation);
+        if ($relation) {
+            /** @var SortableRelation $modelInstance */
+            $modelInstance = new $this->config->modelClass;
+            $reorderColumn = $modelInstance->getRelationSortOrderColumn($relation);
 
-        return $record->pivot->{$reorderColumn};
+            return $record->pivot->{$reorderColumn};
+        }
+
+        return $record->{$record->getSortOrderColumn()};
     }
 
     /**

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -235,7 +235,7 @@ class ListController extends ControllerBehavior
          */
         if (isset($listConfig->filter)) {
             $filterConfig = $this->makeConfig($listConfig->filter);
-            
+
             if (!empty($filterConfig->scopes)) {
                 $widget->cssClasses[] = 'list-flush';
 

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -5,6 +5,7 @@ use Event;
 use Flash;
 use ApplicationException;
 use Backend\Classes\ControllerBehavior;
+use October\Rain\Database\Traits\SortableRelation;
 
 /**
  * Adds features for working with backend lists.
@@ -422,6 +423,18 @@ class ListController extends ControllerBehavior
         }
 
         return $this->listWidgets[$definition]->onRefresh();
+    }
+
+    /**
+     * Returns the sort order value for a specific record.
+     */
+    public function getRecordSortOrder($record, $relation)
+    {
+        /** @var SortableRelation $modelInstance */
+        $modelInstance = new $this->config->modelClass;
+        $reorderColumn = $modelInstance->getRelationSortOrderColumn($relation);
+
+        return $record->pivot->{$reorderColumn};
     }
 
     /**

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -667,6 +667,10 @@ class RelationController extends ControllerBehavior
             $config->alias = $this->alias . 'ViewList';
             $config->showSorting = $this->getConfig('view[showSorting]', true);
             $config->defaultSort = $this->getConfig('view[defaultSort]');
+            $config->sortable = $this->getConfig('view[sortable]', false);
+            $config->reorderRelation = $this->relationName;
+            $config->reorderModel = get_class($this->model);
+            $config->reorderParentId = $this->model->getKey();
             $config->recordsPerPage = $this->getConfig('view[recordsPerPage]');
             $config->showCheckboxes = $this->getConfig('view[showCheckboxes]', !$this->readOnly);
             $config->recordUrl = $this->getConfig('view[recordUrl]', null);

--- a/modules/backend/behaviors/ReorderRelationController.php
+++ b/modules/backend/behaviors/ReorderRelationController.php
@@ -102,9 +102,9 @@ class ReorderRelationController extends ControllerBehavior
 
         return $this->reorderRelationMakePartial(
             'relation_modal',
-                 $params + [
-                    'container' => $this->reorderRelationMakePartial('container', $params)
-                ]
+            $params + [
+                'container' => $this->reorderRelationMakePartial('container', $params),
+            ]
         );
     }
 
@@ -159,7 +159,7 @@ class ReorderRelationController extends ControllerBehavior
         $this->controller->reorderExtendRelationQuery($query);
 
         return $query
-            ->with([$this->relation => function($q) {
+            ->with([$this->relation => function ($q) {
                 $q->orderBy($this->parentModel->getRelationSortOrderColumn($this->relation), 'ASC');
             }])
             ->findOrFail(post('_reorder_parent_id'))

--- a/modules/backend/behaviors/ReorderRelationController.php
+++ b/modules/backend/behaviors/ReorderRelationController.php
@@ -1,0 +1,261 @@
+<?php namespace Backend\Behaviors;
+
+use ApplicationException;
+use Backend;
+use Backend\Classes\ControllerBehavior;
+use Lang;
+use October\Rain\Database\Model;
+use October\Rain\Database\Traits\SortableRelation;
+
+/**
+ * Used for reordering and sorting related records.
+ *
+ * This behavior is implemented in the controller like so:
+ *
+ *     public $implement = [
+ *         'Backend.Behaviors.ReorderRelationController',
+ *     ];
+ *     // Optional:
+ *     public $reorderRelationConfig = 'config_reorder_relation.yaml';
+ *
+ * The `$reorderRelationConfig` property makes reference to the configuration
+ * values as either a YAML file, located in the controller view directory,
+ * or directly as a PHP array.
+ *
+ * @package october\backend
+ */
+class ReorderRelationController extends ControllerBehavior
+{
+    /**
+     * @var Model The related sort model
+     */
+    public $model;
+
+    /**
+     * @var SortableRelation|Model The parent/form model
+     */
+    public $parentModel;
+
+    /**
+     * @var string The relation that is being sorted
+     */
+    public $relation;
+
+    /**
+     * Behavior constructor
+     * @param Backend\Classes\Controller $controller
+     */
+    public function __construct($controller)
+    {
+        parent::__construct($controller);
+
+        // The configuration is optional for this behavior.
+        $this->config = $this->makeConfig($controller->reorderRelationConfig, []);
+    }
+
+    //
+    // AJAX
+    //
+
+    /**
+     * Updates the relation order.
+     * @throws \Exception
+     */
+    public function onReorderRelation()
+    {
+        $this->reorderGetModel();
+        $this->validateModel();
+
+        if (
+            (!$ids = post('record_ids')) ||
+            (!$orders = post('sort_orders'))
+        ) {
+            return;
+        }
+
+        /** @var SortableRelation $instance */
+        $instance = $this->parentModel->newQuery()->find(post('_reorder_parent_id'));
+        $instance->setRelationOrder($this->relation, $ids, $orders);
+    }
+
+    /**
+     * Returns the modal contents.
+     * @return string
+     */
+    public function onRelationButtonReorder()
+    {
+        $this->addJs('../../reordercontroller/assets/js/october.reorder.js', 'core');
+
+        $this->reorderGetModel();
+        $this->validateModel();
+        $this->prepareVars();
+
+        $params = [
+            'reorderRelation' => $this->relation,
+            'reorderModel' => get_class($this->parentModel),
+            'reorderParentId' => post('_reorder_parent_id'),
+            'reorderSortColumn' => $this->parentModel->getRelationSortOrderColumn($this->relation),
+        ];
+
+        return $this->reorderRelationMakePartial(
+            'relation_modal',
+                 $params + [
+                    'container' => $this->reorderRelationMakePartial('container', $params)
+                ]
+        );
+    }
+
+    /**
+     * Update the relation widget once the model gets closed.
+     * @return array
+     */
+    public function onRelationModalClose()
+    {
+        $this->reorderGetModel();
+
+        $this->controller->initRelation(
+            $this->parentModel->newQuery()->findOrFail(post('_reorder_parent_id')),
+            $this->relation
+        );
+
+        return [
+            '#' . $this->controller->relationGetId('view') => $this->controller->relationRenderView($this->relation),
+        ];
+    }
+
+    //
+    // Reordering
+    //
+
+    /**
+     * Sets all required model properties.
+     */
+    public function reorderGetModel()
+    {
+        $this->parentModel = $this->reorderGetParentModel();
+        $this->relation = post('_reorder_relation');
+
+        $relationModelClass = array_get($this->parentModel->getRelationDefinition($this->relation), 0);
+        if (!$relationModelClass) {
+            throw new ApplicationException(
+                sprintf('Could not determine model class for relation "%s"', $this->relation)
+            );
+        }
+
+        return $this->model = new $relationModelClass;
+    }
+
+    /**
+     * Returns all the records from the supplied model.
+     * @return Collection
+     */
+    protected function getRecords()
+    {
+        $query = $this->parentModel->newQuery();
+
+        $this->controller->reorderExtendRelationQuery($query);
+
+        return $query
+            ->with([$this->relation => function($q) {
+                $q->orderBy($this->parentModel->getRelationSortOrderColumn($this->relation), 'ASC');
+            }])
+            ->findOrFail(post('_reorder_parent_id'))
+            ->{$this->relation};
+    }
+
+    /**
+     * Extend the relation query used for finding reorder records. Extra conditions
+     * can be applied to the query, for example, $query->withTrashed();
+     * @param October\Rain\Database\Builder $query
+     * @return void
+     */
+    public function reorderExtendRelationQuery($query)
+    {
+    }
+
+    //
+    // Helpers
+    //
+
+    /**
+     * Prepares common partial variables.
+     */
+    protected function prepareVars()
+    {
+        $this->vars['reorderRecords'] = $this->getRecords();
+        $this->vars['reorderModel'] = $this->model;
+    }
+
+    /**
+     * Return a model instance based on the _reorder_model post value.
+     * @return Model
+     */
+    public function reorderGetParentModel()
+    {
+        $model = post('_reorder_model');
+
+        if (!class_exists($model)) {
+            throw new ApplicationException(
+                sprintf('Model class "%s" does not exist', $model)
+            );
+        }
+
+        return new $model;
+    }
+
+    /**
+     * Validate the supplied form model.
+     * @return void
+     */
+    protected function validateModel()
+    {
+        $modelTraits = class_uses($this->parentModel);
+
+        if (!isset($modelTraits[\October\Rain\Database\Traits\SortableRelation::class])) {
+            throw new ApplicationException(
+                sprintf('The "%s" model must implement the SortableRelation trait.', get_class($this->parentModel))
+            );
+        }
+    }
+
+    /**
+     * Returns the name attribute for a given $record. The attribute
+     * defined in the behaviour config is used here.
+     *
+     * @param Model $record
+     * @param       $relation
+     *
+     * @return string
+     */
+    public function reorderRelationGetRecordName(Model $record, $relation)
+    {
+        $attribute = array_get((array)$this->config, "$relation.nameFrom");
+        if ($attribute) {
+            return (string)$record->$attribute;
+        }
+
+        // Take a guess if no "nameFrom" config is set.
+        return (string)($record->name ?: $record->title);
+    }
+
+    /**
+     * Controller accessor for making partials within this behavior.
+     * @param string $partial
+     * @param array $params
+     * @return string Partial contents
+     */
+    public function reorderRelationMakePartial($partial, $params = [])
+    {
+        $contents = $this->controller->makePartial(
+            'reorder_' . $partial,
+            $params + $this->vars,
+            false
+        );
+
+        if (!$contents) {
+            $contents = $this->makePartial($partial, $params);
+        }
+
+        return $contents;
+    }
+}

--- a/modules/backend/behaviors/ReorderRelationController.php
+++ b/modules/backend/behaviors/ReorderRelationController.php
@@ -77,7 +77,7 @@ class ReorderRelationController extends ControllerBehavior
         }
 
         /** @var SortableRelation $instance */
-        $instance = $this->parentModel->newQuery()->find(post('_reorder_parent_id'));
+        $instance = $this->parentModel->newQuery()->find($this->postValue('_reorder_parent_id'));
         $instance->setRelationOrder($this->relation, $ids, $orders);
     }
 
@@ -96,7 +96,7 @@ class ReorderRelationController extends ControllerBehavior
         $params = [
             'reorderRelation' => $this->relation,
             'reorderModel' => get_class($this->parentModel),
-            'reorderParentId' => post('_reorder_parent_id'),
+            'reorderParentId' => $this->postValue('_reorder_parent_id'),
             'reorderSortColumn' => $this->parentModel->getRelationSortOrderColumn($this->relation),
         ];
 
@@ -117,7 +117,7 @@ class ReorderRelationController extends ControllerBehavior
         $this->reorderGetModel();
 
         $this->controller->initRelation(
-            $this->parentModel->newQuery()->findOrFail(post('_reorder_parent_id')),
+            $this->parentModel->newQuery()->findOrFail($this->postValue('_reorder_parent_id')),
             $this->relation
         );
 
@@ -136,7 +136,7 @@ class ReorderRelationController extends ControllerBehavior
     public function reorderGetModel()
     {
         $this->parentModel = $this->reorderGetParentModel();
-        $this->relation = post('_reorder_relation');
+        $this->relation = $this->postValue('_reorder_relation');
 
         $relationModelClass = array_get($this->parentModel->getRelationDefinition($this->relation), 0);
         if (!$relationModelClass) {
@@ -162,7 +162,7 @@ class ReorderRelationController extends ControllerBehavior
             ->with([$this->relation => function ($q) {
                 $q->orderBy($this->parentModel->getRelationSortOrderColumn($this->relation), 'ASC');
             }])
-            ->findOrFail(post('_reorder_parent_id'))
+            ->findOrFail($this->postValue('_reorder_parent_id'))
             ->{$this->relation};
     }
 
@@ -195,7 +195,7 @@ class ReorderRelationController extends ControllerBehavior
      */
     public function reorderGetParentModel()
     {
-        $model = post('_reorder_model');
+        $model = $this->postValue('_reorder_model');
 
         if (!class_exists($model)) {
             throw new ApplicationException(
@@ -260,5 +260,19 @@ class ReorderRelationController extends ControllerBehavior
         }
 
         return $contents;
+    }
+
+    /**
+     * Fetch a post value for the current relation.
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    private function postValue(string $key)
+    {
+        $relation = post('_reorder_relation_name');
+
+        return post($key. '.' . $relation);
     }
 }

--- a/modules/backend/behaviors/ReorderRelationController.php
+++ b/modules/backend/behaviors/ReorderRelationController.php
@@ -137,7 +137,7 @@ class ReorderRelationController extends ControllerBehavior
     public function reorderGetModel()
     {
         $this->parentModel = $this->reorderGetParentModel();
-        $this->relation = $this->postValue('_reorder_relation');
+        $this->relation = post('_reorder_relation_name');
 
         $relationModelClass = array_get($this->parentModel->getRelationDefinition($this->relation), 0);
         if (!$relationModelClass) {

--- a/modules/backend/behaviors/ReorderRelationController.php
+++ b/modules/backend/behaviors/ReorderRelationController.php
@@ -104,6 +104,7 @@ class ReorderRelationController extends ControllerBehavior
             'relation_modal',
             $params + [
                 'container' => $this->reorderRelationMakePartial('container', $params),
+                'requestParams' => $this->reorderRelationMakePartial('request_params', $params),
             ]
         );
     }

--- a/modules/backend/behaviors/ReorderRelationController.php
+++ b/modules/backend/behaviors/ReorderRelationController.php
@@ -50,7 +50,10 @@ class ReorderRelationController extends ControllerBehavior
         parent::__construct($controller);
 
         // The configuration is optional for this behavior.
-        $this->config = $this->makeConfig($controller->reorderRelationConfig, []);
+        $this->config = [];
+        if ($controller->reorderRelationConfig) {
+            $this->config = $this->makeConfig($controller->reorderRelationConfig, []);
+        }
     }
 
     //

--- a/modules/backend/behaviors/relationcontroller/partials/_button_reorder.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_reorder.htm
@@ -6,7 +6,6 @@
         data-request-data="
             _reorder_parent_id[<?= e($relationName) ?>]: '<?= e($this->vars['formModel']->id) ?>',
             _reorder_model[<?= e($relationName) ?>]: '<?= e(addslashes(get_class($this->vars['formModel']))) ?>',
-            _reorder_relation[<?= e($relationName) ?>]: '<?= e($relationName) ?>',
             _reorder_relation_name: '<?= e($relationName) ?>'
         "
         href="javascript:;"

--- a/modules/backend/behaviors/relationcontroller/partials/_button_reorder.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_reorder.htm
@@ -1,11 +1,13 @@
+<?php $relationName = $this->vars['relationField']; ?>
 <a
         data-control="popup"
         data-size="huge"
         data-handler="onRelationButtonReorder"
         data-request-data="
-            _reorder_parent_id: '<?= e($this->vars['formModel']->id) ?>',
-            _reorder_model: '<?= e(addslashes(get_class($this->vars['formModel']))) ?>',
-            _reorder_relation: '<?= e($this->vars['relationField']) ?>'
+            _reorder_parent_id[<?= e($relationName) ?>]: '<?= e($this->vars['formModel']->id) ?>',
+            _reorder_model[<?= e($relationName) ?>]: '<?= e(addslashes(get_class($this->vars['formModel']))) ?>',
+            _reorder_relation[<?= e($relationName) ?>]: '<?= e($relationName) ?>',
+            _reorder_relation_name: '<?= e($relationName) ?>'
         "
         href="javascript:;"
         class="btn btn-sm btn-secondary oc-icon-reorder">

--- a/modules/backend/behaviors/relationcontroller/partials/_button_reorder.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_button_reorder.htm
@@ -1,0 +1,13 @@
+<a
+        data-control="popup"
+        data-size="huge"
+        data-handler="onRelationButtonReorder"
+        data-request-data="
+            _reorder_parent_id: '<?= e($this->vars['formModel']->id) ?>',
+            _reorder_model: '<?= e(addslashes(get_class($this->vars['formModel']))) ?>',
+            _reorder_relation: '<?= e($this->vars['relationField']) ?>'
+        "
+        href="javascript:;"
+        class="btn btn-sm btn-secondary oc-icon-reorder">
+    <?= e(trans('backend::lang.reorder.default_title')) ?>
+</a>

--- a/modules/backend/behaviors/reordercontroller/assets/js/october.reorder.js
+++ b/modules/backend/behaviors/reordercontroller/assets/js/october.reorder.js
@@ -10,11 +10,13 @@
     var ReorderBehavior = function() {
 
         this.sortMode = null
+        this.context = 'default'
 
         this.simpleSortOrders = []
 
-        this.initSorting = function (mode) {
+        this.initSorting = function (mode, context) {
             this.sortMode = mode
+            this.context = context
 
             if (mode == 'simple') {
                 this.initSortingSimple()
@@ -34,7 +36,9 @@
                 postData = this.getNestedMoveData(sortData)
             }
 
-            $('#reorderTreeList').request('onReorder', {
+            var handler = this.context === 'relation' ? 'onReorderRelation' : 'onReorder'
+
+            $('#reorderTreeList').request(handler, {
                 data: postData
             })
         }

--- a/modules/backend/behaviors/reordercontroller/assets/js/october.reorder.js
+++ b/modules/backend/behaviors/reordercontroller/assets/js/october.reorder.js
@@ -6,7 +6,6 @@
  * - Nested sorting: Post back source and target nodes IDs and the move positioning.
  */
 +function ($) { "use strict";
-
     var ReorderBehavior = function() {
 
         this.sortMode = null

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_container.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_container.htm
@@ -2,7 +2,6 @@
 <?= Form::open() ?>
 
     <input type="hidden" name="_reorder_relation_name" value="<?= e($reorderRelation) ?>">
-    <input type="hidden" name="_reorder_relation[<?= e($reorderRelation) ?>]" value="<?= e($reorderRelation) ?>">
     <input type="hidden" name="_reorder_model[<?= e($reorderRelation) ?>]" value="<?= e($reorderModel) ?>">
     <input type="hidden" name="_reorder_parent_id[<?= e($reorderRelation) ?>]" value="<?= e($reorderParentId) ?>">
 

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_container.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_container.htm
@@ -1,0 +1,30 @@
+<!-- Reorder List -->
+<?= Form::open() ?>
+
+    <input type="hidden" name="_reorder_relation" value="<?= e($reorderRelation) ?>">
+    <input type="hidden" name="_reorder_model" value="<?= e($reorderModel) ?>">
+    <input type="hidden" name="_reorder_parent_id" value="<?= e($reorderParentId) ?>">
+
+    <div
+        id="reorderTreeList"
+        class="control-treelist"
+        data-control="treelist"
+        data-handle="> li > .record > a.move"
+        data-stripe-load-indicator>
+        <?php if ($reorderRecords): ?>
+            <ol id="reorderRecords">
+                <?= $this->reorderRelationMakePartial('records', [
+                    'records' => $reorderRecords,
+                    'sortColumn' => $reorderSortColumn,
+                    'relation' => $reorderRelation
+                ]) ?>
+            </ol>
+        <?php else: ?>
+            <p><?= Lang::get('backend::lang.reorder.no_records') ?></p>
+        <?php endif ?>
+    </div>
+<?= Form::close() ?>
+
+<script>
+    $.oc.reorderBehavior.initSorting('simple', 'relation')
+</script>

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_container.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_container.htm
@@ -1,9 +1,10 @@
 <!-- Reorder List -->
 <?= Form::open() ?>
 
-    <input type="hidden" name="_reorder_relation" value="<?= e($reorderRelation) ?>">
-    <input type="hidden" name="_reorder_model" value="<?= e($reorderModel) ?>">
-    <input type="hidden" name="_reorder_parent_id" value="<?= e($reorderParentId) ?>">
+    <input type="hidden" name="_reorder_relation_name" value="<?= e($reorderRelation) ?>">
+    <input type="hidden" name="_reorder_relation[<?= e($reorderRelation) ?>]" value="<?= e($reorderRelation) ?>">
+    <input type="hidden" name="_reorder_model[<?= e($reorderRelation) ?>]" value="<?= e($reorderModel) ?>">
+    <input type="hidden" name="_reorder_parent_id[<?= e($reorderRelation) ?>]" value="<?= e($reorderParentId) ?>">
 
     <div
         id="reorderTreeList"

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_records.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_records.htm
@@ -1,0 +1,13 @@
+<?php foreach ($records as $record): ?>
+
+    <li data-record-id="<?= $record->getKey() ?>"
+        data-record-sort-order="<?= $record->pivot->{$sortColumn} ?>"
+    >
+        <div class="record">
+            <a href="javascript:;" class="move"></a>
+            <span><?= e($this->reorderRelationGetRecordName($record, $relation)) ?></span>
+            <input name="record_ids[]" type="hidden" value="<?= $record->getKey() ?>" />
+        </div>
+    </li>
+
+<?php endforeach ?>

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_relation_modal.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_relation_modal.htm
@@ -1,0 +1,25 @@
+<div class="modal-header">
+    <button type="button" class="close" data-dismiss="popup">&times;</button>
+    <h4 class="modal-title">
+        <?= e(trans('backend::lang.reorder.relation')) ?>
+    </h4>
+</div>
+
+<div class="modal-body">
+    <?= $container ?>
+</div>
+
+<div class="modal-footer">
+    <button
+            type="button"
+            class="btn btn-default"
+            data-dismiss="popup"
+            data-request="onRelationModalClose"
+            data-request-data="
+                _reorder_parent_id: '<?= e($reorderParentId) ?>',
+                _reorder_model: '<?= e(addslashes($reorderModel)) ?>',
+                _reorder_relation: '<?= e($reorderRelation) ?>'
+            ">
+        <?= e(trans('backend::lang.relation.close')) ?>
+    </button>
+</div>

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_relation_modal.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_relation_modal.htm
@@ -1,5 +1,12 @@
 <div class="modal-header">
-    <button type="button" class="close" data-dismiss="popup">&times;</button>
+    <button
+        type="button"
+        class="close"
+        data-dismiss="popup"
+        <?= $requestParams ?>
+    >
+        &times;
+    </button>
     <h4 class="modal-title">
         <?= e(trans('backend::lang.reorder.relation')) ?>
     </h4>
@@ -11,15 +18,11 @@
 
 <div class="modal-footer">
     <button
-            type="button"
-            class="btn btn-default"
-            data-dismiss="popup"
-            data-request="onRelationModalClose"
-            data-request-data="
-                _reorder_parent_id: '<?= e($reorderParentId) ?>',
-                _reorder_model: '<?= e(addslashes($reorderModel)) ?>',
-                _reorder_relation: '<?= e($reorderRelation) ?>'
-            ">
+        type="button"
+        class="btn btn-default"
+        data-dismiss="popup"
+        <?= $requestParams ?>
+    >
         <?= e(trans('backend::lang.relation.close')) ?>
     </button>
 </div>

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_request_params.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_request_params.htm
@@ -1,7 +1,6 @@
 data-request="onRelationModalClose"
 data-request-data="
     _reorder_relation_name: '<?= e($reorderRelation) ?>',
-    _reorder_relation[<?= e($reorderRelation) ?>]: '<?= e($reorderRelation) ?>',
     _reorder_model[<?= e($reorderRelation) ?>]: '<?= e(addslashes($reorderModel)) ?>',
     _reorder_parent_id[<?= e($reorderRelation) ?>]: '<?= e($reorderParentId) ?>',
 "

--- a/modules/backend/behaviors/reorderrelationcontroller/partials/_request_params.htm
+++ b/modules/backend/behaviors/reorderrelationcontroller/partials/_request_params.htm
@@ -1,0 +1,7 @@
+data-request="onRelationModalClose"
+data-request-data="
+    _reorder_relation_name: '<?= e($reorderRelation) ?>',
+    _reorder_relation[<?= e($reorderRelation) ?>]: '<?= e($reorderRelation) ?>',
+    _reorder_model[<?= e($reorderRelation) ?>]: '<?= e(addslashes($reorderModel)) ?>',
+    _reorder_parent_id[<?= e($reorderRelation) ?>]: '<?= e($reorderParentId) ?>',
+"

--- a/modules/backend/lang/de/lang.php
+++ b/modules/backend/lang/de/lang.php
@@ -295,7 +295,8 @@ return [
     ],
     'reorder' => [
         'default_title' => 'Einträge sortieren',
-        'no_records' => 'Es gibt keine Einträge zum sortieren.'
+        'no_records' => 'Es gibt keine Einträge zum sortieren.',
+        'relation' => 'Sortiere verwandte Einträge',
     ],
     'model' => [
         'name' => "Model",

--- a/modules/backend/lang/de/lang.php
+++ b/modules/backend/lang/de/lang.php
@@ -171,6 +171,7 @@ return [
         'refresh' => 'Erneuern',
         'updating' => 'Aktualisiere...',
         'loading' => 'Laden...',
+        'sort_handle' => 'Sortierung',
         'setup_title' => 'Listen Setup',
         'setup_help' => 'Benutzen Sie Checkboxen, um Spalten auszuwählen, welche Sie in den Listen sehen möchten. Sie können die Position der Spalten ändern, indem Sie diese hinauf oder hinunter ziehen.',
         'records_per_page' => 'Aufzeichnungen pro Seite',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -351,6 +351,7 @@ return [
     'reorder' => [
         'default_title' => 'Reorder records',
         'no_records' => 'There are no records available to sort.',
+        'relation' => 'Sort related entries',
     ],
     'model' => [
         'name' => 'Model',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -216,6 +216,7 @@ return [
         'refresh' => 'Refresh',
         'updating' => 'Updating...',
         'loading' => 'Loading...',
+        'sort_handle' => 'Sort handle',
         'setup_title' => 'List setup',
         'setup_help' => 'Use checkboxes to select columns you want to see in the list. You can change position of columns by dragging them up or down.',
         'records_per_page' => 'Records per page',

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -261,6 +261,7 @@ class Lists extends WidgetBase
         if ($this->sortable) {
             $this->addJs('/modules/system/assets/ui/js/list.sortable.js', 'core');
             $this->showSorting = false;
+            $this->showTree = false;
 
             if ($this->reorderRelation) {
                 /** @var SortableRelation $modelInstance */

--- a/modules/backend/widgets/lists/assets/js/october.list.js
+++ b/modules/backend/widgets/lists/assets/js/october.list.js
@@ -102,8 +102,14 @@
         var relation = this.$el.data('sortableRelation')
         var handler = relation ? 'onReorderRelation' : 'onReorder'
 
+        var recordIds = []
+        this.$el.find('[data-record-id]').each(function (index, el) {
+            recordIds.push(el.dataset.recordId)
+        }.bind(this))
+
         this.$el.request(handler, {
-            data: { sort_orders: this.sortOrders, _reorder_relation_name: relation }
+            data: { sort_orders: this.sortOrders, record_ids: recordIds, _reorder_relation_name: relation },
+            loading: $.oc.stripeLoadIndicator,
         })
     }
 

--- a/modules/backend/widgets/lists/assets/js/october.list.js
+++ b/modules/backend/widgets/lists/assets/js/october.list.js
@@ -11,6 +11,7 @@
         var $el = this.$el = $(element);
 
         this.options = options || {};
+        this.sortOrders = []
 
         var scrollClassContainer = options.scrollClassContainer !== undefined
             ? options.scrollClassContainer
@@ -21,6 +22,17 @@
             scrollSelector: 'thead',
             dragSelector: 'thead'
         })
+
+        if (element.dataset.hasOwnProperty('sortable')) {
+            this.$el.find('.control-list-tbody').listSortable({
+                handle: '.drag-handle'
+            })
+            this.$el.on('dragged.list.sorted', $.proxy(this.processReorder, this))
+
+            this.$el.find('[data-record-sort-order]').each(function (index, el) {
+                this.sortOrders.push(el.dataset.recordSortOrder)
+            }.bind(this))
+        }
 
         this.update()
     }
@@ -84,6 +96,15 @@
     ListWidget.prototype.toggleChecked = function(el) {
         var $checkbox = $('.list-checkbox input[type="checkbox"]', $(el).closest('tr'))
         $checkbox.prop('checked', !$checkbox.is(':checked')).trigger('change')
+    }
+
+    ListWidget.prototype.processReorder = function() {
+        var relation = this.$el.data('sortableRelation')
+        var handler = relation ? 'onReorderRelation' : 'onReorder'
+
+        this.$el.request(handler, {
+            data: { sort_orders: this.sortOrders, _reorder_relation_name: relation }
+        })
     }
 
     // LIST WIDGET PLUGIN DEFINITION

--- a/modules/backend/widgets/lists/partials/_list.htm
+++ b/modules/backend/widgets/lists/partials/_list.htm
@@ -1,9 +1,19 @@
-<div class="control-list list-scrollable" data-control="listwidget">
+<?php if ($sortable): ?>
+    <input type="hidden" name="_reorder_relation[<?= $reorderRelation ?>]" value="<?= e($reorderRelation) ?>">
+    <input type="hidden" name="_reorder_model[<?= $reorderRelation ?>]" value="<?= e($reorderModel) ?>">
+    <input type="hidden" name="_reorder_parent_id[<?= $reorderRelation ?>]" value="<?= e($reorderParentId) ?>">
+<?php endif; ?>
+
+<div class="control-list list-scrollable"
+     data-control="listwidget"
+     <?= $sortable ? 'data-sortable' : '' ?>
+     <?= $reorderRelation ? 'data-sortable-relation="'. e($reorderRelation) .'"' : '' ?>
+>
     <table class="table data" data-control="rowlink">
         <thead>
             <?= $this->makePartial('list_head_row') ?>
         </thead>
-        <tbody>
+        <tbody class="control-list-tbody">
             <?php if (count($records)): ?>
                 <?= $this->makePartial('list_body_rows') ?>
             <?php else: ?>

--- a/modules/backend/widgets/lists/partials/_list.htm
+++ b/modules/backend/widgets/lists/partials/_list.htm
@@ -1,4 +1,4 @@
-<?php if ($sortable): ?>
+<?php if ($sortable && $reorderRelation): ?>
     <input type="hidden" name="_reorder_relation[<?= $reorderRelation ?>]" value="<?= e($reorderRelation) ?>">
     <input type="hidden" name="_reorder_model[<?= $reorderRelation ?>]" value="<?= e($reorderModel) ?>">
     <input type="hidden" name="_reorder_parent_id[<?= $reorderRelation ?>]" value="<?= e($reorderParentId) ?>">

--- a/modules/backend/widgets/lists/partials/_list.htm
+++ b/modules/backend/widgets/lists/partials/_list.htm
@@ -1,5 +1,4 @@
 <?php if ($sortable && $reorderRelation): ?>
-    <input type="hidden" name="_reorder_relation[<?= $reorderRelation ?>]" value="<?= e($reorderRelation) ?>">
     <input type="hidden" name="_reorder_model[<?= $reorderRelation ?>]" value="<?= e($reorderModel) ?>">
     <input type="hidden" name="_reorder_parent_id[<?= $reorderRelation ?>]" value="<?= e($reorderParentId) ?>">
 <?php endif; ?>

--- a/modules/backend/widgets/lists/partials/_list_body_row.htm
+++ b/modules/backend/widgets/lists/partials/_list_body_row.htm
@@ -3,7 +3,7 @@
     $childRecords = $showTree ? $record->getChildren() : null;
     $treeLevelClass = $showTree ? 'list-tree-level-'.$treeLevel : '';
 ?>
-<tr class="<?= $treeLevelClass ?> <?= $this->getRowClass($record) ?>">
+<tr class="<?= $treeLevelClass ?> <?= $this->getRowClass($record) ?>" <?= $sortable ? 'draggable="true"' : '' ?>>
     <?php if ($showCheckboxes): ?>
         <?= $this->makePartial('list_body_checkbox', ['record' => $record]) ?>
     <?php endif ?>

--- a/modules/backend/widgets/lists/partials/_list_sort_handle.htm
+++ b/modules/backend/widgets/lists/partials/_list_sort_handle.htm
@@ -1,0 +1,4 @@
+<div class="drag-handle" style="cursor: move" data-handle>
+    <input name="record_ids[]" data-record-sort-order="<?= e($this->getRecordSortOrder($record, $this->vars['relationField'])) ?>" type="hidden" value="<?= e($record->getKey()) ?>">
+    ☰
+</div>

--- a/modules/backend/widgets/lists/partials/_list_sort_handle.htm
+++ b/modules/backend/widgets/lists/partials/_list_sort_handle.htm
@@ -1,4 +1,7 @@
-<div class="drag-handle" style="cursor: move" data-handle>
-    <input name="record_ids[]" data-record-sort-order="<?= e($this->getRecordSortOrder($record, $this->vars['relationField'])) ?>" type="hidden" value="<?= e($record->getKey()) ?>">
+<div class="drag-handle"
+     data-handle
+     data-record-id="<?= e($record->getKey()) ?>"
+     data-record-sort-order="<?= e($this->getRecordSortOrder($record, $this->vars['relationField'] ?? '')) ?>"
+>
     ☰
 </div>

--- a/modules/system/assets/ui/js/list.sortable.js
+++ b/modules/system/assets/ui/js/list.sortable.js
@@ -199,7 +199,7 @@
     }
 
     ListSortable.prototype.createPlaceholder = function(element, ev) {
-        var placeholder = document.createElement(element.tagName),
+        var placeholder = document.createElement('li'),
             placement = this.getPlaceholderPlacement(element, ev)
 
         this.removePlaceholders()
@@ -315,6 +315,11 @@
         ev.originalEvent.dataTransfer.setData('listsortable/elementid', this.getElementSortableId(ev.target))
         ev.originalEvent.dataTransfer.setData(this.listSortableId, this.listSortableId)
 
+        // Make sure the sort placeholder is never cut off by any hidden overflow.
+        var container = $(ev.target).closest('[data-sortable]')
+        this.originalOverflow = container.css('overflow')
+        container.css({overflow: 'visible'})
+
         // The mousemove handler is used to remove the placeholder
         // when the drag is canceled with Escape button. We can't use
         // the dragend for removing the placeholders because dragend
@@ -395,9 +400,11 @@
 
     ListSortable.prototype.onDragEnd = function(ev) {
         $(document).off('dragover', this.proxy(this.onDocumentDragOver))
-        var list = $(ev.target).closest('[data-sortable]')
-        if (list) {
-            list.trigger('dragged.list.sorted')
+
+        var container = $(ev.target).closest('[data-sortable]')
+        if (container) {
+            container.trigger('dragged.list.sorted')
+            container.css({overflow: this.originalOverflow})
         }
     }
 

--- a/modules/system/assets/ui/less/list.base.less
+++ b/modules/system/assets/ui/less/list.base.less
@@ -56,6 +56,22 @@ th {
     .table {
         background-color: @body-bg;
     }
+
+    .list-sortable-placeholder {
+        display: block;
+        position: relative;
+        height: 0;
+        &:before {
+            display: block;
+            position: absolute;
+            .icon(@chevron-right);
+            font-size: 15px;
+            color: #d35714;
+            left: 0;
+            top: -9px;
+            z-index: 2000;
+        }
+    }
 }
 
 

--- a/modules/system/assets/ui/less/list.base.less
+++ b/modules/system/assets/ui/less/list.base.less
@@ -72,6 +72,10 @@ th {
             z-index: 2000;
         }
     }
+
+    .drag-handle {
+        cursor: move;
+    }
 }
 
 

--- a/modules/system/assets/ui/less/list.less
+++ b/modules/system/assets/ui/less/list.less
@@ -128,7 +128,7 @@ table.table.data {
             }
         }
 
-        // Prevent a border-top the first row entry if the placeholder
+        // Prevent a border-top on the first row entry if the placeholder
         // is placed right above it at the start of a table.
         .list-sortable-placeholder:first-child + tr td {
             border-top: 0;

--- a/modules/system/assets/ui/less/list.less
+++ b/modules/system/assets/ui/less/list.less
@@ -89,7 +89,7 @@ table.table.data {
     }
 
     tbody {
-        tr:nth-child(even) {
+        tr:nth-of-type(even) {
             td, th { background-color: @color-list-accent; }
         }
         td, th {
@@ -126,6 +126,12 @@ table.table.data {
                     position: relative;
                 }
             }
+        }
+
+        // Prevent a border-top the first row entry if the placeholder
+        // is placed right above it at the start of a table.
+        .list-sortable-placeholder:first-child + tr td {
+            border-top: 0;
         }
 
         tr:first-child {
@@ -560,7 +566,7 @@ table.table.data {
             }
 
             tbody {
-                tr:nth-child(even) {
+                tr:nth-of-type(even) {
                     td, th { background-color: transparent; }
                 }
             }

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4308,6 +4308,8 @@ th {text-align:left}
 .table >thead:first-child >tr:first-child >td {border-top:0}
 .table >tbody + tbody {border-top:2px solid #ddd}
 .table .table {background-color:#f9f9f9}
+.table .list-sortable-placeholder {display:block;position:relative;height:0}
+.table .list-sortable-placeholder:before {display:block;position:absolute;font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f054";font-size:15px;color:#d35714;left:0;top:-9px;z-index:2000}
 .table-condensed >thead >tr >th,
 .table-condensed >tbody >tr >th,
 .table-condensed >tfoot >tr >th,

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -4310,6 +4310,7 @@ th {text-align:left}
 .table .table {background-color:#f9f9f9}
 .table .list-sortable-placeholder {display:block;position:relative;height:0}
 .table .list-sortable-placeholder:before {display:block;position:absolute;font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;content:"\f054";font-size:15px;color:#d35714;left:0;top:-9px;z-index:2000}
+.table .drag-handle {cursor:move}
 .table-condensed >thead >tr >th,
 .table-condensed >tbody >tr >th,
 .table-condensed >tfoot >tr >th,
@@ -4451,8 +4452,8 @@ table.table.data thead th.active >a:after {color:#c63e26;opacity:1 !important;fi
 table.table.data thead tr th:first-child {padding-left:10px}
 table.table.data thead tr th:last-child a {padding-right:25px}
 table.table.data thead .list-checkbox .custom-checkbox {top:-16px}
-table.table.data tbody tr:nth-child(even) td,
-table.table.data tbody tr:nth-child(even) th {background-color:#ecf0f1}
+table.table.data tbody tr:nth-of-type(even) td,
+table.table.data tbody tr:nth-of-type(even) th {background-color:#ecf0f1}
 table.table.data tbody td,
 table.table.data tbody th {padding:12px 15px;color:#666;border-top:2px solid white}
 table.table.data tbody td a:not(.btn),
@@ -4465,6 +4466,7 @@ table.table.data tbody td div.progress div.bar,
 table.table.data tbody th div.progress div.bar {position:absolute;left:-15px;top:-11px;bottom:-11px;background:#0181b9;opacity:0.3;filter:alpha(opacity=30)}
 table.table.data tbody td div.progress a,
 table.table.data tbody th div.progress a {position:relative}
+table.table.data tbody .list-sortable-placeholder:first-child + tr td {border-top:0}
 table.table.data tbody tr:first-child th,
 table.table.data tbody tr:first-child td {border-top-width:0}
 table.table.data tbody tr:last-child th,
@@ -4610,8 +4612,8 @@ table.table.data tr.list-tree-level-10 td.list-cell-index-1 {padding-left:115px}
 .report-widget .table-container {margin:-15px}
 .report-widget .table-container table.table.data {margin-bottom:0}
 .report-widget .table-container table.table.data thead tr th {border-top:none !important}
-.report-widget .table-container table.table.data tbody tr:nth-child(even) td,
-.report-widget .table-container table.table.data tbody tr:nth-child(even) th {background-color:transparent}
+.report-widget .table-container table.table.data tbody tr:nth-of-type(even) td,
+.report-widget .table-container table.table.data tbody tr:nth-of-type(even) th {background-color:transparent}
 .list-scrollable-container {touch-action:auto;position:relative}
 .list-scrollable-container:after,
 .list-scrollable-container:before {display:none;position:absolute;top:50%;margin-top:-7px;height:9px;font-size:10px;color:#666}


### PR DESCRIPTION
It is Hacktoberfest once again, so what better time to propose some new features for my favourite CMS! :hugs: 

The wish for sortable relations has been around for some years (#3010). The current solutions are rather hacks than solutions and not in line with October's UI. This PR proposes a possible solution to this problem by adding a `ReorderRelationController`:

![sortable](https://user-images.githubusercontent.com/8600029/95228672-ec73d080-07ff-11eb-952d-91aa17c20b12.gif)

With this PR, the following steps are required to implement a sortable relation:

1. Use [the new `SortableRelation` trait](https://github.com/octobercms/library/pull/526) in your parent model
1. Define what relations are sortable in the `$sortableRelations` property
1. Implement the new `ReorderRelationController` in your Controller
1. Add the new `reorder` toolbar button to your relation widget config

That's it!

I have added an example implementation to the test plugin (Posts -> Edit Post -> Galleries):
https://github.com/OFFLINE-GmbH/test-plugin/commit/f8eb2238dca0642dce38a6882d215ac7e46e3a74

You can optionally define a `public $reorderRelationConfig = 'config_reorder_relation.yaml';` property on your controller to define where the name attributes for the treelist control should be taken from:

```yaml
# ===================================
#  Relation Relation Behavior Config
# ===================================

galleries:
    nameFrom: title

other_relation:
    nameFrom: name
```

If nothing is configured, the control defaults to the `name` then `title` attributes.

Let me know what you think!

Resolves #3010