### PR TITLE
Migrate to League\Csv 9.0

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -803,9 +803,9 @@ class ImportExportController extends ControllerBehavior
 
         if (
             $options['encoding'] !== null &&
-            $reader->isActiveStreamFilter()
+            $reader->supportsStreamFilter()
         ) {
-            $reader->appendStreamFilter(sprintf(
+            $reader->addStreamFilter(sprintf(
                 '%s%s:%s',
                 TranscodeFilter::FILTER_NAME,
                 strtolower($options['encoding']),


### PR DESCRIPTION
OC 1.1 require `league/csv: ~9.1` but use code from 8.x on ImportExport behavior.
https://csv.thephpleague.com/9.0/upgrading/