### PR TITLE
Fix checkboxlist label missing if $option is not string or array

### DIFF
--- a/modules/backend/widgets/form/partials/_field_checkboxlist.htm
+++ b/modules/backend/widgets/form/partials/_field_checkboxlist.htm
@@ -14,7 +14,7 @@
                 $index++;
                 $checkboxId = 'checkbox_'.$field->getId().'_'.$index;
                 if (!in_array($value, $checkedValues)) continue;
-                if (is_string($option)) $option = [$option];
+                if (!is_array($option)) $option = [$option];
             ?>
             <div class="checkbox custom-checkbox">
                 <input
@@ -71,7 +71,7 @@
                 <?php
                     $index++;
                     $checkboxId = 'checkbox_'.$field->getId().'_'.$index;
-                    if (is_string($option)) $option = [$option];
+                    if (!is_array($option)) $option = [$option];
                 ?>
                 <div class="checkbox custom-checkbox">
                     <input


### PR DESCRIPTION
Checkboxlist will not show value from `$options` if it's key & values are not string or array.
For example, if the `$fieldOptions` is an array with all integer values:
```php
[ 
2000 => 2000, 
2001 => 2001,
2009 => 2009
]
```
The `Checkboxlist` widget won't add anything to the `<label>` tag.

This is because there's a check here that make sure if the `$option` is a string, then turn it into an array. 
```php 
/* check is_string */
if (is_string($option)) $option = [$option];
/* output to label */
<label for="<?= $checkboxId ?>">
       <?= e(trans($option[0])) ?>
</label>
```

If the label & value is not a string or an array, then accessing`$option[0]` will not work.

The `dropdown` widget does not check only string, and it works fine if key & value is integer.
https://github.com/octobercms/october/blob/develop/modules/backend/widgets/form/partials/_field_dropdown.htm#L29-L31
```php
<?php
    if (!is_array($option)) $option = [$option];
?>
```        
Why in `checkboxlist` we only checks for string `if (is_string($option))`?
    
My workaround was to cast all the `getSomethingOptions` results into a string. 
But since the fix is pretty small I thought I give it a try to propose this PR. 

And I think it will be more convenient if the options values in `checkboxlist` widget work consistently with the `dropdown` widget.
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->