### PR TITLE
Fix for #5300 - Wrong type hinting for config variable

### DIFF
--- a/modules/backend/classes/ControllerBehavior.php
+++ b/modules/backend/classes/ControllerBehavior.php
@@ -23,7 +23,7 @@ class ControllerBehavior extends ExtensionBase
     }
 
     /**
-     * @var array Supplied configuration.
+     * @var \stdClass Supplied configuration.
      */
     protected $config;
 

--- a/modules/system/traits/ConfigMaker.php
+++ b/modules/system/traits/ConfigMaker.php
@@ -27,7 +27,7 @@ trait ConfigMaker
      * Reads the contents of the supplied file and applies it to this object.
      * @param array $configFile
      * @param array $requiredConfig
-     * @return array|stdClass
+     * @return stdClass
      */
     public function makeConfig($configFile = [], $requiredConfig = [])
     {


### PR DESCRIPTION
There were 2 occurrences of incorrect type hinting for the variable `$config`. It was declared as an array while it was being used as an object. These are the 2 occurrences:

https://github.com/octobercms/october/blob/af6db51b7978aae874844e79e0103b0952d7b762/modules/backend/classes/ControllerBehavior.php#L26

https://github.com/octobercms/october/blob/af6db51b7978aae874844e79e0103b0952d7b762/modules/system/traits/ConfigMaker.php#L30

This PR is an attempt to fix issue #5300