### PR TITLE
Changing install plugins/themes buttons order

### DIFF
--- a/modules/system/controllers/updates/_list_toolbar.htm
+++ b/modules/system/controllers/updates/_list_toolbar.htm
@@ -7,14 +7,14 @@
         <?= e(trans('system::lang.updates.check_label')) ?>
     </a>
     <a
-        href="<?= Backend::url('system/updates/install/themes') ?>"
-        class="btn btn-success oc-icon-plus">
-        <?= e(trans('system::lang.themes.install')) ?>
-    </a>
-    <a
         href="<?= Backend::url('system/updates/install') ?>"
         class="btn btn-success oc-icon-plus">
         <?= e(trans('system::lang.plugins.install')) ?>
+    </a>
+    <a
+        href="<?= Backend::url('system/updates/install/themes') ?>"
+        class="btn btn-success oc-icon-plus">
+        <?= e(trans('system::lang.themes.install')) ?>
     </a>
     <a
         href="<?= Backend::url('system/updates/manage') ?>"


### PR DESCRIPTION
Change order to plugin -> theme, like the install producs page to reduce missclicks.

![image](https://user-images.githubusercontent.com/7849550/96857652-83c35f80-145f-11eb-9269-99cc208d6483.png)

![image](https://user-images.githubusercontent.com/7849550/96857846-c8e79180-145f-11eb-8b25-736175084feb.png)


