### PR TITLE
Add warning on Backend login page when using Internet Explorer

### DIFF
--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -67,6 +67,10 @@ class ServiceProvider extends ModuleServiceProvider
     {
         CombineAssets::registerCallback(function ($combiner) {
             $combiner->registerBundle('~/modules/backend/assets/less/october.less');
+            $combiner->registerBundle(
+                '~/modules/backend/assets/less/auth/auth.less',
+                '~/modules/backend/assets/css/auth/auth.css'
+            );
             $combiner->registerBundle('~/modules/backend/assets/js/october.js');
             $combiner->registerBundle('~/modules/backend/widgets/table/assets/js/build.js');
             $combiner->registerBundle('~/modules/backend/widgets/mediamanager/assets/js/mediamanager-browser.js');

--- a/modules/backend/assets/css/auth/auth.css
+++ b/modules/backend/assets/css/auth/auth.css
@@ -1,0 +1,1 @@
+.ie-warning {width:90%;max-width:400px;margin:0 auto}

--- a/modules/backend/assets/js/auth/auth.js
+++ b/modules/backend/assets/js/auth/auth.js
@@ -7,7 +7,7 @@ $(document).ready(function(){
      * Show message if user is using Internet Explorer, by detecting if the IE-only "documentMode" attribute is within
      * the document object.
      */
-    // if (window.document.documentMode) {
+    if (window.document.documentMode) {
         $('div.ie-warning').show();
-    // }
+    }
 })

--- a/modules/backend/assets/js/auth/auth.js
+++ b/modules/backend/assets/js/auth/auth.js
@@ -2,4 +2,12 @@ $(document).ready(function(){
     $(document.body).removeClass('preload')
 
     $('form input[type=text], form input[type=password]').first().focus()
+
+    /**
+     * Show message if user is using Internet Explorer, by detecting if the IE-only "documentMode" attribute is within
+     * the document object.
+     */
+    // if (window.document.documentMode) {
+        $('div.ie-warning').show();
+    // }
 })

--- a/modules/backend/assets/less/auth/auth.less
+++ b/modules/backend/assets/less/auth/auth.less
@@ -1,0 +1,7 @@
+@import "../../../../backend/assets/less/core/boot.less";
+
+.ie-warning {
+    width: 90%;
+    max-width: 400px;
+    margin: 0 auto;
+}

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -4,6 +4,10 @@ return [
     'auth' => [
         'title' => 'Administration Area',
         'invalid_login' => 'The details you entered did not match our records. Please double-check and try again.',
+        'ie_warning' => [
+            'title' => 'Unsupported Browser',
+            'body' => 'Internet Explorer is no longer supported. You may experience issues when using the Backend. Please upgrade to the Microsoft Edge web browser as soon as possible.',
+        ],
     ],
     'field' => [
         'invalid_type' => 'Invalid field type used :type.',

--- a/modules/backend/layouts/auth.htm
+++ b/modules/backend/layouts/auth.htm
@@ -15,6 +15,7 @@
             $styles = [
                 Url::asset('modules/system/assets/ui/storm.css'),
                 Backend::skinAsset('assets/css/october.css'),
+                Backend::skinAsset('assets/css/auth/auth.css'),
             ];
             $scripts = [
                 Backend::skinAsset('assets/js/vendor/jquery.min.js'),
@@ -68,6 +69,15 @@
                 <div class="layout-row min-size layout-head">
                     <div class="layout-cell">
                         <h1 class="oc-logo"><?= e(Backend\Models\BrandSetting::get('app_name')) ?></h1>
+
+                        <div class="ie-warning callout fade in callout-danger no-icon" style="display: none;">
+                            <div class="header">
+                                <h3><?= e(Lang::get('backend::lang.auth.ie_warning.title')) ?></h3>
+                            </div>
+                            <div class="content">
+                                <p><?= e(Lang::get('backend::lang.auth.ie_warning.body')) ?></p>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="layout-row">


### PR DESCRIPTION
As per the discussion in https://github.com/octobercms/october/discussions/5439, the community has voiced in favour of dropping support for Internet Explorer in the Backend. If we decide to go ahead with this, this PR will display a warning message on the front page for users of Internet Explorer, encouraging them to upgrade to Microsoft Edge.

![image](https://user-images.githubusercontent.com/15900351/103844523-0362e100-50d5-11eb-965c-71e94844457c.png)
