### PR TITLE
Component's title hangs out of container due to styling error

### DIFF
--- a/modules/cms/assets/css/october.components.css
+++ b/modules/cms/assets/css/october.components.css
@@ -77,7 +77,6 @@ div.control-componentlist div.components div.layout-cell > div span {
 .draggable-component-item > div span.name,
 .component-list .components div.layout-cell > div span.name,
 div.control-componentlist div.components div.layout-cell > div span.name {
-  white-space: nowrap;
   padding: 8px 15px 0;
   font-weight: 400;
   line-height: 20px;

--- a/modules/cms/assets/less/october.components.less
+++ b/modules/cms/assets/less/october.components.less
@@ -77,7 +77,6 @@ div.control-componentlist div.components div.layout-cell {
             display: block;
 
             &.name {
-                white-space: nowrap;
                 padding: 8px 15px 0;
                 font-weight: 400;
                 line-height: 20px;


### PR DESCRIPTION
Fix GitHub issue: #5368

![image](https://user-images.githubusercontent.com/57409060/101537314-29d91380-3993-11eb-9888-e15e28d443db.png)

@LukeTowers 