### PR TITLE
Change the max length of login and email

### DIFF
--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -25,8 +25,8 @@ class User extends UserBase
      * Validation rules
      */
     public $rules = [
-        'email' => 'required|between:6,255|email|unique:backend_users',
-        'login' => 'required|between:2,255|unique:backend_users',
+        'email' => 'required|between:6,191|email|unique:backend_users',
+        'login' => 'required|between:2,191|unique:backend_users',
         'password' => 'required:create|min:4|confirmed',
         'password_confirmation' => 'required_with:password|min:4'
     ];


### PR DESCRIPTION
The maximum length of fields are 191 in the database.
![db](https://user-images.githubusercontent.com/2959112/95959362-a2dc4480-0e02-11eb-8e10-34f28367d970.jpg)
