### PR TITLE
(feat) Repeater Index Placeholder

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -300,6 +300,13 @@ class Repeater extends FormWidgetBase
         $config->alias = $this->alias . 'Form' . $index;
         $config->arrayName = $this->getFieldName().'['.$index.']';
         $config->isNested = true;
+        $config->fields = array_map(function ($item) use ($index) {
+            if (!empty($item['label'])) {
+                $item['label'] = str_replace(':index', $index + 1, e(trans($item['label'])));
+            }
+            return $item;
+        }, $config->fields);
+
         if (self::$onAddItemCalled || $this->minItems > 0) {
             $config->enableDefaults = true;
         }


### PR DESCRIPTION
Added ability to specify an index in the repeater items label by specifying an :index placeholder in the string [as mentioned here](https://github.com/octobercms/october/issues/2986#issuecomment-737020996).