### PR TITLE
Add extra features to menus

### DIFF
--- a/modules/backend/classes/MainMenuItem.php
+++ b/modules/backend/classes/MainMenuItem.php
@@ -70,6 +70,16 @@ class MainMenuItem
     public $sideMenu = [];
 
     /**
+     * @var Skeywords[]
+     */
+    public $keywords = [];
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
      * @param string $permission
      * @param array $definition
      */
@@ -126,6 +136,8 @@ class MainMenuItem
         $instance->badge = $data['badge'] ?? null;
         $instance->permissions = $data['permissions'] ?? $instance->permissions;
         $instance->order = $data['order'] ?? $instance->order;
+        $instance->keywords = $data['keywords'] ?? null;
+        $instance->description = $data['description'] ?? null;
         return $instance;
     }
 }

--- a/modules/backend/classes/NavigationManager.php
+++ b/modules/backend/classes/NavigationManager.php
@@ -183,6 +183,8 @@ class NavigationManager
      * - counter - an optional numeric value to output near the menu icon. The value should be
      *   a number or a callable returning a number.
      * - counterLabel - an optional string value to describe the numeric reference in counter.
+     * - keywords - an array used to search for the menu, optional.
+     * - description - a string used to give a brief summary, optional.
      * - sideMenu - an array of side menu items, optional. If provided, the array items
      *   should represent the side menu item code, and each value should be an associative
      *   array with the following keys:
@@ -196,6 +198,9 @@ class NavigationManager
      *      - counterLabel - an optional string value to describe the numeric reference in counter.
      *      - badge - an optional string value to output near the menu icon. The value should be
      *        a string. This value will override the counter if set.
+     *      - keywords - an array used to search for the side menu, optional.
+     *      - description - a string used to give a brief summary for the sidebar entry, optional.
+     *      - group - a string used to group several side menu entries under a single header, optional.
      * @param string $owner Specifies the menu items owner plugin or module in the format Author.Plugin.
      * @param array $definitions An array of the menu item definitions.
      * @throws SystemException
@@ -205,10 +210,14 @@ class NavigationManager
         $validator = Validator::make($definitions, [
             '*.label' => 'required',
             '*.icon' => 'required_without:*.iconSvg',
-            '*.url' => 'required',
+            '*.keywords' => 'nullable|array',
+            '*.description' => 'nullable|string|max:250',
             '*.sideMenu.*.label' => 'nullable|required',
             '*.sideMenu.*.icon' => 'nullable|required_without:*.sideMenu.*.iconSvg',
             '*.sideMenu.*.url' => 'nullable|required',
+            '*.sideMenu.*.keywords' => 'nullable|array',
+            '*.sideMenu.*.description' => 'nullable|string|max:250',
+            '*.sideMenu.*.group' => 'nullable|string|max:250',
         ]);
 
         if ($validator->fails()) {
@@ -479,6 +488,9 @@ class NavigationManager
      * - permissions - an array of permissions the back-end user should have, optional.
      *   The item will be displayed if the user has any of the specified permissions.
      * - order - a position of the item in the menu, optional.
+     * - keywords - an array used to search for the menu, optional.
+     * - description - a string used to give a brief summary, optional.
+     * - group - a string used to group several quick action entries under a single header, optional.
      *
      * @param string $owner Specifies the quick action items owner plugin or module in the format Author.Plugin.
      * @param array $definitions An array of the quick action item definitions.
@@ -490,7 +502,9 @@ class NavigationManager
         $validator = Validator::make($definitions, [
             '*.label' => 'required',
             '*.icon' => 'required_without:*.iconSvg',
-            '*.url' => 'required'
+            '*.url' => 'required',
+            '*.keywords' => 'nullable|array',
+            '*.description' => 'nullable|string|max:250',
         ]);
 
         if ($validator->fails()) {

--- a/modules/backend/classes/QuickActionItem.php
+++ b/modules/backend/classes/QuickActionItem.php
@@ -53,6 +53,21 @@ class QuickActionItem
     public $permissions = [];
 
     /**
+     * @var Skeywords[]
+     */
+    public $keywords = [];
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var string
+     */
+    public $group;
+
+    /**
      * @param null|string|int $attribute
      * @param null|string|array $value
      */
@@ -100,6 +115,9 @@ class QuickActionItem
         $instance->attributes = $data['attributes'] ?? $instance->attributes;
         $instance->permissions = $data['permissions'] ?? $instance->permissions;
         $instance->order = $data['order'] ?? $instance->order;
+        $instance->keywords = $data['keywords'] ?? null;
+        $instance->description = $data['description'] ?? null;
+        $instance->group = $data['group'] ?? null;
         return $instance;
     }
 }

--- a/modules/backend/classes/SideMenuItem.php
+++ b/modules/backend/classes/SideMenuItem.php
@@ -68,6 +68,21 @@ class SideMenuItem
     public $permissions = [];
 
     /**
+     * @var Skeywords[]
+     */
+    public $keywords = [];
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var string
+     */
+    public $group;
+    
+    /**
      * @param null|string|int $attribute
      * @param null|string|array $value
      */
@@ -118,6 +133,9 @@ class SideMenuItem
         $instance->badge = $data['badge'] ?? null;
         $instance->permissions = $data['permissions'] ?? $instance->permissions;
         $instance->order = $data['order'] ?? $instance->order;
+        $instance->keywords = $data['keywords'] ?? null;
+        $instance->description = $data['description'] ?? null;
+        $instance->group = $data['group'] ?? null;
         return $instance;
     }
 }


### PR DESCRIPTION
Here's an example:

```php
    public function registerNavigation()
    {
        return [
            'example' => [
                'label'       => 'Title',
                'url'         => Backend::url('acme/example/start'),
                'icon'        => 'oc-smile',
                'iconSvg'     => 'plugins/acme/example/assets/img/icon.svg',
                'permissions' => ['acme.example.*'],
                'order'       => 10,
                'keywords'    => ['translate', 'content', 'language'],
                'description' => 'Enables multi-lingual websites and translate website contents',

                'sideMenu' => [
                    'one' => [
                        'label'       => 'Title 1',
                        'iconSvg'     => 'plugins/acme/example/assets/img/icon1.svg',
                        'url'         => Backend::url('acme/example/one'),
                        'permissions' => ['acme.example.one'],
                        'keywords'    => ['translate', 'locale', 'prefixes'],
                        'description' => 'Adds locale route prefixes.',
                        'group'       => 'translate',
                        'order'       => 20,
                    ],
                    'two' => [
                        'label'       => 'Title 2',
                        'iconSvg'     => 'plugins/acme/example/assets/img/icon2.svg',
                        'url'         => Backend::url('acme/example/two'),
                        'permissions' => ['acme.example.two'],
                        'keywords'    => ['translate', 'tabs'],
                        'description' => 'Adds translatable tabs.',
                        'group'       => 'translate',
                        'order'       => 30,
                    ]
                ]
            ]
        ];
    }
```

## Advantages of adding these new features to the menus

### Targeted Plugin Recommendations

See screenshot of current setup:

![image](https://user-images.githubusercontent.com/57409060/101290546-f06da000-37fa-11eb-88c8-463ceb85e5d5.png)

The list of plugins is pretty poor and NOT TARGETED! By adding `keywords` to plugin menus we can now give a more targeted list of recommendations based off what the end-user has previous downloaded and comparing it to related `keywords`.

### Search Side Menus

Again by adding `keywords` we can search for the exact sub-menu page.

### Sub-menu groups

Currently this feature is setup only in the settings page and not for the rest of the cms, below is an example screenshot:

![image](https://user-images.githubusercontent.com/57409060/101290659-9d481d00-37fb-11eb-9f85-75b6cd6ea804.png)

Above: Three entries grouped under the heading **SYSTEM**.

By adding `group` we can group several sub-menu entries under a single header. A useful feature for developers to organize menu entries better.

### Descriptions

Currently this feature is setup only in the settings page and not for the rest of the cms, below is an example screenshot:

![image](https://user-images.githubusercontent.com/57409060/101290709-f87a0f80-37fb-11eb-875e-f64b07c856e1.png)

By adding `description` we can give the end-users a bit more information about the menu option.

### Other examples

Could go on and on,... but hopefully I pushed my case across to add these extra properties to the api's.

### Testing

I tested the attached code in v1.1.1 and saw it working through various api's listed in the `NavigationManager`, I tested the rest of the cms and saw no conflicts, I tested a working menu fine with these new properties and I tested other menu's that don't contain these properties - no conflicts were found.

### This pr also fixes these issues

- https://github.com/octobercms/october/issues/5214 (requested to add `group` property).

---

Fingers crossed to get added - hard to please all the admins 💯 

Maybe this will help:

![image](https://user-images.githubusercontent.com/57409060/101386176-b3fe7a80-38b4-11eb-8414-409d7d8703e7.png)
