### PR TITLE
Improved RelationController titles granularity + added flashes

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1149,7 +1149,10 @@ class RelationController extends ControllerBehavior
             }
         }
 
-        if ($flashMessage = Lang::get($this->getConfig('manage[flash][create]'))) Flash::success($flashMessage);
+        $flashMessage = Lang::get($this->getConfig('manage[flash][create]'));
+        if ($flashMessage) {
+            Flash::success($flashMessage);
+        }
 
         return $this->relationRefresh();
     }
@@ -1181,7 +1184,10 @@ class RelationController extends ControllerBehavior
             $this->viewModel->save(null, $this->manageWidget->getSessionKey());
         }
 
-        if ($flashMessage = Lang::get($this->getConfig('manage[flash][update]'))) Flash::success($flashMessage);
+        $flashMessage = Lang::get($this->getConfig('manage[flash][update]'));
+        if ($flashMessage) {
+            Flash::success($flashMessage);
+        }
 
         return $this->relationRefresh();
     }
@@ -1224,7 +1230,12 @@ class RelationController extends ControllerBehavior
             $this->viewModel = $this->relationModel;
         }
 
-        if ($relationAffected && ($flashMessage = Lang::get($this->getConfig('manage[flash][delete]')))) Flash::success($flashMessage);
+        if ($relationAffected) {
+            $flashMessage = Lang::get($this->getConfig('manage[flash][delete]'));
+            if ($flashMessage) {
+                Flash::success($flashMessage);
+            }
+        }
 
         return $this->relationRefresh();
     }
@@ -1258,7 +1269,10 @@ class RelationController extends ControllerBehavior
                     $this->relationObject->add($model, $sessionKey);
                 }
 
-                if ($flashMessage = Lang::get($this->getConfig('manage[flash][add]'))) Flash::success($flashMessage);
+                $flashMessage = Lang::get($this->getConfig('manage[flash][add]'));
+                if ($flashMessage) {
+                    Flash::success($flashMessage);
+                }
             }
         }
         /*
@@ -1289,7 +1303,10 @@ class RelationController extends ControllerBehavior
                     }
                 }
 
-                if ($flashMessage = Lang::get($this->getConfig('manage[flash][link]'))) Flash::success($flashMessage);
+                $flashMessage = Lang::get($this->getConfig('manage[flash][link]'));
+                if ($flashMessage) {
+                    Flash::success($flashMessage);
+                }
             }
         }
 
@@ -1321,7 +1338,10 @@ class RelationController extends ControllerBehavior
                     $this->relationObject->remove($model, $sessionKey);
                 }
 
-                if ($flashMessage = Lang::get($this->getConfig('manage[flash][remove]'))) Flash::success($flashMessage);
+                $flashMessage = Lang::get($this->getConfig('manage[flash][remove]'));
+                if ($flashMessage) {
+                    Flash::success($flashMessage);
+                }
             }
         }
         /*
@@ -1353,7 +1373,10 @@ class RelationController extends ControllerBehavior
             $this->viewWidget->setFormValues([]);
             $this->viewModel = $this->relationModel;
 
-            if ($flashMessage = Lang::get($this->getConfig('manage[flash][unlink]'))) Flash::success($flashMessage);
+            $flashMessage = Lang::get($this->getConfig('manage[flash][unlink]'));
+            if ($flashMessage) {
+                Flash::success($flashMessage);
+            }
         }
 
         return $this->relationRefresh();
@@ -1406,7 +1429,10 @@ class RelationController extends ControllerBehavior
             }
         });
 
-            if ($flashMessage = Lang::get($this->getConfig('manage[flash][add]'))) Flash::success($flashMessage);
+        $flashMessage = Lang::get($this->getConfig('manage[flash][add]'));
+        if ($flashMessage) {
+            Flash::success($flashMessage);
+        }
 
         return ['#'.$this->relationGetId('view') => $this->relationRenderView()];
     }
@@ -1424,7 +1450,10 @@ class RelationController extends ControllerBehavior
             $modelToSave->save(null, $this->pivotWidget->getSessionKey());
         }
 
-        if ($flashMessage = Lang::get($this->getConfig('manage[flash][update]'))) Flash::success($flashMessage);
+        $flashMessage = Lang::get($this->getConfig('manage[flash][update]'));
+        if ($flashMessage) {
+            Flash::success($flashMessage);
+        }
 
         return ['#'.$this->relationGetId('view') => $this->relationRenderView()];
     }
@@ -1650,30 +1679,37 @@ class RelationController extends ControllerBehavior
         switch ($this->manageMode) {
             case 'pivot':
             case 'list':
-                if ($customTitle = array_get($customTitles, 'list') && is_string($customTitle)) {
+                $customTitle = array_get($customTitles, 'list');
+                if ($customTitle && is_string($customTitle)) {
                     return $customTitle;
                 }
+
                 if ($this->eventTarget === 'button-link') {
-                    if ($customTitle = array_get($customTitles, 'list.link')) return $customTitle;
-                    return 'backend::lang.relation.link_a_new';
+                    $customTitle = array_get($customTitles, 'list.link');
+                    return $customTitle ?: 'backend::lang.relation.link_a_new';
                 }
-                if ($customTitle = array_get($customTitles, 'list.add')) return $customTitle;
-                return 'backend::lang.relation.add_a_new';
+
+                $customTitle = array_get($customTitles, 'list.add');
+                return $customTitle ?: 'backend::lang.relation.add_a_new';
 
             case 'form':
-                if ($customTitle = array_get($customTitles, 'form') && is_string($customTitle)) {
+                $customTitle = array_get($customTitles, 'form');
+                if ($customTitle && is_string($customTitle)) {
                     return $customTitle;
                 }
+
                 if ($this->readOnly) {
-                    if ($customTitle = array_get($customTitles, 'form.preview')) return $customTitle;
-                    return 'backend::lang.relation.preview_name';
+                    $customTitle = array_get($customTitles, 'form.preview');
+                    return $customTitle ?: 'backend::lang.relation.preview_name';
                 }
+
                 if ($this->manageId) {
-                    if ($customTitle = array_get($customTitles, 'form.update')) return $customTitle;
-                    return 'backend::lang.relation.update_name';
+                    $customTitle = array_get($customTitles, 'form.update');
+                    return $customTitle ?: 'backend::lang.relation.update_name';
                 }
-                if ($customTitle = array_get($customTitles, 'form.create')) return $customTitle;
-                return 'backend::lang.relation.create_name';
+
+                $customTitle = array_get($customTitles, 'form.create');
+                return $customTitle ?: 'backend::lang.relation.create_name';
         }
     }
 
@@ -1692,15 +1728,17 @@ class RelationController extends ControllerBehavior
         $customTitles = is_array($customTitle) ? $customTitle : [];
 
         if ($this->readOnly) {
-            if ($customTitle = array_get($customTitles, 'preview')) return $customTitle;
-            return 'backend::lang.relation.related_data';
+            $customTitle = array_get($customTitles, 'preview');
+            return $customTitle ?: 'backend::lang.relation.related_data';
         }
+
         if ($this->manageId) {
-            if ($customTitle = array_get($customTitles, 'update')) return $customTitle;
-            return 'backend::lang.relation.related_data';
+            $customTitle = array_get($customTitles, 'update');
+            return $customTitle ?: 'backend::lang.relation.related_data';
         }
-        if ($customTitle = array_get($customTitles, 'create')) return $customTitle;
-        return 'backend::lang.relation.related_data';
+
+        $customTitle = array_get($customTitles, 'create');
+        return $customTitle ?: 'backend::lang.relation.related_data';
     }
 
     /**

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1210,7 +1210,8 @@ class RelationController extends ControllerBehavior
                         continue;
                     }
 
-                    $relationAffected |= $obj->delete();
+                    $result = $obj->delete();
+                    $relationAffected = $relationAffected || $result;
                 }
             }
         }
@@ -1220,7 +1221,8 @@ class RelationController extends ControllerBehavior
         elseif ($this->viewMode == 'single') {
             $relatedModel = $this->viewModel;
             if ($relatedModel->exists) {
-                $relationAffected |= $relatedModel->delete();
+                $result = $relatedModel->delete();
+                $relationAffected = $relationAffected || $result;
             }
 
             // Reinitialise the form with a blank model

--- a/modules/backend/behaviors/relationcontroller/partials/_pivot_form.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_pivot_form.htm
@@ -8,7 +8,7 @@
 
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
-            <h4 class="modal-title"><?= e(trans('backend::lang.relation.related_data', ['name'=>trans($relationLabel)])) ?></h4>
+            <h4 class="modal-title"><?= e(trans($relationPivotTitle, ['name'=>trans($relationLabel)])) ?></h4>
         </div>
         <div class="modal-body">
             <?= $relationPivotWidget->render(['preview' => $this->readOnly]) ?>
@@ -48,7 +48,7 @@
 
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="popup">&times;</button>
-            <h4 class="modal-title"><?= e(trans('backend::lang.relation.related_data', ['name'=>trans($relationLabel)])) ?></h4>
+            <h4 class="modal-title"><?= e(trans($relationPivotTitle, ['name'=>trans($relationLabel)])) ?></h4>
         </div>
         <div class="modal-body">
             <?= $relationPivotWidget->render() ?>


### PR DESCRIPTION
I am trying to improve RelationController titles granularity. Current `manage.title` or `manage.{list|form}.title` does not cover all possible cases. Furthermore pivot's form title was not editable at all.

I also added optional flash messages for all available cases. That can be defined in relation config YAML file:
```
roles:
    manage:
        list: ...
        form: ...
        title:
            form: 
                create: Create new role
                update: Update this role
                preview: Preview of role
            list:
                add: Add existing role
                link: Link existing role
        flash:
            create: Created!
            update: Updated!
            delete: Deleted!
            add: Added!
            remove: Removed!
            link: Linked!
            unlink: Unlinked!
    pivot:
        form: ...
        title:
            create: Create new pivot
            update: Update existing pivot
            preview: Preview of pivot
```
Now developer has full control over titles and flashes management without using any hook.

**Todo**
- [x] implementation.
- [x] add example to [test-plugin](https://github.com/octoberrain/test-plugin/pull/90).
- [x] docs for this PR if accepted.
- add to docs that [toolbarButtons](https://octobercms.com/docs/backend/relations#configuring-relation) can be defined like array of `key => text label` too (Edit: Done by [DanHarrin on March](https://github.com/octobercms/docs/pull/444), but still not on website).
