### PR TITLE
Purge orphaned mail templates/layouts/partials. 

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -61,13 +61,6 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerValidator();
         $this->registerGlobalViewVars();
 
-        Event::listen('system.plugins.afterUpdate', function ($action) {
-            if (in_array($action, ['disable', 'remove'])) {
-                // purge orphaned mail templates
-                MailTemplate::syncAll();
-            }
-        });
-
         /*
          * Register other module providers
          */
@@ -365,6 +358,15 @@ class ServiceProvider extends ModuleServiceProvider
             $plainOnly = $view === null; // When "plain-text only" email is sent, $view is null, this sets the flag appropriately
             return !MailManager::instance()->$method($message, $raw ?: $view ?: $plain, $data, $plainOnly);
         });
+
+        Event::listen('system.plugins.afterDisable', function ($pluginCode) {
+            MailTemplate::syncAll();
+        });
+
+        Event::listen('system.plugins.afterRemove', function ($pluginCode) {
+            MailTemplate::syncAll();
+        });
+
     }
 
     /*

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -360,9 +360,7 @@ class ServiceProvider extends ModuleServiceProvider
         });
 
         $mailSync = function ($pluginCode) {
-            if ($this->app->hasDatabase()) {
-                MailTemplate::syncAll();
-            }
+            MailTemplate::syncAll();
         };
         Event::listen('system.plugins.afterDisable', $mailSync);
         Event::listen('system.plugins.afterRemove', $mailSync);

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -24,6 +24,7 @@ use System\Twig\Extension as TwigExtension;
 use System\Twig\SecurityPolicy as TwigSecurityPolicy;
 use System\Models\EventLog;
 use System\Models\MailSetting;
+use System\Models\MailTemplate;
 use System\Classes\CombineAssets;
 use Backend\Classes\WidgetManager;
 use October\Rain\Support\ModuleServiceProvider;
@@ -59,6 +60,13 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerAssetBundles();
         $this->registerValidator();
         $this->registerGlobalViewVars();
+
+        Event::listen('system.plugins.afterUpdate', function ($action) {
+            if (in_array($action, ['disable', 'remove'])) {
+                // purge orphaned mail templates
+                MailTemplate::syncAll();
+            }
+        });
 
         /*
          * Register other module providers

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -360,7 +360,7 @@ class ServiceProvider extends ModuleServiceProvider
         });
 
         $mailSync = function ($pluginCode) {
-            if (!$this->app->runningUnitTests()) {
+            if ($this->app->hasDatabase()) {
                 MailTemplate::syncAll();
             }
         };

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -366,7 +366,6 @@ class ServiceProvider extends ModuleServiceProvider
         Event::listen('system.plugins.afterRemove', function ($pluginCode) {
             MailTemplate::syncAll();
         });
-
     }
 
     /*

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -359,13 +359,13 @@ class ServiceProvider extends ModuleServiceProvider
             return !MailManager::instance()->$method($message, $raw ?: $view ?: $plain, $data, $plainOnly);
         });
 
-        Event::listen('system.plugins.afterDisable', function ($pluginCode) {
-            MailTemplate::syncAll();
-        });
-
-        Event::listen('system.plugins.afterRemove', function ($pluginCode) {
-            MailTemplate::syncAll();
-        });
+        $mailSync = function ($pluginCode) {
+            if (!$this->app->runningUnitTests()) {
+                MailTemplate::syncAll();
+            }
+        };
+        Event::listen('system.plugins.afterDisable', $mailSync);
+        Event::listen('system.plugins.afterRemove', $mailSync);
     }
 
     /*

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -632,6 +632,18 @@ class PluginManager
         if ($pluginObj = $this->findByIdentifier($code)) {
             $pluginObj->disabled = true;
         }
+
+        /**
+         * @event system.plugins.afterDisable
+         * Provides an opportunity to take actions after a plugin has been disabled.
+         *
+         * Example usage:
+         *
+         *     Event::listen('system.plugins.afterDisable', function ((String) $pluginCode) {
+         *         trace_log('Plugin ' . $pluginCode . ' has been disabled.');
+         *     });
+         *
+         */
         Event::fire('system.plugins.afterDisable', [$code]);
 
         return true;
@@ -663,6 +675,18 @@ class PluginManager
         if ($pluginObj = $this->findByIdentifier($code)) {
             $pluginObj->disabled = false;
         }
+
+        /**
+         * @event system.plugins.afterEnable
+         * Provides an opportunity to take actions after a plugin has been enabled.
+         *
+         * Example usage:
+         *
+         *     Event::listen('system.plugins.afterEnable', function ((String) $pluginCode) {
+         *         trace_log('Plugin ' . $pluginCode . ' has been enabled.');
+         *     });
+         *
+         */
         Event::fire('system.plugins.afterEnable', [$code]);
 
         return true;
@@ -863,6 +887,17 @@ class PluginManager
         $code = $this->normalizeIdentifier($id);
         unset($this->plugins[$code]);
 
+        /**
+         * @event system.plugins.afterRemove
+         * Provides an opportunity to take actions after a plugin has been removed.
+         *
+         * Example usage:
+         *
+         *     Event::listen('system.plugins.afterRemove', function ((String) $pluginCode) {
+         *         trace_log('Plugin ' . $pluginCode . ' has been removed.');
+         *     });
+         *
+         */
         Event::fire('system.plugins.afterRemove', [$code]);
     }
 

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -633,19 +633,6 @@ class PluginManager
             $pluginObj->disabled = true;
         }
 
-        /**
-         * @event system.plugins.afterDisable
-         * Provides an opportunity to take actions after a plugin has been disabled.
-         *
-         * Example usage:
-         *
-         *     Event::listen('system.plugins.afterDisable', function ((String) $pluginCode) {
-         *         trace_log('Plugin ' . $pluginCode . ' has been disabled.');
-         *     });
-         *
-         */
-        Event::fire('system.plugins.afterDisable', [$code]);
-
         return true;
     }
 
@@ -675,19 +662,6 @@ class PluginManager
         if ($pluginObj = $this->findByIdentifier($code)) {
             $pluginObj->disabled = false;
         }
-
-        /**
-         * @event system.plugins.afterEnable
-         * Provides an opportunity to take actions after a plugin has been enabled.
-         *
-         * Example usage:
-         *
-         *     Event::listen('system.plugins.afterEnable', function ((String) $pluginCode) {
-         *         trace_log('Plugin ' . $pluginCode . ' has been enabled.');
-         *     });
-         *
-         */
-        Event::fire('system.plugins.afterEnable', [$code]);
 
         return true;
     }

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -857,7 +857,7 @@ class PluginManager
         }
 
         // actually remove the plugin from our internal container
-        unset($this->plugins[$id]);
+        unset($this->plugins[ $this->normalizeIdentifier($id) ]);
     }
 
     /**

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -844,21 +844,20 @@ class PluginManager
      */
     public function deletePlugin($id)
     {
-        $code = $this->normalizeIdentifier($id);
-
         /*
          * Rollback plugin
          */
-        UpdateManager::instance()->rollbackPlugin($code);
+        UpdateManager::instance()->rollbackPlugin($id);
 
         /*
          * Delete from file system
          */
-        if ($pluginPath = self::instance()->getPluginPath($code)) {
+        if ($pluginPath = self::instance()->getPluginPath($id)) {
             File::deleteDirectory($pluginPath);
         }
 
         // actually remove the plugin from our internal container
+        $code = $this->normalizeIdentifier($id);
         unset($this->plugins[$code]);
     }
 

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -867,7 +867,7 @@ class PluginManager
          *
          * Example usage:
          *
-         *     Event::listen('system.plugins.afterRemove', function ((String) $pluginCode) {
+         *     Event::listen('system.plugins.afterRemove', function ((string) $pluginCode) {
          *         trace_log('Plugin ' . $pluginCode . ' has been removed.');
          *     });
          *

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -855,6 +855,9 @@ class PluginManager
         if ($pluginPath = self::instance()->getPluginPath($id)) {
             File::deleteDirectory($pluginPath);
         }
+
+        // actually remove the plugin from our internal container
+        unset($this->plugins[$id]);
     }
 
     /**

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -4,6 +4,7 @@ use Db;
 use App;
 use Str;
 use Log;
+use Event;
 use File;
 use Lang;
 use View;

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -631,6 +631,7 @@ class PluginManager
         if ($pluginObj = $this->findByIdentifier($code)) {
             $pluginObj->disabled = true;
         }
+        Event::fire('system.plugins.afterDisable', [$code]);
 
         return true;
     }
@@ -661,6 +662,7 @@ class PluginManager
         if ($pluginObj = $this->findByIdentifier($code)) {
             $pluginObj->disabled = false;
         }
+        Event::fire('system.plugins.afterEnable', [$code]);
 
         return true;
     }
@@ -859,6 +861,8 @@ class PluginManager
         // Remove the plugin from the internal container
         $code = $this->normalizeIdentifier($id);
         unset($this->plugins[$code]);
+
+        Event::fire('system.plugins.afterRemove', [$code]);
     }
 
     /**

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -844,20 +844,22 @@ class PluginManager
      */
     public function deletePlugin($id)
     {
+        $code = $this->normalizeIdentifier($id);
+
         /*
          * Rollback plugin
          */
-        UpdateManager::instance()->rollbackPlugin($id);
+        UpdateManager::instance()->rollbackPlugin($code);
 
         /*
          * Delete from file system
          */
-        if ($pluginPath = self::instance()->getPluginPath($id)) {
+        if ($pluginPath = self::instance()->getPluginPath($code)) {
             File::deleteDirectory($pluginPath);
         }
 
         // actually remove the plugin from our internal container
-        unset($this->plugins[ $this->normalizeIdentifier($id) ]);
+        unset($this->plugins[$code]);
     }
 
     /**

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -856,7 +856,7 @@ class PluginManager
             File::deleteDirectory($pluginPath);
         }
 
-        // actually remove the plugin from our internal container
+        // Remove the plugin from the internal container
         $code = $this->normalizeIdentifier($id);
         unset($this->plugins[$code]);
     }

--- a/modules/system/console/PluginDisable.php
+++ b/modules/system/console/PluginDisable.php
@@ -41,7 +41,7 @@ class PluginDisable extends Command
         }
 
         // Disable this plugin
-        $pluginManager->disablePlugin($pluginName);
+        $pluginManager->disablePlugin($pluginName, true);
 
         $plugin = PluginVersion::where('code', $pluginName)->first();
         $plugin->is_disabled = true;

--- a/modules/system/console/PluginEnable.php
+++ b/modules/system/console/PluginEnable.php
@@ -40,7 +40,7 @@ class PluginEnable extends Command
             return $this->error(sprintf('Unable to find a registered plugin called "%s"', $pluginName));
         }
 
-        // Disable this plugin
+        // Enable this plugin
         $pluginManager->enablePlugin($pluginName);
 
         $plugin = PluginVersion::where('code', $pluginName)->first();

--- a/modules/system/console/PluginEnable.php
+++ b/modules/system/console/PluginEnable.php
@@ -41,7 +41,7 @@ class PluginEnable extends Command
         }
 
         // Enable this plugin
-        $pluginManager->enablePlugin($pluginName);
+        $pluginManager->enablePlugin($pluginName, true);
 
         $plugin = PluginVersion::where('code', $pluginName)->first();
         $plugin->is_disabled = false;

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -12,6 +12,7 @@ use Response;
 use BackendMenu;
 use Cms\Classes\ThemeManager;
 use Backend\Classes\Controller;
+use System\Models\MailTemplate;
 use System\Models\Parameter;
 use System\Models\PluginVersion;
 use System\Classes\UpdateManager;
@@ -876,6 +877,9 @@ class Updates extends Controller
                 }
             }
         }
+
+        // Make sure orphaned mail templates get purged
+        MailTemplate::syncAll();
 
         Flash::success(Lang::get("system::lang.plugins.{$bulkAction}_success"));
         return $this->listRefresh('manage');

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -1,5 +1,6 @@
 <?php namespace System\Controllers;
 
+use Event;
 use Lang;
 use Html;
 use Yaml;
@@ -811,9 +812,8 @@ class Updates extends Controller
     {
         if ($pluginCode = post('code')) {
             PluginManager::instance()->deletePlugin($pluginCode);
-            // purge orphaned mail templates
-            MailTemplate::syncAll();
             Flash::success(Lang::get('system::lang.plugins.remove_success'));
+            Event::fire('system.plugins.afterUpdate', ['remove']);
         }
 
         return Redirect::refresh();
@@ -880,11 +880,7 @@ class Updates extends Controller
             }
         }
 
-        if (in_array($bulkAction, ['disable', 'remove'])) {
-            // purge orphaned mail templates
-            MailTemplate::syncAll();
-        }
-
+        Event::fire('system.plugins.afterUpdate', [$bulkAction]);
 
         Flash::success(Lang::get("system::lang.plugins.{$bulkAction}_success"));
         return $this->listRefresh('manage');

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -813,7 +813,6 @@ class Updates extends Controller
         if ($pluginCode = post('code')) {
             PluginManager::instance()->deletePlugin($pluginCode);
             Flash::success(Lang::get('system::lang.plugins.remove_success'));
-            Event::fire('system.plugins.afterUpdate', ['remove']);
         }
 
         return Redirect::refresh();
@@ -879,8 +878,6 @@ class Updates extends Controller
                 }
             }
         }
-
-        Event::fire('system.plugins.afterUpdate', [$bulkAction]);
 
         Flash::success(Lang::get("system::lang.plugins.{$bulkAction}_success"));
         return $this->listRefresh('manage');

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -1,6 +1,5 @@
 <?php namespace System\Controllers;
 
-use Event;
 use Lang;
 use Html;
 use Yaml;
@@ -13,7 +12,6 @@ use Response;
 use BackendMenu;
 use Cms\Classes\ThemeManager;
 use Backend\Classes\Controller;
-use System\Models\MailTemplate;
 use System\Models\Parameter;
 use System\Models\PluginVersion;
 use System\Classes\UpdateManager;

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -811,6 +811,8 @@ class Updates extends Controller
     {
         if ($pluginCode = post('code')) {
             PluginManager::instance()->deletePlugin($pluginCode);
+            // purge orphaned mail templates
+            MailTemplate::syncAll();
             Flash::success(Lang::get('system::lang.plugins.remove_success'));
         }
 
@@ -878,8 +880,11 @@ class Updates extends Controller
             }
         }
 
-        // Make sure orphaned mail templates get purged
-        MailTemplate::syncAll();
+        if (in_array($bulkAction, ['disable', 'remove'])) {
+            // purge orphaned mail templates
+            MailTemplate::syncAll();
+        }
+
 
         Flash::success(Lang::get("system::lang.plugins.{$bulkAction}_success"));
         return $this->listRefresh('manage');

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -135,7 +135,6 @@ class PluginVersion extends Model
              *
              */
             Event::fire('system.plugins.afterDisable', [$this->code]);
-
         } elseif ($this->getOriginal('is_disabled') === 1 && $this->is_disabled === 0) {
             /**
              * @event system.plugins.afterEnable

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -1,5 +1,6 @@
 <?php namespace System\Models;
 
+use Event;
 use Lang;
 use Model;
 use Config;
@@ -113,6 +114,41 @@ class PluginVersion extends Model
             $this->name = $this->code;
             $this->description = Lang::get('system::lang.plugins.unknown_plugin');
             $this->orphaned = true;
+        }
+    }
+
+    /**
+     * After the model is saved
+     */
+    public function afterSave()
+    {
+        if ($this->getOriginal('is_disabled') === 0 && $this->is_disabled === 1) {
+            /**
+             * @event system.plugins.afterDisable
+             * Provides an opportunity to take actions after a plugin has been disabled.
+             *
+             * Example usage:
+             *
+             *     Event::listen('system.plugins.afterDisable', function ((String) $pluginCode) {
+             *         trace_log('Plugin ' . $pluginCode . ' has been disabled.');
+             *     });
+             *
+             */
+            Event::fire('system.plugins.afterDisable', [$this->code]);
+
+        } elseif ($this->getOriginal('is_disabled') === 1 && $this->is_disabled === 0) {
+            /**
+             * @event system.plugins.afterEnable
+             * Provides an opportunity to take actions after a plugin has been enabled.
+             *
+             * Example usage:
+             *
+             *     Event::listen('system.plugins.afterEnable', function ((String) $pluginCode) {
+             *         trace_log('Plugin ' . $pluginCode . ' has been enabled.');
+             *     });
+             *
+             */
+            Event::fire('system.plugins.afterEnable', [$this->code]);
         }
     }
 

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -149,7 +149,7 @@ class PluginVersion extends Model
              */
             Event::fire('system.plugins.afterEnable', [$this->code]);
         }
-        if (!$this->getOriginal('is_frozen')  && $this->is_frozen) {
+        if (!$this->getOriginal('is_frozen') && $this->is_frozen) {
             /**
              * @event system.plugins.afterFreeze
              * Provides an opportunity to take actions after a plugin has been frozen.

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -130,7 +130,7 @@ class PluginVersion extends Model
              *
              * Example usage:
              *
-             *     Event::listen('system.plugins.afterDisable', function ((String) $pluginCode) {
+             *     Event::listen('system.plugins.afterDisable', function ((string) $pluginCode) {
              *         trace_log('Plugin ' . $pluginCode . ' has been disabled.');
              *     });
              *

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -122,7 +122,7 @@ class PluginVersion extends Model
      */
     public function afterSave()
     {
-        // The plugin has been disabled.
+        // Detect if the plugin has been disabled.
         if (!$this->getOriginal('is_disabled') && $this->is_disabled) {
             /**
              * @event system.plugins.afterDisable

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -122,7 +122,7 @@ class PluginVersion extends Model
      */
     public function afterSave()
     {
-        if (!$this->getOriginal('is_disabled')  && $this->is_disabled) {
+        if (!$this->getOriginal('is_disabled') && $this->is_disabled) {
             /**
              * @event system.plugins.afterDisable
              * Provides an opportunity to take actions after a plugin has been disabled.

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -122,7 +122,7 @@ class PluginVersion extends Model
      */
     public function afterSave()
     {
-        if ($this->getOriginal('is_disabled') === 0 && $this->is_disabled === 1) {
+        if (!$this->getOriginal('is_disabled')  && $this->is_disabled) {
             /**
              * @event system.plugins.afterDisable
              * Provides an opportunity to take actions after a plugin has been disabled.
@@ -135,7 +135,7 @@ class PluginVersion extends Model
              *
              */
             Event::fire('system.plugins.afterDisable', [$this->code]);
-        } elseif ($this->getOriginal('is_disabled') === 1 && $this->is_disabled === 0) {
+        } elseif ($this->getOriginal('is_disabled') && !$this->is_disabled) {
             /**
              * @event system.plugins.afterEnable
              * Provides an opportunity to take actions after a plugin has been enabled.
@@ -148,6 +148,33 @@ class PluginVersion extends Model
              *
              */
             Event::fire('system.plugins.afterEnable', [$this->code]);
+        }
+        if (!$this->getOriginal('is_frozen')  && $this->is_frozen) {
+            /**
+             * @event system.plugins.afterFreeze
+             * Provides an opportunity to take actions after a plugin has been frozen.
+             *
+             * Example usage:
+             *
+             *     Event::listen('system.plugins.afterFreeze', function ((String) $pluginCode) {
+             *         trace_log('Plugin ' . $pluginCode . ' has been frozen.');
+             *     });
+             *
+             */
+            Event::fire('system.plugins.afterFreeze', [$this->code]);
+        } elseif ($this->getOriginal('is_frozen') && !$this->is_frozen) {
+            /**
+             * @event system.plugins.afterUnfreeze
+             * Provides an opportunity to take actions after a plugin has been unfrozen.
+             *
+             * Example usage:
+             *
+             *     Event::listen('system.plugins.afterUnfreeze
+             *         trace_log('Plugin ' . $pluginCode . ' has been unfrozen.');
+             *     });
+             *
+             */
+            Event::fire('system.plugins.afterUnfreeze', [$this->code]);
         }
     }
 

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -122,6 +122,7 @@ class PluginVersion extends Model
      */
     public function afterSave()
     {
+        // The plugin has been disabled.
         if (!$this->getOriginal('is_disabled') && $this->is_disabled) {
             /**
              * @event system.plugins.afterDisable
@@ -135,46 +136,6 @@ class PluginVersion extends Model
              *
              */
             Event::fire('system.plugins.afterDisable', [$this->code]);
-        } elseif ($this->getOriginal('is_disabled') && !$this->is_disabled) {
-            /**
-             * @event system.plugins.afterEnable
-             * Provides an opportunity to take actions after a plugin has been enabled.
-             *
-             * Example usage:
-             *
-             *     Event::listen('system.plugins.afterEnable', function ((String) $pluginCode) {
-             *         trace_log('Plugin ' . $pluginCode . ' has been enabled.');
-             *     });
-             *
-             */
-            Event::fire('system.plugins.afterEnable', [$this->code]);
-        }
-        if (!$this->getOriginal('is_frozen') && $this->is_frozen) {
-            /**
-             * @event system.plugins.afterFreeze
-             * Provides an opportunity to take actions after a plugin has been frozen.
-             *
-             * Example usage:
-             *
-             *     Event::listen('system.plugins.afterFreeze', function ((String) $pluginCode) {
-             *         trace_log('Plugin ' . $pluginCode . ' has been frozen.');
-             *     });
-             *
-             */
-            Event::fire('system.plugins.afterFreeze', [$this->code]);
-        } elseif ($this->getOriginal('is_frozen') && !$this->is_frozen) {
-            /**
-             * @event system.plugins.afterUnfreeze
-             * Provides an opportunity to take actions after a plugin has been unfrozen.
-             *
-             * Example usage:
-             *
-             *     Event::listen('system.plugins.afterUnfreeze
-             *         trace_log('Plugin ' . $pluginCode . ' has been unfrozen.');
-             *     });
-             *
-             */
-            Event::fire('system.plugins.afterUnfreeze', [$this->code]);
         }
     }
 

--- a/modules/system/models/PluginVersion.php
+++ b/modules/system/models/PluginVersion.php
@@ -118,7 +118,7 @@ class PluginVersion extends Model
     }
 
     /**
-     * After the model is saved
+     * Fired after the model is saved
      */
     public function afterSave()
     {

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -240,4 +240,12 @@ class PluginManagerTest extends TestCase
         $result = $this->manager->exists('Unknown.Plugin');
         $this->assertFalse($result);
     }
+
+    public function testNormalizeIdentifier()
+    {
+        $id = 'october.sample';
+        $code = $this->manager->normalizeIdentifier($id);
+
+        $this->assertEquals('October.Sample', $code);
+    }
 }


### PR DESCRIPTION
Purge Mail Templates when plugins are removed / disabled.

This prevents the following exception to be thrown when a mail templates registered by a plugin are no longer active:
```
if (! isset($this->hints[$segments[0]])) {
   throw new InvalidArgumentException("No hint path defined for [{$segments[0]}].");
}
```
ref. vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php line 112

In order to replicate the problem, do the following:

1. Install a plugin that registers mail templates (e.g. RainLab.User).
2. Install RainLab.Translate.
3. Go to `Settings->Mail->Mail templates` page (this actually add the registered mail templates to the database).
4. Go to `Settings->System->Updates & Plugins` and disable the plugin installed in step1.
5. Go to `Settings->Translate->Translate messages` page.
6. Click on `Scan for messages`
7. Click on `Begin scan`

You should see the Exception mentioned above being thrown.