### PR TITLE
Add ability to configure whether or not backend users must be activated before they can login

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -36,4 +36,5 @@ return [
         'suspensionTime' => 15,
     ],
 
+    "requireActivation" => false,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -35,6 +35,13 @@ return [
          */
         'suspensionTime' => 15,
     ],
-
+    /*
+    |--------------------------------------------------------------------------
+    | Require activation
+    |--------------------------------------------------------------------------
+    |
+    | Toggle if a backend user needs to be activated before login.
+    |
+     */
     "requireActivation" => false,
 ];

--- a/modules/backend/classes/AuthManager.php
+++ b/modules/backend/classes/AuthManager.php
@@ -60,6 +60,7 @@ class AuthManager extends RainAuthManager
     protected function init()
     {
         $this->useThrottle = Config::get('auth.throttle.enabled', true);
+        $this->requireActivation = Config::get('auth.requireActivation', true);
         parent::init();
     }
 

--- a/modules/backend/classes/AuthManager.php
+++ b/modules/backend/classes/AuthManager.php
@@ -60,7 +60,7 @@ class AuthManager extends RainAuthManager
     protected function init()
     {
         $this->useThrottle = Config::get('auth.throttle.enabled', true);
-        $this->requireActivation = Config::get('auth.requireActivation', true);
+        $this->requireActivation = Config::get('auth.requireActivation', false);
         parent::init();
     }
 


### PR DESCRIPTION
The original activation function was half implemented. So I add an extra config option, and wire it into `AuthManager` initialization phase.

This change may open some other possible to further implement new functions like register as backend user, or create an alternative way to block certain user beside deleting the record.