### PR TITLE
Register plugin after installation

### DIFF
--- a/modules/system/console/PluginInstall.php
+++ b/modules/system/console/PluginInstall.php
@@ -49,13 +49,17 @@ class PluginInstall extends Command
         $manager->extractPlugin($code, $hash);
 
         /*
-         * Migrate plugin
+         * Make sure plugin is registered
          */
-        $this->output->writeln(sprintf('<info>Migrating plugin...</info>', $code));
         $pluginManager = PluginManager::instance();
         $pluginManager->loadPlugins();
         $plugin = $pluginManager->findByIdentifier($code);
         $pluginManager->registerPlugin($plugin, $code);
+
+        /*
+         * Migrate plugin
+         */
+        $this->output->writeln(sprintf('<info>Migrating plugin...</info>', $code));
         $manager->updatePlugin($code);
     }
 

--- a/modules/system/console/PluginInstall.php
+++ b/modules/system/console/PluginInstall.php
@@ -52,7 +52,10 @@ class PluginInstall extends Command
          * Migrate plugin
          */
         $this->output->writeln(sprintf('<info>Migrating plugin...</info>', $code));
-        PluginManager::instance()->loadPlugins();
+        $pluginManager = PluginManager::instance();
+        $pluginManager->loadPlugins();
+        $plugin = $pluginManager->findByIdentifier($code);
+        $pluginManager->registerPlugin($plugin, $code);
         $manager->updatePlugin($code);
     }
 


### PR DESCRIPTION
Without this, the plugin is not registered and its migrations won't run properly if there are external dependencies.