### PR TITLE
Allow third-party icons in October components

### DIFF
--- a/modules/cms/assets/css/october.components.css
+++ b/modules/cms/assets/css/october.components.css
@@ -198,7 +198,15 @@ div.control-componentlist div.components div.layout-cell > div.popover-highlight
   display: none;
 }
 div.control-componentlist div.components div.layout-cell > div span.name {
-  padding-right: 20px;
+  padding: 8px 20px 0 38px;
+}
+div.control-componentlist div.components div.layout-cell > div span.name i {
+  position: absolute;
+  font-size: 16px;
+  left: 15px;
+  top: 10px;
+  opacity: 0.7;
+  filter: alpha(opacity=70);
 }
 div.control-componentlist div.components div.layout-cell > div span.description {
   padding-bottom: 35px;

--- a/modules/cms/assets/css/october.components.css
+++ b/modules/cms/assets/css/october.components.css
@@ -198,7 +198,7 @@ div.control-componentlist div.components div.layout-cell > div.popover-highlight
   display: none;
 }
 div.control-componentlist div.components div.layout-cell > div span.name {
-  padding-left: 38px;
+  padding-right: 20px;
 }
 div.control-componentlist div.components div.layout-cell > div span.description {
   padding-bottom: 35px;

--- a/modules/cms/assets/css/october.components.css
+++ b/modules/cms/assets/css/october.components.css
@@ -22,16 +22,6 @@ div.control-componentlist div.components div.layout-cell > div {
   position: relative;
   border-right: 1px solid #ecf0f1;
 }
-.draggable-component-item > div:before,
-.component-list .components div.layout-cell > div:before,
-div.control-componentlist div.components div.layout-cell > div:before {
-  position: absolute;
-  font-size: 16px;
-  left: 15px;
-  top: 7px;
-  opacity: 0.7;
-  filter: alpha(opacity=70);
-}
 .draggable-component-item > div:hover,
 .component-list .components div.layout-cell > div:hover,
 div.control-componentlist div.components div.layout-cell > div:hover {

--- a/modules/cms/assets/less/october.components.less
+++ b/modules/cms/assets/less/october.components.less
@@ -49,14 +49,6 @@ div.control-componentlist div.components div.layout-cell {
         position: relative;
         border-right: 1px solid @color-panel-light;
 
-        &:before {
-            position: absolute;
-            font-size: 16px;
-            left: 15px;
-            top: 7px;
-            .opacity(0.7);
-        }
-
         &:hover {
             color: @color-component-hover-text;
             &:before {

--- a/modules/cms/assets/less/october.components.less
+++ b/modules/cms/assets/less/october.components.less
@@ -84,6 +84,14 @@ div.control-componentlist div.components div.layout-cell {
                 font-size: @font-size-base - 1;
             }
 
+            i {
+			    position: absolute;
+				font-size: 16px;
+				left: 15px;
+				top: 10px;
+				.opacity(0.7);
+            }
+
             &.description {
                 padding: 0 15px 10px;
                 margin-top: 8px;
@@ -214,7 +222,7 @@ div.control-componentlist {
 
                 span {
                     &.name {
-                        padding-right: 20px;
+                        padding: 8px 20px 0 38px;
                     }
 
                     &.description {

--- a/modules/cms/assets/less/october.components.less
+++ b/modules/cms/assets/less/october.components.less
@@ -214,7 +214,7 @@ div.control-componentlist {
 
                 span {
                     &.name {
-                        padding-left: 38px;
+                        padding-right: 20px;
                     }
 
                     &.description {

--- a/modules/cms/formwidgets/components/partials/_component.htm
+++ b/modules/cms/formwidgets/components/partials/_component.htm
@@ -6,7 +6,7 @@
         data-inspector-description="<?= $description = e($this->getComponentDescription($component)) ?>"
         data-inspector-config="<?= e($this->getComponentsPropertyConfig($component)) ?>"
         data-inspector-class="<?= get_class($component) ?>">
-            <span class="name"><i class="<?= $component->pluginIcon ?>"></i> <?= $name ?></span>
+            <span class="name"><i class="<?= e(str_replace('oc-', '', $component->pluginIcon)) ?>"></i> <?= $name ?></span>
             <span class="description"><?= $description ?></span>
             <span class="alias oc-icon-code"><?= e($component->alias) ?></span>
             <input type="hidden" name="component_properties[]" data-inspector-values value="<?= e($this->getComponentPropertyValues($component)) ?>" />

--- a/modules/cms/formwidgets/components/partials/_component.htm
+++ b/modules/cms/formwidgets/components/partials/_component.htm
@@ -6,7 +6,7 @@
         data-inspector-description="<?= $description = e($this->getComponentDescription($component)) ?>"
         data-inspector-config="<?= e($this->getComponentsPropertyConfig($component)) ?>"
         data-inspector-class="<?= get_class($component) ?>">
-            <span class="name"><i class="<?= e(preg_replace('/^oc\-/', '', $component->pluginIcon)) ?>"></i> <?= $name ?></span>
+            <span class="name"><i class="<?= e($component->pluginIcon) ?>"></i> <?= $name ?></span>
             <span class="description"><?= $description ?></span>
             <span class="alias oc-icon-code"><?= e($component->alias) ?></span>
             <input type="hidden" name="component_properties[]" data-inspector-values value="<?= e($this->getComponentPropertyValues($component)) ?>" />

--- a/modules/cms/formwidgets/components/partials/_component.htm
+++ b/modules/cms/formwidgets/components/partials/_component.htm
@@ -6,7 +6,7 @@
         data-inspector-description="<?= $description = e($this->getComponentDescription($component)) ?>"
         data-inspector-config="<?= e($this->getComponentsPropertyConfig($component)) ?>"
         data-inspector-class="<?= get_class($component) ?>">
-            <span class="name"><i class="<?= e($component->componentCssClass) ?>"></i> <?= $name ?></span>
+            <span class="name"><i class="<?= $component->pluginIcon ?>"></i> <?= $name ?></span>
             <span class="description"><?= $description ?></span>
             <span class="alias oc-icon-code"><?= e($component->alias) ?></span>
             <input type="hidden" name="component_properties[]" data-inspector-values value="<?= e($this->getComponentPropertyValues($component)) ?>" />

--- a/modules/cms/formwidgets/components/partials/_component.htm
+++ b/modules/cms/formwidgets/components/partials/_component.htm
@@ -6,7 +6,7 @@
         data-inspector-description="<?= $description = e($this->getComponentDescription($component)) ?>"
         data-inspector-config="<?= e($this->getComponentsPropertyConfig($component)) ?>"
         data-inspector-class="<?= get_class($component) ?>">
-            <span class="name"><i class="<?= e(str_replace('oc-', '', $component->pluginIcon)) ?>"></i> <?= $name ?></span>
+            <span class="name"><i class="<?= e(preg_replace('/^oc\-/', '', $component->pluginIcon)) ?>"></i> <?= $name ?></span>
             <span class="description"><?= $description ?></span>
             <span class="alias oc-icon-code"><?= e($component->alias) ?></span>
             <input type="hidden" name="component_properties[]" data-inspector-values value="<?= e($this->getComponentPropertyValues($component)) ?>" />

--- a/modules/cms/formwidgets/components/partials/_component.htm
+++ b/modules/cms/formwidgets/components/partials/_component.htm
@@ -1,12 +1,12 @@
 <div class="layout-cell <?= e($component->componentCssClass) ?> <?= $component->isHidden ? 'hidden' : null ?>">
     <div
-        class="<?= 'oc-'.$component->pluginIcon ?> layout-relative"
+        class="layout-relative"
         <?php if ($component->inspectorEnabled): ?>data-inspectable<?php endif ?>
         data-inspector-title="<?= $name = e($this->getComponentName($component)) ?>"
         data-inspector-description="<?= $description = e($this->getComponentDescription($component)) ?>"
         data-inspector-config="<?= e($this->getComponentsPropertyConfig($component)) ?>"
         data-inspector-class="<?= get_class($component) ?>">
-            <span class="name"><?= $name ?></span>
+            <span class="name"><i class="<?= e($component->componentCssClass) ?>"></i> <?= $name ?></span>
             <span class="description"><?= $description ?></span>
             <span class="alias oc-icon-code"><?= e($component->alias) ?></span>
             <input type="hidden" name="component_properties[]" data-inspector-values value="<?= e($this->getComponentPropertyValues($component)) ?>" />


### PR DESCRIPTION
Relates to this github issue: https://github.com/octobercms/october/issues/5428

![image](https://user-images.githubusercontent.com/57409060/103097139-32218780-45fe-11eb-8e0d-eb3ad25052ba.png)

I'm using font-awesome 6 icons in my plugins, with this pr. I see no problems in the main navigation bar, sidebar menu, cms page sidebar component list, adding components to pages etc and viewing components list in the builder plugin.

Happy days!
