### PR TITLE
Take extension from options into account

### DIFF
--- a/modules/system/classes/ImageResizer.php
+++ b/modules/system/classes/ImageResizer.php
@@ -381,7 +381,7 @@ class ImageResizer
      */
     public function getExtension()
     {
-        return FileHelper::extension($this->image['path']);
+        return array_get($this->options, 'extension', FileHelper::extension($this->image['path']));
     }
 
     /**

--- a/tests/unit/system/classes/ImageResizerTest.php
+++ b/tests/unit/system/classes/ImageResizerTest.php
@@ -335,6 +335,22 @@ class ImageResizerTest extends PluginTestCase
         $this->assertStringContainsString('october%20space', $imageResizer->getResizedUrl(), 'Resized URLs are not properly URL encoded');
     }
 
+    public function testGetExtension()
+    {
+        $imageResizer = new ImageResizer(
+            (new CmsController())->themeUrl('assets/images/october.png'),
+            150,
+            120,
+            [
+                'extension' => 'jpg',
+            ]
+        );
+        $localTempPath = $this->callProtectedMethod($imageResizer, 'getLocalTempPath');
+
+        $this->assertTrue(ends_with($localTempPath, '.jpg'));
+        $this->assertEquals($imageResizer->getExtension(), 'jpg');
+    }
+
     protected function setUpStorage()
     {
         $this->app->useStoragePath(base_path('storage/temp'));


### PR DESCRIPTION
Without this, the temporary path given to the resizer does not contain the extension provided in $options['extension'] which prevents the resizer from converting to the new image type.