### PR TITLE
Fix: Group filter type with modelClass does not work when 500+ options are available

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -391,7 +391,7 @@ class Filter extends WidgetBase
         $query = $model->newQuery();
         $query->limit(100);
 
-        // If scope has active filter(s) run additional query and leter merge it with base query
+        // If scope has active filter(s) run additional query and later merge it with base query
         if ($scope->value) {
             $modelIds = array_keys($scope->value);
             $activeOptions = $model::findMany($modelIds);

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -389,7 +389,9 @@ class Filter extends WidgetBase
         $model = $this->scopeModels[$scope->scopeName];
 
         $query = $model->newQuery();
-        $query->limit(100);
+        
+        // @todo Implement support for lazy loading of options
+        $query->limit(500);
 
         /**
          * @event backend.filter.extendQuery
@@ -415,7 +417,7 @@ class Filter extends WidgetBase
         $this->fireSystemEvent('backend.filter.extendQuery', [$query, $scope]);
 
         if (!$searchQuery) {
-            // If scope has active filter(s) run additional query and later merge it with base query
+            // If scope has active filter(s) run additional query and merge it with base query
             if ($scope->value) {
                 $modelIds = array_keys($scope->value);
                 $activeOptions = $model::findMany($modelIds);

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -290,24 +290,16 @@
             active = this.scopeValues[this.activeScopeName],
             available = this.scopeAvailable[this.activeScopeName],
             fromItems = isDeselect ? active : available,
-            toItems = isDeselect ? available : active,
             testFunc = function(active){ return active.id == itemId },
-            item = $.grep(fromItems, testFunc).pop(),
+            item = $.grep(fromItems, testFunc).pop() ?? {'id': itemId, 'name': $item.text()},
             filtered = $.grep(fromItems, testFunc, true)
 
         if (isDeselect) {
             this.scopeValues[this.activeScopeName] = filtered
+            this.scopeAvailable[this.activeScopeName].push(item)
         } else {
             this.scopeAvailable[this.activeScopeName] = filtered
-        }
-
-        if (item) {
-            toItems.push(item)
-        } else {
-            toItems.push({
-                'id': itemId,
-                'name': $item.text()
-            })
+            this.scopeValues[this.activeScopeName].push(item)
         }
 
         this.toggleFilterButtons(active)

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -295,18 +295,20 @@
             item = $.grep(fromItems, testFunc).pop(),
             filtered = $.grep(fromItems, testFunc, true)
 
-        if (isDeselect)
+        if (isDeselect) {
             this.scopeValues[this.activeScopeName] = filtered
-        else
+        } else {
             this.scopeAvailable[this.activeScopeName] = filtered
+        }
 
-        if (item)
+        if (item) {
             toItems.push(item)
-        else
+        } else {
             toItems.push({
                 'id': itemId,
                 'name': $item.text()
             })
+        }
 
         this.toggleFilterButtons(active)
         this.updateScopeSetting(this.$activeScope, isDeselect ? filtered.length : active.length)

--- a/modules/system/assets/ui/js/filter.js
+++ b/modules/system/assets/ui/js/filter.js
@@ -302,6 +302,11 @@
 
         if (item)
             toItems.push(item)
+        else
+            toItems.push({
+                'id': itemId,
+                'name': $item.text()
+            })
 
         this.toggleFilterButtons(active)
         this.updateScopeSetting(this.$activeScope, isDeselect ? filtered.length : active.length)

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3149,9 +3149,10 @@ $item.addClass('animate-enter').prependTo($otherContainer).one('webkitAnimationE
 if(!this.scopeValues[this.activeScopeName])
 return
 var
-itemId=$item.data('item-id'),active=this.scopeValues[this.activeScopeName],available=this.scopeAvailable[this.activeScopeName],fromItems=isDeselect?active:available,toItems=isDeselect?available:active,testFunc=function(active){return active.id==itemId},item=$.grep(fromItems,testFunc).pop(),filtered=$.grep(fromItems,testFunc,true)
-if(isDeselect){this.scopeValues[this.activeScopeName]=filtered}else{this.scopeAvailable[this.activeScopeName]=filtered}
-if(item){toItems.push(item)}else{toItems.push({'id':itemId,'name':$item.text()})}
+itemId=$item.data('item-id'),active=this.scopeValues[this.activeScopeName],available=this.scopeAvailable[this.activeScopeName],fromItems=isDeselect?active:available,testFunc=function(active){return active.id==itemId},item=$.grep(fromItems,testFunc).pop()??{'id':itemId,'name':$item.text()},filtered=$.grep(fromItems,testFunc,true)
+if(isDeselect){this.scopeValues[this.activeScopeName]=filtered
+this.scopeAvailable[this.activeScopeName].push(item)}else{this.scopeAvailable[this.activeScopeName]=filtered
+this.scopeValues[this.activeScopeName].push(item)}
 this.toggleFilterButtons(active)
 this.updateScopeSetting(this.$activeScope,isDeselect?filtered.length:active.length)
 this.isActiveScopeDirty=true

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3150,14 +3150,8 @@ if(!this.scopeValues[this.activeScopeName])
 return
 var
 itemId=$item.data('item-id'),active=this.scopeValues[this.activeScopeName],available=this.scopeAvailable[this.activeScopeName],fromItems=isDeselect?active:available,toItems=isDeselect?available:active,testFunc=function(active){return active.id==itemId},item=$.grep(fromItems,testFunc).pop(),filtered=$.grep(fromItems,testFunc,true)
-if(isDeselect)
-this.scopeValues[this.activeScopeName]=filtered
-else
-this.scopeAvailable[this.activeScopeName]=filtered
-if(item)
-toItems.push(item)
-else
-toItems.push({'id':itemId,'name':$item.text()})
+if(isDeselect){this.scopeValues[this.activeScopeName]=filtered}else{this.scopeAvailable[this.activeScopeName]=filtered}
+if(item){toItems.push(item)}else{toItems.push({'id':itemId,'name':$item.text()})}
 this.toggleFilterButtons(active)
 this.updateScopeSetting(this.$activeScope,isDeselect?filtered.length:active.length)
 this.isActiveScopeDirty=true

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3156,6 +3156,8 @@ else
 this.scopeAvailable[this.activeScopeName]=filtered
 if(item)
 toItems.push(item)
+else
+toItems.push({'id':itemId,'name':$item.text()})
 this.toggleFilterButtons(active)
 this.updateScopeSetting(this.$activeScope,isDeselect?filtered.length:active.length)
 this.isActiveScopeDirty=true


### PR DESCRIPTION
This PR solves #5459 

`config_filter.yaml` example:

```
scopes:
    customer:
        label: Client
        type: group
        modelClass: Brightstaff\Brightcrm\Models\Client
        conditions: customer_id in (:filtered)
        nameFrom: name
```

Maybe it's enough to have limit(50) instead of limit(100) in Filter.php?