### PR TITLE
Ensure that MediaLibrary::listAllDirectories() honors config for paths to ignore

### DIFF
--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -291,6 +291,10 @@ class MediaLibrary
             if (Str::startsWith($folder, $exclude)) {
                 continue;
             }
+            if (!$this->isVisible($folder)) {
+                $exclude[] = $folder . '/';
+                continue;
+            }
 
             $result[] = $folder;
         }

--- a/tests/unit/system/classes/MediaLibraryTest.php
+++ b/tests/unit/system/classes/MediaLibraryTest.php
@@ -1,9 +1,16 @@
 <?php
 
+use Illuminate\Filesystem\FilesystemAdapter;
 use System\Classes\MediaLibrary;
 
 class MediaLibraryTest extends TestCase // @codingStandardsIgnoreLine
 {
+    public function setUp(): void
+    {
+        MediaLibrary::forgetInstance();
+        parent::setUp();
+    }
+
     public function tearDown(): void
     {
         $this->removeMedia();
@@ -87,6 +94,33 @@ class MediaLibraryTest extends TestCase // @codingStandardsIgnoreLine
         $this->assertEquals('/text.txt', $contents[2]->path, 'Media library item does not have the right path');
         $this->assertNotEmpty($contents[2]->lastModified, 'Media library item last modified is empty');
         $this->assertNotEmpty($contents[2]->size, 'Media library item size is empty');
+    }
+
+    public function testListAllDirectories()
+    {
+        $disk = $this->createConfiguredMock(FilesystemAdapter::class, [
+            'allDirectories' => [
+                '/media/.ignore1',
+                '/media/.ignore2',
+                '/media/dir',
+                '/media/dir/sub',
+                '/media/exclude',
+                '/media/hidden',
+                '/media/hidden/sub1',
+                '/media/hidden/sub1/deep1',
+                '/media/hidden/sub2',
+                '/media/hidden but not really',
+                '/media/name'
+            ]
+        ]);
+
+        $this->app['config']->set('cms.storage.media.folder', 'media');
+        $this->app['config']->set('cms.storage.media.ignore', ['hidden']);
+        $this->app['config']->set('cms.storage.media.ignorePatterns', ['^\..*']);
+        $instance = MediaLibrary::instance();
+        $this->setProtectedProperty($instance, 'storageDisk', $disk);
+
+        $this->assertEquals(['/', '/dir', '/dir/sub', '/hidden but not really', '/name'], $instance->listAllDirectories(['/exclude']));
     }
 
     protected function setUpStorage()


### PR DESCRIPTION
The media library can be configured to ignore file names and patterns. However, when using the back-end media manager to move a file, every sub-directory in the media folder is listed as a possible destination regardless of configuration, which can be confusing for end users. This pull request aims to fix that and adds a test for correct behavior.