### PR TITLE
WIP: Add ability to specify custom sorting via map or Model callback

### DIFF
--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -227,7 +227,7 @@ return [
         'delete_selected_success' => 'Deleted selected records.',
         'column_switch_true' => 'Yes',
         'column_switch_false' => 'No',
-        'sortable_method_not_exists' => "The model class :model must define a method :method() to either handle or return custom sorting logic.",
+        'sortable_method_not_exists' => 'The model class ":model" must define a method ":method()" to handle custom sorting logic.',
     ],
     'fileupload' => [
         'attachment' => 'Attachment',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -227,6 +227,7 @@ return [
         'delete_selected_success' => 'Deleted selected records.',
         'column_switch_true' => 'Yes',
         'column_switch_false' => 'No',
+        'sortable_method_not_exists' => "The model class :model must define a method :method() to either handle or return custom sorting logic.",
     ],
     'fileupload' => [
         'attachment' => 'Attachment',

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -530,7 +530,8 @@ class Lists extends WidgetBase
 
                 $this->buildQueryCustomSort($query, $customSort);
             } else {
-                if (($column = array_get($this->allColumns, $sortColumn)) && $column->valueFrom) {
+                $column = array_get($this->getColumns(), $sortColumn);
+                if ($column && $column->valueFrom) {
                     $sortColumn = $this->isColumnPivot($column)
                         ? 'pivot_' . $column->valueFrom
                         : $column->valueFrom;

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -661,6 +661,7 @@ class Lists extends WidgetBase
         $whens = collect($customSort)
             ->transform(function ($when, $then) use ($field) {
                 $when = Db::connection()->getPdo()->quote($when);
+                
                 return "WHEN {$field} = $when THEN $then";
             })
             ->implode(' ');

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -634,14 +634,17 @@ class Lists extends WidgetBase
             // Forward the custom sort to the specified method
             $sorting = $this->model->$customSort($query, $column);
 
-            // If a response is given, handle them appropriately
+            // If a raw SQL string is returned, convert it to an Expression
+            if (is_string($sorting)) {
+                // If you have bindings you should return Db::raw($sql, $bindings) instead of just the SQL string.
+                $sorting = Db::raw($sorting);
+            }
+
             if ($sorting instanceof Expression) {
+                // A raw DB Expression
                 $query->orderByRaw($sorting);
-            } elseif (is_string($sorting)) {
-                // If you have bindings you should return Db::raw($sql, $bindings) instead of just the $sql string.
-                $query->orderByRaw(Db::raw($sorting));
             } elseif (is_array($sorting) || $sorting instanceof Arrayable) {
-                // build the query again, except this time using the array map
+                // An array definition (signifying the order of the values to return)
                 $this->applyCustomSorting($query, $sorting);
             }
 

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -653,15 +653,14 @@ class Lists extends WidgetBase
         $customSort = ($customSort instanceof Arrayable) ? $customSort->toArray() : (array) $customSort;
 
         // Compile a CASE WHEN/THEN END string to handle the sorting logic
-        $bindings = collect();
         $whens = collect($customSort)
-            ->transform(function ($when, $then) use ($field, $bindings) {
+            ->transform(function ($when, $then) use ($field) {
                 return "WHEN {$field} = '$when' THEN $then";
             })
             ->implode(' ');
 
         // Add bindings to raw query and apply sorting
-        $raw = DB::raw('CASE ' . $whens . ' END ' . $this->getSortDirection(), $bindings->toArray());
+        $raw = DB::raw('CASE ' . $whens . ' END ' . $this->getSortDirection());
         $query->orderByRaw($raw);
     }
 

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -632,7 +632,7 @@ class Lists extends WidgetBase
             }
 
             // Forward the custom sort to the specified method
-            $sorting = $this->model->$customSort($query, $column);
+            $sorting = $this->model->$customSort($query, $column, $this->getSortDirection());
 
             // If a raw SQL string is returned, convert it to an Expression
             if (is_string($sorting)) {
@@ -660,7 +660,8 @@ class Lists extends WidgetBase
         // Compile a CASE WHEN/THEN END string to handle the sorting logic
         $whens = collect($customSort)
             ->transform(function ($when, $then) use ($field) {
-                return "WHEN {$field} = '$when' THEN $then";
+                $when = Db::connection()->getPdo()->quote($when);
+                return "WHEN {$field} = $when THEN $then";
             })
             ->implode(' ');
 

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -592,8 +592,8 @@ class Lists extends WidgetBase
      * Check if the current sort column has a custom map.
      * We check if the column's sortable property is an array or string.
      *
-     * array: represents the order of which the values should be returned
-     * string: references a function on the relevant model that defines or handles the custom sort
+     * - array: represents the order of which the values should be returned
+     * - string: references a function on the relevant model that defines or handles the custom sort
      *
      * @return boolean
      */

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -597,7 +597,7 @@ class Lists extends WidgetBase
      *
      * @return boolean
      */
-    public function sortColumnHasCustomSorting(): bool
+    public function sortColumnHasCustomSorting()
     {
         $column = $this->getColumns()[$this->getSortColumn()] ?? [];
 

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -17,6 +17,8 @@ use Backend\Classes\WidgetBase;
 use October\Rain\Database\Model;
 use ApplicationException;
 use BackendAuth;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Query\Expression;
 
 /**
  * List Widget
@@ -633,12 +635,12 @@ class Lists extends WidgetBase
             $sorting = $this->model->$customSort($query, $column);
 
             // If a response is given, handle them appropriately
-            if ($sorting instanceof \Illuminate\Database\Query\Expression) {
+            if ($sorting instanceof Expression) {
                 $query->orderByRaw($sorting);
             } elseif (is_string($sorting)) {
                 // If you have bindings you should return Db::raw($sql, $bindings) instead of just the $sql string.
                 $query->orderByRaw(Db::raw($sorting));
-            } elseif (is_array($sorting) || $sorting instanceof \Illuminate\Contracts\Support\Arrayable) {
+            } elseif (is_array($sorting) || $sorting instanceof Arrayable) {
                 // build the query again, except this time using the array map
                 $this->applyCustomSorting($query, $sorting);
             }

--- a/tests/unit/backend/widgets/ListsTest.php
+++ b/tests/unit/backend/widgets/ListsTest.php
@@ -138,14 +138,31 @@ class ListsTest extends PluginTestCase
         ]);
     }
 
-    public function testColumnSortableArrayOverride()
+    /**
+     * Ensure that the sortable property can be represented by an array
+     * of integer keys (typically be an integer enum) that control the
+     * order of the results in both ASC and DESC order
+     *
+     * YAML example:
+     *
+     *     status:
+     *         type: text
+     *         valueFrom: status_label
+     *         sortable:
+     *             - 3
+     *             - 1
+     *             - 2
+     *
+     * @return void
+     */
+    public function testColumnSortableCanSortByArrayWithIntegerKeys()
     {
         $user = new UserFixture;
         $this->actingAs($user);
 
         // Test that the records can be sorted in 'ascending' order
 
-        $list = $this->sortableListsFixture(false, 'asc');
+        $list = $this->createListFixtureIntegerKeys(false, 'asc');
         $list->render();
 
         $this->assertNotNull($list->getColumn('id'));
@@ -158,7 +175,7 @@ class ListsTest extends PluginTestCase
 
         // Test that the records can be sorted in 'descending' order
 
-        $list = $this->sortableListsFixture(false, 'desc');
+        $list = $this->createListFixtureIntegerKeys(false, 'desc');
         $list->render();
 
         $this->assertNotNull($list->getColumn('id'));
@@ -170,7 +187,70 @@ class ListsTest extends PluginTestCase
         $this->assertEquals([1, 2, 4, 3], $recordIds, 'The sortable array map records (desc) do not match the one defined in the List');
     }
 
-    public function testColumnSortableMethodOverrideReturnMap()
+    /**
+     * Ensure that the sortable property can be represented by an array
+     * of string keys (typically be a string enum) that control the
+     * order of the results in both ASC and DESC order
+     *
+     * YAML example:
+     *
+     *     service:
+     *         type: text
+     *         valueFrom: service_label
+     *         sortable:
+     *             - local
+     *             - whm
+     *             - cpanel
+     *
+     * @return void
+     */
+    public function testColumnSortableCanSortByArrayWithStringKeys()
+    {
+        $user = new UserFixture;
+        $this->actingAs($user);
+
+        // Test that the records can be sorted in 'ascending' order
+
+        $list = $this->createListFixtureStringKeys('asc');
+        $list->render();
+
+        $this->assertNotNull($list->getColumn('first_name'));
+        $this->assertNotNull($list->getColumn('email'));
+
+        $this->assertEquals(['Admin', 'Def', 'Ghi', 'Abc'], $list->getColumn('first_name')->sortable, 'The sortable array map (asc) does not match the one defined in the List');
+
+        $recordNames = $list->vars['records']->pluck('first_name')->toArray();
+        $this->assertEquals(['Admin', 'Def', 'Ghi', 'Abc'], $recordNames, 'The sortable array map records (asc) do not match the one defined in the List');
+
+        // Test that the records can be sorted in 'descending' order
+
+        $list = $this->createListFixtureStringKeys('desc');
+        $list->render();
+
+        $this->assertNotNull($list->getColumn('first_name'));
+        $this->assertNotNull($list->getColumn('email'));
+
+        $this->assertEquals(['Admin', 'Def', 'Ghi', 'Abc'], $list->getColumn('first_name')->sortable, 'The sortable array map (asc) does not match the one defined in the List');
+
+        $recordIds = $list->vars['records']->pluck('first_name')->toArray();
+        $this->assertEquals(['Abc', 'Ghi', 'Def', 'Admin'], $recordIds, 'The sortable array map records (desc) do not match the one defined in the List');
+    }
+
+    /**
+     * Ensure that the sortable property can be represented by a model
+     * callback that returns an array of integer keys that control the
+     * order of the results in both ASC and DESC order
+     *
+     * Model example (Order model):
+     *
+     *     public function sortOrderStatusField(Builder $query)
+     *     {
+     *         return [OrderStatus::PENDING, OrderStatus::PROCESSING, OrderStatus::DISPATCHED, OrderStatus::COMPLETED];
+     *     }
+     *
+     * @return void
+     */
+    public function testColumnSortableCanSortByMethodWithArrayResponse()
     {
         $user = new UserFixture;
         $this->actingAs($user);
@@ -183,7 +263,7 @@ class ListsTest extends PluginTestCase
 
         // Test that the records can be sorted in 'ascending' order
 
-        $list = $this->sortableListsFixture(true, 'asc');
+        $list = $this->createListFixtureIntegerKeys(true, 'asc');
         $list->render();
 
         $this->assertNotNull($list->getColumn('id'));
@@ -196,7 +276,7 @@ class ListsTest extends PluginTestCase
 
         // Test that the records can be sorted in 'descending' order
 
-        $list = $this->sortableListsFixture(true, 'desc');
+        $list = $this->createListFixtureIntegerKeys(true, 'desc');
         $list->render();
 
         $this->assertNotNull($list->getColumn('id'));
@@ -208,7 +288,21 @@ class ListsTest extends PluginTestCase
         $this->assertEquals([4, 1, 3, 2], $recordIds, 'The sortable method callback records (desc) do not match the one defined in the List');
     }
 
-    public function testColumnSortableMethodOverrideReturnQueryString()
+    /**
+     * Ensure that the sortable property can be represented by a model
+     * callback that returns an SQL query string that controls the
+     * order of the results in both ASC and DESC order.
+     *
+     * Model example (Order model):
+     *
+     *     public function sortOrderStatusField(Builder $query)
+     *     {
+     *         return 'CASE WHEN id = 2 THEN 1 WHEN id = 1 THEN 2 WHEN id = 4 THEN 3 WHEN id = 3 THEN 4 END';
+     *     }
+     *
+     * @return void
+     */
+    public function testColumnSortableCanSortByMethodWithQueryStringResponse()
     {
         $user = new UserFixture;
         $this->actingAs($user);
@@ -222,7 +316,7 @@ class ListsTest extends PluginTestCase
 
         // Test that the records can be sorted in 'ascending' order
 
-        $list = $this->sortableListsFixture(true, 'asc');
+        $list = $this->createListFixtureIntegerKeys(true, 'asc');
         $list->render();
 
         $this->assertNotNull($list->getColumn('id'));
@@ -243,7 +337,7 @@ class ListsTest extends PluginTestCase
             });
         });
 
-        $list = $this->sortableListsFixture(true, 'desc');
+        $list = $this->createListFixtureIntegerKeys(true, 'desc');
         $list->render();
 
         $this->assertNotNull($list->getColumn('id'));
@@ -255,7 +349,20 @@ class ListsTest extends PluginTestCase
         $this->assertEquals([3, 4, 1, 2], $recordIds, 'The sortable method callback records (desc) do not match the one defined in the List');
     }
 
-    protected function sortableListsFixture(bool $method = false, string $sortDirection = 'asc')
+    /**
+     * Several of these test require multiple entities with custom sorting of the IDs using a custom map.
+     * This mimicks the real-use of an integer Enum field.
+     *
+     * The list returned will either have a hard-defined map of integer values ($method === true) or a
+     * callback against the User method called sortIdField ($method === false).
+     *
+     * The list returned will be ASC order by default unless specified (via $sortDirection)
+     *
+     * @param boolean $method
+     * @param string $sortDirection
+     * @return Lists
+     */
+    protected function createListFixtureIntegerKeys(bool $method = false, string $sortDirection = 'asc')
     {
         User::firstOrCreate([
             'id' => 2,
@@ -311,6 +418,83 @@ class ListsTest extends PluginTestCase
             ],
             'defaultSort' => [
                 'column' => 'id',
+                'direction' => $sortDirection,
+            ],
+        ]);
+    }
+
+    /**
+     * One of the above tests will need multiple entities with custom sorting of the first name field.
+     * This mimicks the real-use of an string Enum field.
+     *
+     * The list returned will have a hard-defined map of first name values. No method callback needs
+     * to be tested here.
+     *
+     * The list returned will be ASC order by default unless specified (via $sortDirection)
+     *
+     * @param string $sortDirection
+     * @return Lists
+     */
+    protected function createListFixtureStringKeys(string $sortDirection = 'asc')
+    {
+        User::firstOrCreate([
+            'id' => 2,
+        ], [
+            'first_name' => 'Abc',
+            'last_name' => 'Person',
+            'login' => 'testperson',
+            'email' => 'test@person.org',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        User::firstOrCreate([
+            'id' => 3,
+        ], [
+            'first_name' => 'Def',
+            'last_name' => 'Person',
+            'login' => 'fooperson',
+            'email' => 'foo@person.org',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        User::firstOrCreate([
+            'id' => 4,
+        ], [
+            'first_name' => 'Ghi',
+            'last_name' => 'Person',
+            'login' => 'barperson',
+            'email' => 'bar@person.org',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        return new Lists(null, [
+            'model' => new User,
+            'arrayName' => 'array',
+            'columns' => [
+                'id' => [
+                    'type' => 'text',
+                    'label' => 'ID',
+                ],
+                'first_name' => [
+                    'label' => 'First Name',
+                    'type' => 'text',
+                    'sortable' => [
+                        'Admin',
+                        'Def',
+                        'Ghi',
+                        'Abc',
+                    ],
+                ],
+                'email' => [
+                    'type' => 'text',
+                    'label' => 'Email',
+                ],
+            ],
+            'defaultSort' => [
+                'column' => 'first_name',
                 'direction' => $sortDirection,
             ],
         ]);

--- a/tests/unit/backend/widgets/ListsTest.php
+++ b/tests/unit/backend/widgets/ListsTest.php
@@ -137,4 +137,135 @@ class ListsTest extends PluginTestCase
             ]
         ]);
     }
+
+    public function testColumnSortableArrayOverride()
+    {
+        $user = new UserFixture;
+        $this->actingAs($user);
+
+        // Test that the records can be sorted in 'ascending' order
+
+        $list = $this->sortableListsFixture(false, 'asc');
+        $list->render();
+
+        $this->assertNotNull($list->getColumn('id'));
+        $this->assertNotNull($list->getColumn('email'));
+
+        $this->assertEquals([3, 4, 2, 1], $list->getColumn('id')->sortable, 'The sortable array map (asc) does not match the one defined in the List');
+
+        $recordIds = $list->vars['records']->pluck('id')->toArray();
+        $this->assertEquals([3, 4, 2, 1], $recordIds, 'The sortable array map records (asc) do not match the one defined in the List');
+
+        // Test that the records can be sorted in 'descending' order
+
+        $list = $this->sortableListsFixture(false, 'desc');
+        $list->render();
+
+        $this->assertNotNull($list->getColumn('id'));
+        $this->assertNotNull($list->getColumn('email'));
+
+        $this->assertEquals([3, 4, 2, 1], $list->getColumn('id')->sortable, 'The sortable array map (asc) does not match the one defined in the List');
+
+        $recordIds = $list->vars['records']->pluck('id')->toArray();
+        $this->assertEquals([1, 2, 4, 3], $recordIds, 'The sortable array map records (desc) do not match the one defined in the List');
+    }
+
+    public function testColumnSortableMethodOverrideReturnMap()
+    {
+        $user = new UserFixture;
+        $this->actingAs($user);
+
+        User::extend(function ($user) {
+            $user->addDynamicMethod('sortIdField', function ($query, $listColumn) use ($user) {
+                return [2, 3, 1, 4];
+            });
+        });
+
+        // Test that the records can be sorted in 'ascending' order
+
+        $list = $this->sortableListsFixture(true, 'asc');
+        $list->render();
+
+        $this->assertNotNull($list->getColumn('id'));
+        $this->assertNotNull($list->getColumn('email'));
+
+        $this->assertEquals('sortIdField', $list->getColumn('id')->sortable, 'The sortable method callback (asc) does not match the one defined in the List');
+
+        $recordIds = $list->vars['records']->pluck('id')->toArray();
+        $this->assertEquals([2, 3, 1, 4], $recordIds, 'The sortable method callback records (asc) do not match the one defined in the List');
+
+        // Test that the records can be sorted in 'descending' order
+
+        $list = $this->sortableListsFixture(true, 'desc');
+        $list->render();
+
+        $this->assertNotNull($list->getColumn('id'));
+        $this->assertNotNull($list->getColumn('email'));
+
+        $this->assertEquals('sortIdField', $list->getColumn('id')->sortable, 'The sortable method callback (asc) does not match the one defined in the List');
+
+        $recordIds = $list->vars['records']->pluck('id')->toArray();
+        $this->assertEquals([4, 1, 3, 2], $recordIds, 'The sortable method callback records (desc) do not match the one defined in the List');
+    }
+
+    protected function sortableListsFixture(bool $method = false, string $sortDirection = 'asc')
+    {
+        User::firstOrCreate([
+            'id' => 2,
+        ], [
+            'first_name' => 'Test',
+            'last_name' => 'Person',
+            'login' => 'testperson',
+            'email' => 'test@person.org',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        User::firstOrCreate([
+            'id' => 3,
+        ], [
+            'first_name' => 'Foo',
+            'last_name' => 'Person',
+            'login' => 'fooperson',
+            'email' => 'foo@person.org',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        User::firstOrCreate([
+            'id' => 4,
+        ], [
+            'first_name' => 'Bar',
+            'last_name' => 'Person',
+            'login' => 'barperson',
+            'email' => 'bar@person.org',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        return new Lists(null, [
+            'model' => new User,
+            'arrayName' => 'array',
+            'columns' => [
+                'id' => [
+                    'type' => 'text',
+                    'label' => 'ID',
+                    'sortable' => ($method) ? 'sortIdField' : [
+                        3,
+                        4,
+                        2,
+                        1,
+                    ],
+                ],
+                'email' => [
+                    'type' => 'text',
+                    'label' => 'Email',
+                ],
+            ],
+            'defaultSort' => [
+                'column' => 'id',
+                'direction' => $sortDirection,
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
# Work In Progress.

This PR adds the ability for developers to customise the sort order of any enum-like field, for cases when the numerical value of said enum differs from the ideal sort order of the values displayed.

The best use case example I can think of is the status of a Booking/Order. Lets say a business uses this column to identify the progress of each order, where they can view their progresses in order from start to finish.

For example you may have the following workflow for orders (which is on par with the numerical order of the statuses):
```
1: Confirmed
2: Delivering
3: Completed
4: Cancelled
```

Lets say you then add a 5th enum value later down the track, which represents a status occurring after `Confirmed` and before `Delivering`. Lets call this `Processing`:
```
5: Processing
```

This of course would push all `Processing` orders to the bottom of the list, differing from the workflow.

Insert this PR here.

Now you can define a specific order of the results by defining the order where each enum value should be placed.

columns.yaml:
```yaml
status:
    label: Status
    type: text
    sortable:
        - 1
        - 5
        - 2
        - 3
        - 4
```

This would therefore show `Processing` orders before `Delivering` orders. This is all done through dynamically generated SQL using `CASE WHEN/THEN END` (MySQL, Sqlite, SQL Server compatible)

Better yet, this PR also adds the ability for a custom callback against the relevant model.

columns.yaml:
```yaml
status:
    label: Status
    type: text
    sortable: sortStatusField
```

models\Order.php
```php
...
    public function sortStatusField(\Illuminate\Database\Eloquent\Builder $query, \Backend\Classes\ListColumn $column)
    {
        return OrderStatus::select('id')->orderBy('sequential_order_in_workflow')->get()->pluck('id');
    }
...
```

The model's callback is flexible and can return:

- array (or Arrayable): Similar to the arrays defined in the columns.yaml file
- string: A raw DB query string
- \Illuminate\Database\Query\Expression: A raw DB query expression
- void: Handle all of the ordering external directly in the model


## TODO:

- Ensure non-integer values are escaped in the `WHEN {$field} = '$when'` portion of the SQL `CASE` definition
- Ensure sortDirection is accessible via model callback (for those who are not returning an array or Arrayable object)
- More tests?