### PR TITLE
Prevent exception when mail templates/layouts are not found

### DIFF
--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -74,19 +74,14 @@ class MailLayout extends Model
 
     public static function findOrMakeLayout($code)
     {
-        try {
-            $layout = self::whereCode($code)->first();
+        $layout = self::whereCode($code)->first();
 
-            if (!$layout && View::exists($code)) {
-                $layout = new self;
-                $layout->code = $code;
-                $layout->fillFromView($code);
-            }
-            return $layout;
+        if (!$layout && View::exists($code)) {
+            $layout = new self;
+            $layout->code = $code;
+            $layout->fillFromView($code);
         }
-        catch (Exception $e) {
-            return null;
-        }
+        return $layout;
     }
 
     /**
@@ -157,6 +152,12 @@ class MailLayout extends Model
 
     protected static function getTemplateSections($code)
     {
-        return MailParser::parse(FileHelper::get(View::make($code)->getPath()));
+        try {
+            $view = View::make($code);
+            return MailParser::parse(FileHelper::get($view->getPath()));
+        }
+        catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -2,7 +2,6 @@
 
 use View;
 use Model;
-use InvalidArgumentException;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use ApplicationException;
@@ -152,12 +151,10 @@ class MailLayout extends Model
 
     protected static function getTemplateSections($code)
     {
-        try {
-            $view = View::make($code);
-            return MailParser::parse(FileHelper::get($view->getPath()));
-        }
-        catch (InvalidArgumentException $e) {
+        if (!View::exists($code)) {
             return null;
         }
+        $view = View::make($code);
+        return MailParser::parse(FileHelper::get($view->getPath()));
     }
 }

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -54,6 +54,7 @@ class MailLayout extends Model
      * Fired before the model is deleted.
      *
      * @return void
+     * @throws ApplicationException if the template is locked
      */
     public function beforeDelete()
     {
@@ -63,7 +64,7 @@ class MailLayout extends Model
     }
 
     /**
-     * List MailLayouts codes keyed by id.
+     * List MailLayouts codes keyed by ID.
      *
      * @return array
      */
@@ -77,7 +78,7 @@ class MailLayout extends Model
     }
 
     /**
-     * Return the id of a MailLayout searched by its code.
+     * Return the ID of a MailLayout instance from a defined code.
      *
      * @param string $code
      * @return string
@@ -88,8 +89,7 @@ class MailLayout extends Model
     }
 
     /**
-     * Find a MailLayout by its code or create a new
-     * one from the view file.
+     * Find a MailLayout instance by its code or create a new instance from the view file.
      *
      * @param string $code
      * @return MailLayout
@@ -134,8 +134,9 @@ class MailLayout extends Model
     /**
      * Fill model using a view file retrieved by code.
      *
-     * @param string $code
+     * @param string|null $code
      * @return void
+     * @throws ApplicationException if a layout with the defined code is not registered.
      */
     public function fillFromCode($code = null)
     {

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -2,7 +2,7 @@
 
 use View;
 use Model;
-use Exception;
+use InvalidArgumentException;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use ApplicationException;
@@ -156,7 +156,7 @@ class MailLayout extends Model
             $view = View::make($code);
             return MailParser::parse(FileHelper::get($view->getPath()));
         }
-        catch (\Exception $e) {
+        catch (InvalidArgumentException $e) {
             return null;
         }
     }

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -2,6 +2,7 @@
 
 use View;
 use Model;
+use Exception;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use ApplicationException;
@@ -73,15 +74,19 @@ class MailLayout extends Model
 
     public static function findOrMakeLayout($code)
     {
-        $layout = self::whereCode($code)->first();
+        try {
+            $layout = self::whereCode($code)->first();
 
-        if (!$layout && View::exists($code)) {
-            $layout = new self;
-            $layout->code = $code;
-            $layout->fillFromView($code);
+            if (!$layout && View::exists($code)) {
+                $layout = new self;
+                $layout->code = $code;
+                $layout->fillFromView($code);
+            }
+            return $layout;
         }
-
-        return $layout;
+        catch (Exception $e) {
+            return null;
+        }
     }
 
     /**

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -132,7 +132,7 @@ class MailLayout extends Model
     }
 
     /**
-     * Fill model using a view file by code.
+     * Fill model using a view file retrieved by code.
      *
      * @param string $code
      * @return void
@@ -153,7 +153,7 @@ class MailLayout extends Model
     }
 
     /**
-     * Fill model using a view file by path.
+     * Fill model using a view file retrieved by path.
      *
      * @param string $path
      * @return void
@@ -187,7 +187,7 @@ class MailLayout extends Model
     }
 
     /**
-     * Get section array from a view file by code.
+     * Get section array from a view file retrieved by code.
      *
      * @param string $code
      * @return array|null

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -50,6 +50,11 @@ class MailLayout extends Model
 
     public static $codeCache;
 
+    /**
+     * Fired before the model is deleted.
+     *
+     * @return void
+     */
     public function beforeDelete()
     {
         if ($this->is_locked) {
@@ -57,6 +62,11 @@ class MailLayout extends Model
         }
     }
 
+    /**
+     * List MailLayouts codes keyed by id.
+     *
+     * @return array
+     */
     public static function listCodes()
     {
         if (self::$codeCache !== null) {
@@ -66,11 +76,24 @@ class MailLayout extends Model
         return self::$codeCache = self::lists('id', 'code');
     }
 
+    /**
+     * Return the id of a MailLayout searched by its code.
+     *
+     * @param string $code
+     * @return string
+     */
     public static function getIdFromCode($code)
     {
         return array_get(self::listCodes(), $code);
     }
 
+    /**
+     * Find a MailLayout by its code or create a new
+     * one from the view file.
+     *
+     * @param string $code
+     * @return MailLayout
+     */
     public static function findOrMakeLayout($code)
     {
         $layout = self::whereCode($code)->first();
@@ -87,6 +110,7 @@ class MailLayout extends Model
     /**
      * Loops over each mail layout and ensures the system has a layout,
      * if the layout does not exist, it will create one.
+     *
      * @return void
      */
     public static function createLayouts()
@@ -107,6 +131,12 @@ class MailLayout extends Model
         }
     }
 
+    /**
+     * Fill model using a view file by code.
+     *
+     * @param string $code
+     * @return void
+     */
     public function fillFromCode($code = null)
     {
         $definitions = MailManager::instance()->listRegisteredLayouts();
@@ -122,6 +152,12 @@ class MailLayout extends Model
         $this->fillFromView($definition);
     }
 
+    /**
+     * Fill model using a view file by path.
+     *
+     * @param string $path
+     * @return void
+     */
     public function fillFromView($path)
     {
         $sections = self::getTemplateSections($path);
@@ -150,6 +186,12 @@ class MailLayout extends Model
         $this->content_text = array_get($sections, 'text');
     }
 
+    /**
+     * Get section array from a view file by code.
+     *
+     * @param string $code
+     * @return array|null
+     */
     protected static function getTemplateSections($code)
     {
         if (!View::exists($code)) {

--- a/modules/system/models/MailLayout.php
+++ b/modules/system/models/MailLayout.php
@@ -80,6 +80,7 @@ class MailLayout extends Model
             $layout->code = $code;
             $layout->fillFromView($code);
         }
+
         return $layout;
     }
 

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -2,10 +2,10 @@
 
 use View;
 use Model;
+use InvalidArgumentException;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use ApplicationException;
-use Exception;
 use File as FileHelper;
 
 /**
@@ -51,18 +51,13 @@ class MailPartial extends Model
 
     public static function findOrMakePartial($code)
     {
-        try {
-            if (!$template = self::whereCode($code)->first()) {
-                $template = new self;
-                $template->code = $code;
-                $template->fillFromCode($code);
-            }
+        if (!$template = self::whereCode($code)->first()) {
+            $template = new self;
+            $template->code = $code;
+            $template->fillFromCode($code);
+        }
 
-            return $template;
-        }
-        catch (Exception $ex) {
-            return null;
-        }
+        return $template;
     }
 
     /**
@@ -128,7 +123,7 @@ class MailPartial extends Model
             $view = View::make($code);
             return MailParser::parse(FileHelper::get($view->getPath()));
         }
-        catch (\Exception $e) {
+        catch (InvalidArgumentException $e) {
             return null;
         }
     }

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -2,7 +2,6 @@
 
 use View;
 use Model;
-use InvalidArgumentException;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use ApplicationException;
@@ -119,12 +118,10 @@ class MailPartial extends Model
 
     protected static function getTemplateSections($code)
     {
-        try {
-            $view = View::make($code);
-            return MailParser::parse(FileHelper::get($view->getPath()));
-        }
-        catch (InvalidArgumentException $e) {
+        if (!View::exists($code)) {
             return null;
         }
+        $view = View::make($code);
+        return MailParser::parse(FileHelper::get($view->getPath()));
     }
 }

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -2,10 +2,10 @@
 
 use View;
 use Model;
-use Exception;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use ApplicationException;
+use Exception;
 use File as FileHelper;
 
 /**

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -124,6 +124,12 @@ class MailPartial extends Model
 
     protected static function getTemplateSections($code)
     {
-        return MailParser::parse(FileHelper::get(View::make($code)->getPath()));
+        try {
+            $view = View::make($code);
+            return MailParser::parse(FileHelper::get($view->getPath()));
+        }
+        catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -55,10 +55,10 @@ class MailPartial extends Model
     }
 
     /**
-     * Find a MailPartial record by code or create one from a view file.
+     * Find a MailPartial instance by code or create a new instance from a view file.
      *
      * @param string $code
-     * @return MailTemplate model
+     * @return MailTemplate
      */
     public static function findOrMakePartial($code)
     {
@@ -113,7 +113,7 @@ class MailPartial extends Model
     /**
      * Fill model using a view file retrieved by code.
      *
-     * @param string $code
+     * @param string|null $code
      * @return void
      */
     public function fillFromCode($code = null)

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -2,6 +2,7 @@
 
 use View;
 use Model;
+use Exception;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use ApplicationException;
@@ -50,13 +51,18 @@ class MailPartial extends Model
 
     public static function findOrMakePartial($code)
     {
-        if (!$template = self::whereCode($code)->first()) {
-            $template = new self;
-            $template->code = $code;
-            $template->fillFromCode($code);
-        }
+        try {
+            if (!$template = self::whereCode($code)->first()) {
+                $template = new self;
+                $template->code = $code;
+                $template->fillFromCode($code);
+            }
 
-        return $template;
+            return $template;
+        }
+        catch (Exception $e) {
+            return null;
+        }
     }
 
     /**

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -42,6 +42,11 @@ class MailPartial extends Model
         'content_html'          => 'required',
     ];
 
+    /**
+     * Fired after the model has been fetched.
+     *
+     * @return void
+     */
     public function afterFetch()
     {
         if (!$this->is_custom) {
@@ -49,6 +54,12 @@ class MailPartial extends Model
         }
     }
 
+    /**
+     * Find a MailPartial record by code or create one from a view file.
+     *
+     * @param string $code
+     * @return MailTemplate model
+     */
     public static function findOrMakePartial($code)
     {
         try {
@@ -68,6 +79,7 @@ class MailPartial extends Model
     /**
      * Loops over each mail layout and ensures the system has a layout,
      * if the layout does not exist, it will create one.
+     *
      * @return void
      */
     public static function createPartials()
@@ -98,6 +110,12 @@ class MailPartial extends Model
         }
     }
 
+    /**
+     * Fill model using a view file retrieved by code.
+     *
+     * @param string $code
+     * @return void
+     */
     public function fillFromCode($code = null)
     {
         $definitions = MailManager::instance()->listRegisteredPartials();
@@ -113,6 +131,12 @@ class MailPartial extends Model
         $this->fillFromView($definition);
     }
 
+    /**
+     * Fill model using a view file retrieved by path.
+     *
+     * @param string $path
+     * @return void
+     */
     public function fillFromView($path)
     {
         $sections = self::getTemplateSections($path);
@@ -122,6 +146,12 @@ class MailPartial extends Model
         $this->content_text = array_get($sections, 'text');
     }
 
+    /**
+     * Get section array from a view file retrieved by code.
+     *
+     * @param string $code
+     * @return array|null
+     */
     protected static function getTemplateSections($code)
     {
         if (!View::exists($code)) {

--- a/modules/system/models/MailPartial.php
+++ b/modules/system/models/MailPartial.php
@@ -60,7 +60,7 @@ class MailPartial extends Model
 
             return $template;
         }
-        catch (Exception $e) {
+        catch (Exception $ex) {
             return null;
         }
     }

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -2,6 +2,7 @@
 
 use View;
 use Model;
+use InvalidArgumentException;
 use System\Classes\MailManager;
 use October\Rain\Mail\MailParser;
 use File as FileHelper;
@@ -68,7 +69,12 @@ class MailTemplate extends Model
         $codes = array_keys(self::listAllTemplates());
 
         foreach ($codes as $code) {
-            $result[] = self::findOrMakeTemplate($code);
+            try {
+                $result[] = self::findOrMakeTemplate($code);
+            }
+            catch (InvalidArgumentException $e) {
+                // skip orphaned templates for disabled/removed plugins
+            }
         }
 
         return $result;

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -69,12 +69,7 @@ class MailTemplate extends Model
         $codes = array_keys(self::listAllTemplates());
 
         foreach ($codes as $code) {
-            try {
-                $result[] = self::findOrMakeTemplate($code);
-            }
-            catch (InvalidArgumentException $e) {
-                // skip orphaned templates for disabled/removed plugins
-            }
+            $result[] = self::findOrMakeTemplate($code);
         }
 
         return $result;
@@ -152,7 +147,13 @@ class MailTemplate extends Model
 
     protected static function getTemplateSections($code)
     {
-        return MailParser::parse(FileHelper::get(View::make($code)->getPath()));
+        try {
+            $view = View::make($code);
+            return MailParser::parse(FileHelper::get($view->getPath()));
+        }
+        catch (\Exception $e) {
+            return null;
+        }
     }
 
     public static function findOrMakeTemplate($code)

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -47,6 +47,7 @@ class MailTemplate extends Model
 
     /**
      * Returns an array of template codes and descriptions.
+     *
      * @return array
      */
     public static function listAllTemplates()
@@ -60,6 +61,7 @@ class MailTemplate extends Model
 
     /**
      * Returns a list of all mail templates.
+     *
      * @return array Returns an array of the MailTemplate objects.
      */
     public static function allTemplates()
@@ -78,6 +80,7 @@ class MailTemplate extends Model
 
     /**
      * Syncronise all file templates to the database.
+     *
      * @return void
      */
     public static function syncAll()
@@ -133,6 +136,7 @@ class MailTemplate extends Model
 
     /**
      * Fill model using provided content.
+     *
      * @param string $content
      * @return void
      */
@@ -143,6 +147,7 @@ class MailTemplate extends Model
 
     /**
      * Fill model using a view.
+     *
      * @param string $path
      * @return void
      */
@@ -153,6 +158,7 @@ class MailTemplate extends Model
 
     /**
      * Fill model using provided section array.
+     *
      * @param array $sections
      * @return void
      */
@@ -168,6 +174,7 @@ class MailTemplate extends Model
 
     /**
      * Get section array from a view file.
+     *
      * @param string $code
      * @return array|null
      */
@@ -182,6 +189,7 @@ class MailTemplate extends Model
 
     /**
      * Find a MailTemplate record by code or create one from a view file.
+     *
      * @param string $code
      * @return MailTemplate model
      */

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -157,7 +157,7 @@ class MailTemplate extends Model
      */
     protected function fillFromSections($sections)
     {
-        $this->content_html = array_get($sections, 'html', '<!-- empty content -->');
+        $this->content_html = array_get($sections, 'html');
         $this->content_text = array_get($sections, 'text');
         $this->subject = array_get($sections, 'settings.subject', 'No subject');
 

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -121,6 +121,7 @@ class MailTemplate extends Model
 
     /**
      * Fired after the model has been fetched.
+     *
      * @return void
      */
     public function afterFetch()

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -173,7 +173,7 @@ class MailTemplate extends Model
     }
 
     /**
-     * Get section array from a view file by code.
+     * Get section array from a view file retrieved by code.
      *
      * @param string $code
      * @return array|null

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -146,7 +146,7 @@ class MailTemplate extends Model
     }
 
     /**
-     * Fill model using a view.
+     * Fill model using a view file path.
      *
      * @param string $path
      * @return void
@@ -173,7 +173,7 @@ class MailTemplate extends Model
     }
 
     /**
-     * Get section array from a view file.
+     * Get section array from a view file by code.
      *
      * @param string $code
      * @return array|null

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -119,6 +119,10 @@ class MailTemplate extends Model
         }
     }
 
+    /**
+     * Fired after the model has been fetched.
+     * @return void
+     */
     public function afterFetch()
     {
         if (!$this->is_custom) {
@@ -126,16 +130,31 @@ class MailTemplate extends Model
         }
     }
 
+    /**
+     * Fill model using provided content.
+     * @param string $content
+     * @return void
+     */
     public function fillFromContent($content)
     {
         $this->fillFromSections(MailParser::parse($content));
     }
 
+    /**
+     * Fill model using a view.
+     * @param string $path
+     * @return void
+     */
     public function fillFromView($path)
     {
         $this->fillFromSections(self::getTemplateSections($path));
     }
 
+    /**
+     * Fill model using provided section array.
+     * @param array $sections
+     * @return void
+     */
     protected function fillFromSections($sections)
     {
         $this->content_html = array_get($sections, 'html', '<!-- empty content -->');
@@ -146,6 +165,11 @@ class MailTemplate extends Model
         $this->layout = MailLayout::findOrMakeLayout($layoutCode);
     }
 
+    /**
+     * Get section array from a view file.
+     * @param string $code
+     * @return array|null
+     */
     protected static function getTemplateSections($code)
     {
         if (!View::exists($code)) {
@@ -155,6 +179,11 @@ class MailTemplate extends Model
         return MailParser::parse(FileHelper::get($view->getPath()));
     }
 
+    /**
+     * Find a MailTemplate record by code or create one from a view file.
+     * @param string $code
+     * @return MailTemplate model
+     */
     public static function findOrMakeTemplate($code)
     {
         $template = self::whereCode($code)->first();

--- a/modules/system/models/MailTemplate.php
+++ b/modules/system/models/MailTemplate.php
@@ -151,7 +151,7 @@ class MailTemplate extends Model
             $view = View::make($code);
             return MailParser::parse(FileHelper::get($view->getPath()));
         }
-        catch (\Exception $e) {
+        catch (InvalidArgumentException $e) {
             return null;
         }
     }


### PR DESCRIPTION
Replaces #5305
Fixes: rainlab/translate-plugin#513

To replicate the problem:
- [Install RainLab.Translate.]
- [Install a plugin that registers mail templates (e.g. RainLab.User).]
- Go to Settings->Mail->Mail templates page (this actually add the registered mail templates to the database).
- Go to Settings->System->Updates & Plugins and disable the `RainLab.User` plugin.
- Go to Settings->Translate->Translate messages page.
- Click on Scan for messages
- Click on Begin scan
