### PR TITLE
localize all installed themes

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -313,7 +313,8 @@ class ServiceProvider extends ModuleServiceProvider
         foreach (CmsTheme::all() as $theme) {
             $langPath = $theme->getPath() . '/lang';
             if (File::isDirectory($langPath)) {
-                Lang::addNamespace('themes.' . $theme->getId(), $langPath);
+                $config = $theme->getConfig();
+                Lang::addNamespace('themes.' . array_get($config, 'code'), $langPath);
             }
         }
     }

--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -314,7 +314,9 @@ class ServiceProvider extends ModuleServiceProvider
             $langPath = $theme->getPath() . '/lang';
             if (File::isDirectory($langPath)) {
                 $config = $theme->getConfig();
-                Lang::addNamespace('themes.' . array_get($config, 'code'), $langPath);
+                if ($code = array_get($config, 'code')) {
+                    Lang::addNamespace('themes.' . $code, $langPath);
+                }
             }
         }
     }

--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -310,16 +310,11 @@ class ServiceProvider extends ModuleServiceProvider
      */
     protected function bootBackendLocalization()
     {
-        $theme = CmsTheme::getActiveTheme();
-
-        if (is_null($theme)) {
-            return;
-        }
-
-        $langPath = $theme->getPath() . '/lang';
-
-        if (File::isDirectory($langPath)) {
-            Lang::addNamespace('themes.' . $theme->getId(), $langPath);
+        foreach (CmsTheme::all() as $theme) {
+            $langPath = $theme->getPath() . '/lang';
+            if (File::isDirectory($langPath)) {
+                Lang::addNamespace('themes.' . $theme->getId(), $langPath);
+            }
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/octobercms/october/pull/4960

Opening a discussion regarding a "recent" addition making possible to localize the CURRENTLY ACTIVE.

The problem is that all other installed themes are NOT localized so that all labels using string localization will fail to localize, making theme customization difficult at best before it actually gets activated.

I propose the following change which solves the issue by looping through all installed themes. 
This also uses the theme's code instead of the theme's directory in case the user installs the theme under a different folder.