### PR TITLE
Update CONTRIBUTING to explain about js complier assets

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To help us merge your Pull Request, please make sure you follow these points:
 
 - Describe the problem clearly in the Pull Request description
 - Please make your fix on the `develop` branch. This makes merging much easier.
-- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For October CMS javascript files edit the **non-minified** and **non-combined versions**. For third-party vendor files you should update both the **.min** and **non-min** versions. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
+- Do not edit compiled core asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js`, etc. directly. Instead, edit the LESS files inside the `less/` directory  if you wish to update the styles. For October CMS JavaScript files, edit the **non-minified** and **non-combined versions**. For third-party vendor files, you should update both the **.min** and **non-min** versions. Afterwards, run `php artisan october:util compile assets` from the project root to compile all assets and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
 - For any change that you make, **please also add a test case(s)** in the `tests/unit` directory. This helps us understand the issue and make sure that it will stay fixed forever.
 
 Thank you for your contributions!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To help us merge your Pull Request, please make sure you follow these points:
 
 - Describe the problem clearly in the Pull Request description
 - Please make your fix on the `develop` branch. This makes merging much easier.
-- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For javascript files edit the **non-minified** and **non-combined versions**. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
+- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For October CMS javascript files edit the **non-minified** and **non-combined versions**. For third-party vendor files edit both the **.min** and **.non-min** versions. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
 - For any change that you make, **please also add a test case(s)** in the `tests/unit` directory. This helps us understand the issue and make sure that it will stay fixed forever.
 
 Thank you for your contributions!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To help us merge your Pull Request, please make sure you follow these points:
 
 - Describe the problem clearly in the Pull Request description
 - Please make your fix on the `develop` branch. This makes merging much easier.
-- Do not edit compiled asset files such as `october.css`, `framework.css`, etc. directly. Instead, edit the LESS files inside the `less/` directory and then run `php artisan october:util compile assets` from the project root and commit the changed LESS files as well as the recompiled asset files.
+ - Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For javascript files edit the **non-minified** and **non-combined versions**. Then run `php artisan october:util compile assets` from the project root and commit the changes including the recompiled asset files from the artisan command. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
 - For any change that you make, **please also add a test case(s)** in the `tests/unit` directory. This helps us understand the issue and make sure that it will stay fixed forever.
 
 Thank you for your contributions!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To help us merge your Pull Request, please make sure you follow these points:
 
 - Describe the problem clearly in the Pull Request description
 - Please make your fix on the `develop` branch. This makes merging much easier.
- - Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For javascript files edit the **non-minified** and **non-combined versions**. Then run `php artisan october:util compile assets` from the project root and commit the changes including the recompiled asset files from the artisan command. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
+- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For javascript files edit the **non-minified** and **non-combined versions**. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
 - For any change that you make, **please also add a test case(s)** in the `tests/unit` directory. This helps us understand the issue and make sure that it will stay fixed forever.
 
 Thank you for your contributions!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To help us merge your Pull Request, please make sure you follow these points:
 
 - Describe the problem clearly in the Pull Request description
 - Please make your fix on the `develop` branch. This makes merging much easier.
-- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For October CMS javascript files edit the **non-minified** and **non-combined versions**. For third-party vendor files edit both the **.min** and **non-min** versions. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
+- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For October CMS javascript files edit the **non-minified** and **non-combined versions**. For third-party vendor files you should update both the **.min** and **non-min** versions. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
 - For any change that you make, **please also add a test case(s)** in the `tests/unit` directory. This helps us understand the issue and make sure that it will stay fixed forever.
 
 Thank you for your contributions!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To help us merge your Pull Request, please make sure you follow these points:
 
 - Describe the problem clearly in the Pull Request description
 - Please make your fix on the `develop` branch. This makes merging much easier.
-- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For October CMS javascript files edit the **non-minified** and **non-combined versions**. For third-party vendor files edit both the **.min** and **.non-min** versions. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
+- Do not edit compiled asset files such as `october.css`, `storm.js`, `framework.css`, `framework.combined.js`, `framework-min.js` etc. directly. Instead, edit the LESS files inside the `less/` directory for updating the styles. For October CMS javascript files edit the **non-minified** and **non-combined versions**. For third-party vendor files edit both the **.min** and **non-min** versions. Then run `php artisan october:util compile assets` from the project root and commit the changes. For a full list of commands see the documentation here: https://octobercms.com/docs/console/commands#october-util-command
 - For any change that you make, **please also add a test case(s)** in the `tests/unit` directory. This helps us understand the issue and make sure that it will stay fixed forever.
 
 Thank you for your contributions!


### PR DESCRIPTION
I have updated code line 82 as it talks only about compiling css/less files and doesn't mention js files.

Linked to discussion here: https://github.com/octobercms/october/discussions/5427
 