### PR TITLE
Drop Rain tests from main October CMS test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,7 @@
             "tests/concerns/InteractsWithAuthentication.php",
             "tests/fixtures/backend/models/UserFixture.php",
             "tests/TestCase.php",
-            "tests/PluginTestCase.php",
-            "vendor/october/rain/tests/DbTestCase.php"
+            "tests/PluginTestCase.php"
         ]
     },
     "scripts": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,9 +13,6 @@
         <testsuite name="October CMS Test Suite">
             <directory>./tests/unit</directory>
         </testsuite>
-        <testsuite name="October Rain Test Suite">
-            <directory>./vendor/october/rain/tests</directory>
-        </testsuite>
     </testsuites>
 
     <filter>


### PR DESCRIPTION
Previously, October CMS ran the Rain library unit tests alongside the main October CMS unit tests. While this has historically worked, the introduction of a `DbTestCase` class in the Rain library has resulted in a conflict between the `TestCase` class within October CMS, and the `TestCase` class in the Rain library itself.

As the library is tested on its own when PRs and commits are made to it, it is reasonable to assume that the functionality is adequately tested by this setup. Having the tests also run here is an unnecessary step, as we would want to see the *effect* that changes to the library has on October CMS, not vice versa. We already, as part of the tests in October CMS itself, switch the library to the latest snapshot of the library based on the `develop` branch, so we would see the consequences that any changes to the library introduce when PRs or further commits are made to October CMS itself.