### PR TITLE
fix themes localization namespace

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -298,7 +298,7 @@ class ServiceProvider extends ModuleServiceProvider
         $langPath = $theme->getPath() . '/lang';
 
         if (File::isDirectory($langPath)) {
-            Lang::addNamespace("theme.{$theme->getId()}", $langPath);
+            Lang::addNamespace("themes.{$theme->getId()}", $langPath);
         }
     }
 


### PR DESCRIPTION
Namespace was using "theme.*" instead of "themes.*"

Related: #4960