### PR TITLE
Add max files option to fileupload

### DIFF
--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -65,6 +65,11 @@ class FileUpload extends FormWidgetBase
     public $maxFilesize;
 
     /**
+     * @var mixed Max files number.
+     */
+    public $maxFiles;
+
+    /**
      * @var array Options used for generating thumbnails.
      */
     public $thumbOptions = [
@@ -109,6 +114,7 @@ class FileUpload extends FormWidgetBase
             'imageHeight',
             'fileTypes',
             'maxFilesize',
+            'maxFiles',
             'mimeTypes',
             'thumbOptions',
             'useCaption',
@@ -159,6 +165,7 @@ class FileUpload extends FormWidgetBase
         $this->vars['cssDimensions'] = $this->getCssDimensions();
         $this->vars['cssBlockDimensions'] = $this->getCssDimensions('block');
         $this->vars['useCaption'] = $this->useCaption;
+        $this->vars['maxFiles'] = $this->maxFiles;
         $this->vars['prompt'] = $this->getPromptText();
     }
 

--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -65,7 +65,7 @@ class FileUpload extends FormWidgetBase
     public $maxFilesize;
 
     /**
-     * @var mixed Max files number.
+     * @var integer|null Max files number.
      */
     public $maxFiles;
 

--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -158,14 +158,14 @@ class FileUpload extends FormWidgetBase
         $this->vars['singleFile'] = $fileList->first();
         $this->vars['displayMode'] = $this->getDisplayMode();
         $this->vars['emptyIcon'] = $this->getConfig('emptyIcon', 'icon-upload');
-        $this->vars['imageHeight'] = $this->imageHeight;
-        $this->vars['imageWidth'] = $this->imageWidth;
+        $this->vars['imageHeight'] = (is_int($this->imageHeight)) ? $this->imageHeight : null;
+        $this->vars['imageWidth'] = (is_int($this->imageWidth)) ? $this->imageWidth : null;
         $this->vars['acceptedFileTypes'] = $this->getAcceptedFileTypes(true);
-        $this->vars['maxFilesize'] = $this->maxFilesize;
+        $this->vars['maxFilesize'] = (is_int($this->maxFilesize)) ? $this->maxFilesize : null;
         $this->vars['cssDimensions'] = $this->getCssDimensions();
         $this->vars['cssBlockDimensions'] = $this->getCssDimensions('block');
         $this->vars['useCaption'] = $this->useCaption;
-        $this->vars['maxFiles'] = $this->maxFiles;
+        $this->vars['maxFiles'] = (is_int($this->maxFiles)) ? $this->maxFiles : null;
         $this->vars['prompt'] = $this->getPromptText();
     }
 

--- a/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
+++ b/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
@@ -100,10 +100,17 @@
             paramName: this.options.paramName,
             clickable: this.$uploadButton.get(0),
             previewsContainer: this.$filesContainer.get(0),
-            maxFiles: !this.options.isMulti ? 1 : null,
             maxFilesize: this.options.maxFilesize,
             timeout: 0,
             headers: {}
+        }
+
+        if (!this.options.isMulti) {
+            this.uploaderOptions.maxFiles = 1
+        } else if (this.options.maxFiles) {
+            this.uploaderOptions.maxFiles = this.options.maxFiles
+        } else {
+            this.uploaderOptions.maxFiles = null
         }
 
         if (this.options.fileTypes) {

--- a/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
+++ b/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
@@ -102,8 +102,7 @@
             previewsContainer: this.$filesContainer.get(0),
             maxFilesize: this.options.maxFilesize,
             timeout: 0,
-            headers: {},
-            dictMaxFilesExceeded: 'backend::lang.fileupload.max_files_exceeded'
+            headers: {}
         }
 
         if (!this.options.isMulti) {

--- a/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
+++ b/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
@@ -34,7 +34,7 @@
     FileUpload.prototype = Object.create(BaseProto)
     FileUpload.prototype.constructor = FileUpload
 
-    FileUpload.prototype.init = function() {
+    FileUpload.prototype.init = function () {
         if (this.options.isMulti === null) {
             this.options.isMulti = this.$el.hasClass('is-multi')
         }
@@ -69,7 +69,7 @@
 
     }
 
-    FileUpload.prototype.dispose = function() {
+    FileUpload.prototype.dispose = function () {
 
         this.$el.off('click', '.upload-object.is-success', this.proxy(this.onClickSuccessObject))
         this.$el.off('click', '.upload-object.is-error', this.proxy(this.onClickErrorObject))
@@ -94,7 +94,7 @@
     // Uploading
     //
 
-    FileUpload.prototype.bindUploader = function() {
+    FileUpload.prototype.bindUploader = function () {
         this.uploaderOptions = {
             url: this.options.url,
             paramName: this.options.paramName,
@@ -102,7 +102,8 @@
             previewsContainer: this.$filesContainer.get(0),
             maxFilesize: this.options.maxFilesize,
             timeout: 0,
-            headers: {}
+            headers: {},
+            dictMaxFilesExceeded: 'backend::lang.fileupload.max_files_exceeded'
         }
 
         if (!this.options.isMulti) {
@@ -138,13 +139,43 @@
         }
 
         this.dropzone = new Dropzone(this.$el.get(0), this.uploaderOptions)
+
         this.dropzone.on('addedfile', this.proxy(this.onUploadAddedFile))
         this.dropzone.on('sending', this.proxy(this.onUploadSending))
         this.dropzone.on('success', this.proxy(this.onUploadSuccess))
         this.dropzone.on('error', this.proxy(this.onUploadError))
+        this.dropzone.on('maxfilesreached', this.proxy(this.removeEventListeners))
+        this.dropzone.on('removedfile', this.proxy(this.setupEventListeners))
+        this.loadAlreadyUploadedFiles()
     }
 
-    FileUpload.prototype.onResizeFileInfo = function(file) {
+    FileUpload.prototype.removeEventListeners = function () {
+        this.dropzone.removeEventListeners()
+    }
+
+    FileUpload.prototype.setupEventListeners = function () {
+        if (this.dropzone.files.length < this.dropzone.options.maxFiles) {
+            this.dropzone.setupEventListeners()
+        }
+    }
+
+    FileUpload.prototype.loadAlreadyUploadedFiles = function () {
+        var self = this
+
+        this.$el.find('.server-file').each(function () {
+            var file = $(this).data()
+
+            self.dropzone.files.push(file)
+            self.dropzone.emit('addedfile', file)
+            self.dropzone.emit('success', file, file)
+
+            $(this).remove()
+        })
+
+        self.dropzone._updateMaxFilesReachedClass()
+    }
+
+    FileUpload.prototype.onResizeFileInfo = function (file) {
         var info,
             targetWidth,
             targetHeight
@@ -193,12 +224,12 @@
         this.evalIsPopulated()
     }
 
-    FileUpload.prototype.onUploadSending = function(file, xhr, formData) {
+    FileUpload.prototype.onUploadSending = function (file, xhr, formData) {
         this.addExtraFormData(formData)
         xhr.setRequestHeader('X-OCTOBER-REQUEST-HANDLER', this.options.uploadHandler)
     }
 
-    FileUpload.prototype.onUploadSuccess = function(file, response) {
+    FileUpload.prototype.onUploadSuccess = function (file, response) {
         var $preview = $(file.previewElement),
             $img = $('.image img', $preview)
 
@@ -214,7 +245,7 @@
         this.triggerChange();
     }
 
-    FileUpload.prototype.onUploadError = function(file, error) {
+    FileUpload.prototype.onUploadError = function (file, error) {
         var $preview = $(file.previewElement)
         $preview.addClass('is-error')
     }
@@ -222,11 +253,11 @@
     /*
      * Trigger change event (Compatibility with october.form.js)
      */
-    FileUpload.prototype.triggerChange = function() {
+    FileUpload.prototype.triggerChange = function () {
         this.$el.closest('[data-field-name]').trigger('change.oc.formwidget')
     }
 
-    FileUpload.prototype.addExtraFormData = function(formData) {
+    FileUpload.prototype.addExtraFormData = function (formData) {
         if (this.options.extraData) {
             $.each(this.options.extraData, function (name, value) {
                 formData.append(name, value)
@@ -241,10 +272,10 @@
         }
     }
 
-    FileUpload.prototype.removeFileFromElement = function($element) {
+    FileUpload.prototype.removeFileFromElement = function ($element) {
         var self = this
 
-        $element.each(function() {
+        $element.each(function () {
             var $el = $(this),
                 obj = $el.data('dzFileObject')
 
@@ -261,7 +292,7 @@
     // Sorting
     //
 
-    FileUpload.prototype.bindSortable = function() {
+    FileUpload.prototype.bindSortable = function () {
         var
             self = this,
             placeholderEl = $('<div class="upload-object upload-placeholder"/>').css({
@@ -279,20 +310,19 @@
                 _super($item, container)
                 self.onSortAttachments()
             },
-            distance: 10
+                distance: 10
         })
     }
 
-    FileUpload.prototype.onSortAttachments = function() {
+    FileUpload.prototype.onSortAttachments = function () {
         if (this.options.sortHandler) {
-
             /*
              * Build an object of ID:ORDER
              */
             var orderData = {}
 
             this.$el.find('.upload-object.is-success')
-                .each(function(index){
+                .each(function (index) {
                     var id = $(this).data('id')
                     orderData[id] = index + 1
                 })
@@ -307,16 +337,16 @@
     // User interaction
     //
 
-    FileUpload.prototype.onRemoveObject = function(ev) {
+    FileUpload.prototype.onRemoveObject = function (ev) {
         var self = this,
             $object = $(ev.target).closest('.upload-object')
 
         $(ev.target)
             .closest('.upload-remove-button')
-            .one('ajaxPromise', function(){
+            .one('ajaxPromise', function () {
                 $object.addClass('is-loading')
             })
-            .one('ajaxDone', function(){
+            .one('ajaxDone', function () {
                 self.removeFileFromElement($object)
                 self.evalIsPopulated()
                 self.triggerChange()
@@ -329,7 +359,7 @@
     FileUpload.prototype.onClickSuccessObject = function(ev) {
         if ($(ev.target).closest('.meta').length) return
 
-        var $target = $(ev.target).closest('.upload-object')
+            var $target = $(ev.target).closest('.upload-object')
 
         if (!this.options.configHandler) {
             window.open($target.data('path'))
@@ -341,9 +371,9 @@
             extraData: { file_id: $target.data('id') }
         })
 
-        $target.one('popupComplete', function(event, element, modal){
+        $target.one('popupComplete', function (event, element, modal) {
 
-            modal.one('ajaxDone', 'button[type=submit]', function(e, context, data) {
+            modal.one('ajaxDone', 'button[type=submit]', function (e, context, data) {
                 if (data.displayName) {
                     $('[data-dz-name]', $target).text(data.displayName)
                 }
@@ -351,7 +381,7 @@
         })
     }
 
-    FileUpload.prototype.onClickErrorObject = function(ev) {
+    FileUpload.prototype.onClickErrorObject = function (ev) {
         var
             self = this,
             $target = $(ev.target).closest('.upload-object'),
@@ -373,7 +403,7 @@
         })
 
         var $container = $target.data('oc.popover').$container
-        $container.one('click', '[data-remove-file]', function() {
+        $container.one('click', '[data-remove-file]', function () {
             $target.data('oc.popover').hide()
             self.removeFileFromElement($target)
             self.evalIsPopulated()
@@ -384,7 +414,7 @@
     // Helpers
     //
 
-    FileUpload.prototype.evalIsPopulated = function() {
+    FileUpload.prototype.evalIsPopulated = function () {
         var isPopulated = !!$('.upload-object', this.$filesContainer).length
         this.$el.toggleClass('is-populated', isPopulated)
 
@@ -400,9 +430,9 @@
      */
     FileUpload.prototype.getFilesize = function (file) {
         var formatter = new Intl.NumberFormat('en', {
-                style: 'decimal',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
+            style: 'decimal',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
             }),
             size = 0,
             units = 'bytes'
@@ -458,8 +488,12 @@
             var $this   = $(this)
             var data    = $this.data('oc.fileUpload')
             var options = $.extend({}, FileUpload.DEFAULTS, $this.data(), typeof option == 'object' && option)
-            if (!data) $this.data('oc.fileUpload', (data = new FileUpload(this, options)))
-            if (typeof option == 'string') data[option].call($this)
+            if (!data) {
+                $this.data('oc.fileUpload', (data = new FileUpload(this, options)))
+                if (typeof option == 'string') {
+                    data[option].call($this)
+                }
+            }
         })
     }
 

--- a/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
+++ b/modules/backend/formwidgets/fileupload/assets/js/fileupload.js
@@ -309,7 +309,7 @@
                 _super($item, container)
                 self.onSortAttachments()
             },
-                distance: 10
+            distance: 10
         })
     }
 
@@ -429,9 +429,9 @@
      */
     FileUpload.prototype.getFilesize = function (file) {
         var formatter = new Intl.NumberFormat('en', {
-            style: 'decimal',
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
+                style: 'decimal',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
             }),
             size = 0,
             units = 'bytes'
@@ -487,12 +487,8 @@
             var $this   = $(this)
             var data    = $this.data('oc.fileUpload')
             var options = $.extend({}, FileUpload.DEFAULTS, $this.data(), typeof option == 'object' && option)
-            if (!data) {
-                $this.data('oc.fileUpload', (data = new FileUpload(this, options)))
-                if (typeof option == 'string') {
-                    data[option].call($this)
-                }
-            }
+            if (!data) $this.data('oc.fileUpload', (data = new FileUpload(this, options)))
+            if (typeof option == 'string') data[option].call($this)
         })
     }
 

--- a/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
@@ -9,6 +9,7 @@
     data-max-filesize="<?= $maxFilesize ?>"
     <?php if ($useCaption): ?>data-config-handler="<?= $this->getEventHandler('onLoadAttachmentConfig') ?>"<?php endif ?>
     <?php if ($acceptedFileTypes): ?>data-file-types="<?= $acceptedFileTypes ?>"<?php endif ?>
+    <?php if ($maxFiles): ?>data-max-files="<?= $maxFiles ?>"<?php endif ?>
     <?= $this->formField->getAttributes() ?>
 >
 

--- a/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
@@ -1,3 +1,4 @@
+<script src="../../../../../../october/modules/backend/formwidgets/fileupload/assets/js/fileupload.js"></script>
 <div
     id="<?= $this->getId() ?>"
     class="field-fileupload style-file-multi is-sortable is-multi <?= count($fileList) ? 'is-populated' : '' ?> <?= $this->previewMode ? 'is-preview' : '' ?>"
@@ -21,27 +22,14 @@
     <!-- Existing files -->
     <div class="upload-files-container">
         <?php foreach ($fileList as $file): ?>
-            <div class="upload-object is-success" data-id="<?= $file->id ?>" data-path="<?= $file->pathUrl ?>">
-                <div class="icon-container">
-                    <i class="icon-file"></i>
-                </div>
-                <div class="info">
-                    <h4 class="filename">
-                        <span data-dz-name><?= e($file->title ?: $file->file_name) ?></span>
-                        <a
-                            href="javascript:;"
-                            class="upload-remove-button"
-                            data-request="<?= $this->getEventHandler('onRemoveAttachment') ?>"
-                            data-request-confirm="<?= e(trans('backend::lang.fileupload.remove_confirm')) ?>"
-                            data-request-data="file_id: <?= $file->id ?>"
-                            ><i class="icon-times"></i></a>
-                    </h4>
-                    <p class="size"><?= e($file->sizeToString()) ?></p>
-                </div>
-                <div class="meta">
-                    <a href="javascript:;" class="drag-handle"><i class="icon-bars"></i></a>
-                </div>
-            </div>
+            <div class="server-file"
+                 data-id="<?= $file->id ?>"
+                 data-path="<?= $file->pathUrl ?>"
+                 data-thumb="<?= $file->thumbUrl ?>"
+                 data-name="<?= e($file->title ?: $file->file_name) ?>"
+                 data-size="<?= e($file->file_size) ?>"
+                 data-accepted="true"
+            ></div>
         <?php endforeach ?>
     </div>
 </div>

--- a/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_file_multi.htm
@@ -1,4 +1,3 @@
-<script src="../../../../../../october/modules/backend/formwidgets/fileupload/assets/js/fileupload.js"></script>
 <div
     id="<?= $this->getId() ?>"
     class="field-fileupload style-file-multi is-sortable is-multi <?= count($fileList) ? 'is-populated' : '' ?> <?= $this->previewMode ? 'is-preview' : '' ?>"

--- a/modules/backend/formwidgets/fileupload/partials/_image_multi.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_image_multi.htm
@@ -9,6 +9,7 @@
     data-max-filesize="<?= $maxFilesize ?>"
     <?php if ($useCaption): ?>data-config-handler="<?= $this->getEventHandler('onLoadAttachmentConfig') ?>"<?php endif ?>
     <?php if ($acceptedFileTypes): ?>data-file-types="<?= $acceptedFileTypes ?>"<?php endif ?>
+    <?php if ($maxFiles): ?>data-max-files="<?= $maxFiles ?>"<?php endif ?>
     <?= $this->formField->getAttributes() ?>
 >
 

--- a/modules/backend/formwidgets/fileupload/partials/_image_multi.htm
+++ b/modules/backend/formwidgets/fileupload/partials/_image_multi.htm
@@ -21,27 +21,14 @@
     <!-- Existing files -->
     <div class="upload-files-container">
         <?php foreach ($fileList as $file): ?>
-            <div class="upload-object is-success" data-id="<?= $file->id ?>" data-path="<?= $file->pathUrl ?>">
-                <div class="icon-container image">
-                    <img src="<?= $file->thumbUrl ?>" alt="" />
-                </div>
-                <div class="info">
-                    <h4 class="filename">
-                        <span data-dz-name><?= e($file->title ?: $file->file_name) ?></span>
-                        <a
-                            href="javascript:;"
-                            class="upload-remove-button"
-                            data-request="<?= $this->getEventHandler('onRemoveAttachment') ?>"
-                            data-request-confirm="<?= e(trans('backend::lang.fileupload.remove_confirm')) ?>"
-                            data-request-data="file_id: <?= $file->id ?>"
-                            ><i class="icon-times"></i></a>
-                    </h4>
-                    <p class="size"><?= e($file->sizeToString()) ?></p>
-                </div>
-                <div class="meta">
-                    <a href="javascript:;" class="drag-handle"><i class="icon-bars"></i></a>
-                </div>
-            </div>
+            <div class="server-file"
+                 data-id="<?= $file->id ?>"
+                 data-path="<?= $file->pathUrl ?>"
+                 data-thumb="<?= $file->thumbUrl ?>"
+                 data-name="<?= e($file->title ?: $file->file_name) ?>"
+                 data-size="<?= e($file->file_size) ?>"
+                 data-accepted="true"
+            ></div>
         <?php endforeach ?>
     </div>
 </div>


### PR DESCRIPTION
Hi,
this PR just gives the ability to limit the number of fileupload using the native DropZone.js option directly from the yaml:
```yaml
photos:
    label: Photos
    commentAbove: Maximum 3 files
    type: fileupload
    maxFiles: 3
```
render this when you try to upload more than 3 files:
![image](https://user-images.githubusercontent.com/53976837/99042129-8449a480-258c-11eb-9c9a-aa43c7f85ed6.png)
with an clear error message when you click on it:
![image](https://user-images.githubusercontent.com/53976837/99042150-8f9cd000-258c-11eb-869d-1863e435aeda.png)

I didn't find the way to translate the error message.
When switching to other language, the string `You can not upload any more files.` is not translated (I didn't expect it to of course). *If someone can tell me how to do* :+1: 

I'll update the doc when/if this PR is merged.