### PR TITLE
Move theme localization to the boot process of the CMS Service Provider

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -44,7 +44,6 @@ class ServiceProvider extends ModuleServiceProvider
             $this->registerBackendPermissions();
             $this->registerBackendWidgets();
             $this->registerBackendSettings();
-            $this->registerBackendLocalization();
         }
     }
 
@@ -59,6 +58,10 @@ class ServiceProvider extends ModuleServiceProvider
 
         $this->bootMenuItemEvents();
         $this->bootRichEditorEvents();
+
+        if (App::runningInBackend()) {
+            $this->bootBackendLocalization();
+        }
     }
 
     /**
@@ -303,16 +306,16 @@ class ServiceProvider extends ModuleServiceProvider
     }
 
     /**
-     * Registers localization from an active theme for backend items.
+     * Boots localization from an active theme for backend items.
      */
-    protected function registerBackendLocalization()
+    protected function bootBackendLocalization()
     {
         $theme = CmsTheme::getActiveTheme();
 
         $langPath = $theme->getPath() . '/lang';
 
         if (File::isDirectory($langPath)) {
-            Lang::addNamespace("themes.{$theme->getId()}", $langPath);
+            Lang::addNamespace('themes.' . $theme->getId(), $langPath);
         }
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/octobercms/october/pull/4960.

It appears that doing this in the "register" process can result, at times, in an exception to be thrown as the connection to the DB is not yet established.

![image](https://user-images.githubusercontent.com/15900351/98630603-77437000-2356-11eb-8663-34016ebfd710.png)

This seemed to occur for me only on signing in to the Backend, and also seemed to be intermittent - sometimes it worked.

Moving it to the `boot` method in the CMS service provider makes it more stable.