### PR TITLE
Theme:sync path pattern fix

### DIFF
--- a/modules/system/console/ThemeSync.php
+++ b/modules/system/console/ThemeSync.php
@@ -105,7 +105,7 @@ class ThemeSync extends Command
 
             foreach ($userPaths as $userPath) {
                 foreach ($themePaths as $themePath) {
-                    $pregMatch = '/' . str_replace('/', '\/', $userPath) . '/i';
+                    $pregMatch = '/^' . str_replace('/', '\/', $userPath) . '/i';
 
                     if ($userPath === $themePath || preg_match($pregMatch, $themePath)) {
                         $paths[] = $themePath;


### PR DESCRIPTION
When synchronizing files to the database, there is a problem with matching the paths to be synchronized because regex does not work as expected.

I have executed the following command:

`artisan theme:sync --target=database --force --paths=layouts/,pages/,partials/`

But at the moment it also synchronizes paths that should not be synchronized. For example: `content/static-pages/`. Because here the pattern applies to `pages/`.

The fix is that the pattern starts at the beginning of the line.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->