### PR TITLE
Add support for jsonable fields

### DIFF
--- a/modules/backend/formwidgets/CodeEditor.php
+++ b/modules/backend/formwidgets/CodeEditor.php
@@ -215,4 +215,28 @@ class CodeEditor extends FormWidgetBase
         $this->displayIndentGuides = $preferences->editor_display_indent_guides;
         $this->showPrintMargin = $preferences->editor_show_print_margin;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLoadValue()
+    {
+        if ($this->model->isJsonable($this->fieldName)) {
+            return json_encode($this->formField->value, JSON_PRETTY_PRINT);
+        }
+
+        return parent::getLoadValue();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSaveValue($value)
+    {
+        if ($this->model->isJsonable($this->fieldName)) {
+            return json_decode($value);
+        }
+
+        return parent::getSaveValue($value);
+    }
 }


### PR DESCRIPTION
Our code editor form widget currently does not support jsonable fields. This seems like a pretty expected use case for the widget, so I've extended it to check if the field is jsonable. If so, the value will be encoded/decoded upon read/write.

I considered doing this commit a bit higher up in the `FormWidgetBase`, but decided against it because the use case for editing jsonable fields is pretty narrow, and I figured this would be easier to merge.

### Steps to reproduce

1. Create a model with a [jsonable field](https://octobercms.com/docs/database/model#property-jsonable)
2. Create a backend form with a [code editor form widget](https://octobercms.com/docs/backend/forms#widget-codeeditor) on the jsonable field

### Expected result

I should be able to use the code editor to modify the raw json.

### Actual result

<img width="1076" alt="Screen Shot 2020-12-04 at 11 52 35 PM" src="https://user-images.githubusercontent.com/7980426/101236158-132d7680-368c-11eb-8b02-4137bb38f165.png">

### Fixed result

<img width="1440" alt="Screen Shot 2020-12-05 at 12 02 01 AM" src="https://user-images.githubusercontent.com/7980426/101236283-2ee54c80-368d-11eb-8ece-11888449085c.png">
