### PR TITLE
Allow to define searchScope for relation manager manage widget

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -843,6 +843,9 @@ class RelationController extends ControllerBehavior
             }
 
             $widget = $this->makeWidget('Backend\Widgets\Lists', $config);
+            $widget->setSearchOptions([
+                'scope' => $this->getConfig('manage[searchScope]')
+            ]);
 
             /*
              * Apply defined constraints


### PR DESCRIPTION
In your `config_relation.yaml` you can use `searchScope` as follow:

```
family:
    label: Család
    deferredBinding: true
    manage:
        showSearch: true
        searchScope: textSearch
        recordsPerPage: 10
        form: $/brightstaff/brightcrm/models/family/relation_fields.yaml
        list: $/brightstaff/brightcrm/models/family/columns.yaml
    view:
        form: $/brightstaff/brightcrm/models/family/fields.yaml
        toolbarButtons: create|link|unlink
```
Now when you click Link button in relation manager, your scope will be applied when search in the list.