### PR TITLE
Lists widget relation column's ordering proposal

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -499,8 +499,14 @@ class Lists extends WidgetBase
                 $relationObj = $this->model->{$column->relation}();
                 $countQuery = $relationObj->getRelationExistenceQuery($relationObj->getRelated()->newQueryWithoutScopes(), $query);
 
+                $sqlOrder = null;
+                foreach($relationObj->getBaseQuery()->orders ?? [] as $order) {
+                    $sqlOrder[] = $order['column'] . ' ' . $order['direction'];
+                }
+                if (!empty($sqlOrder)) $sqlOrder = ' order by ' . implode(' ', $sqlOrder);
+
                 $joinSql = $this->isColumnRelated($column, true)
-                    ? DbDongle::raw("group_concat(" . $sqlSelect . " separator ', ')")
+                    ? DbDongle::raw("group_concat(" . $sqlSelect . $sqlOrder . " separator ', ')")
                     : DbDongle::raw($sqlSelect);
 
                 $joinSql = $countQuery->select($joinSql)->toSql();


### PR DESCRIPTION
This PR is proposal of Lists widget relation column's ordering.
When relation column is used in Lists widget, and relation is 1:N/M:N, values of selected column are joined by separator, but in undefined order. This PR uses relation's predefined ordering, if set.

I am not sure if I found the best way to achieve my goal, every help or comment is welcome.