### PR TITLE
Support specifying step, min, and max attributes on number inputs for list filters

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -151,6 +151,7 @@ class Filter extends WidgetBase
                 if ($step = array_get($scope->config, 'step')) {
                     $params['step'] = is_numeric($step) ? $step : null;
                 }
+                // no break, these paramaters apply to both of the following cases
 
             case 'number':
                 if (is_numeric($scope->value)) {

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -122,7 +122,7 @@ class Filter extends WidgetBase
                         $params['after']    = $after;
                     }
                     else {
-                        $params['afterStr'] = '∞';
+                        $params['afterStr'] = '-∞';
                         $params['after']    = null;
                     }
 

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -140,12 +140,12 @@ class Filter extends WidgetBase
 
             case 'number':
             case 'numberrange':
-                if ($minInput = array_get($scope->config, 'minInput')) {
-                    $params['minInput'] = is_numeric($minInput) ? $minInput : null;
+                if ($minInput = array_get($scope->config, 'min')) {
+                    $params['minValue'] = is_numeric($minInput) ? $minInput : null;
                 }
 
-                if ($maxInput = array_get($scope->config, 'maxInput')) {
-                    $params['maxInput'] = is_numeric($maxInput) ? $maxInput : null;
+                if ($maxInput = array_get($scope->config, 'max')) {
+                    $params['maxValue'] = is_numeric($maxInput) ? $maxInput : null;
                 }
 
                 if ($step = array_get($scope->config, 'step')) {

--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -137,6 +137,21 @@ class Filter extends WidgetBase
                 }
 
                 break;
+
+            case 'number':
+            case 'numberrange':
+                if ($minInput = array_get($scope->config, 'minInput')) {
+                    $params['minInput'] = is_numeric($minInput) ? $minInput : null;
+                }
+
+                if ($maxInput = array_get($scope->config, 'maxInput')) {
+                    $params['maxInput'] = is_numeric($maxInput) ? $maxInput : null;
+                }
+
+                if ($step = array_get($scope->config, 'step')) {
+                    $params['step'] = is_numeric($step) ? $step : null;
+                }
+
             case 'number':
                 if (is_numeric($scope->value)) {
                     $params['number'] = $scope->value;

--- a/modules/backend/widgets/filter/partials/_scope_number.htm
+++ b/modules/backend/widgets/filter/partials/_scope_number.htm
@@ -6,8 +6,8 @@
     data-scope-data="<?= e(json_encode([
         'number' => isset($number) ? $number : null,
         'step' => isset($step) ? $step : null,
-        'minInput' => isset($minInput) ? $minInput : null,
-        'maxInput' => isset($maxInput) ? $maxInput : null,
+        'minValue' => isset($minValue) ? $minValue : null,
+        'maxValue' => isset($maxValue) ? $maxValue : null,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>

--- a/modules/backend/widgets/filter/partials/_scope_number.htm
+++ b/modules/backend/widgets/filter/partials/_scope_number.htm
@@ -5,6 +5,7 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'number' => isset($number) ? $number : null,
+        'step' => isset($scope->config['step']) ? $scope->config['step'] : null,
         'minInput' => isset($scope->config['minInput']) ? $scope->config['minInput'] : null,
         'maxInput' => isset($scope->config['maxInput']) ? $scope->config['maxInput'] : null,
     ]))

--- a/modules/backend/widgets/filter/partials/_scope_number.htm
+++ b/modules/backend/widgets/filter/partials/_scope_number.htm
@@ -5,6 +5,8 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'number' => isset($number) ? $number : null,
+        'minInput' => isset($scope->config['minInput']) ? $scope->config['minInput'] : null,
+        'maxInput' => isset($scope->config['maxInput']) ? $scope->config['maxInput'] : null,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>

--- a/modules/backend/widgets/filter/partials/_scope_number.htm
+++ b/modules/backend/widgets/filter/partials/_scope_number.htm
@@ -5,9 +5,9 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'number' => isset($number) ? $number : null,
-        'step' => isset($scope->config['step']) ? $scope->config['step'] : null,
-        'minInput' => isset($scope->config['minInput']) ? $scope->config['minInput'] : null,
-        'maxInput' => isset($scope->config['maxInput']) ? $scope->config['maxInput'] : null,
+        'step' => isset($step) ? $step : null,
+        'minInput' => isset($minInput) ? $minInput : null,
+        'maxInput' => isset($maxInput) ? $maxInput : null,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>

--- a/modules/backend/widgets/filter/partials/_scope_numberrange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_numberrange.htm
@@ -5,6 +5,8 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'numbers' =>  [isset($min) ? $min : null, isset($max) ? $max : null],
+        'minInput' => isset($scope->config['minInput']) ? $scope->config['minInput'] : null,
+        'maxInput' => isset($scope->config['maxInput']) ? $scope->config['maxInput'] : null,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>

--- a/modules/backend/widgets/filter/partials/_scope_numberrange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_numberrange.htm
@@ -5,11 +5,12 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'numbers' =>  [isset($min) ? $min : null, isset($max) ? $max : null],
-        'step' => isset($scope->config['step']) ? $scope->config['step'] : null,
-        'minInput' => isset($scope->config['minInput']) ? $scope->config['minInput'] : null,
-        'maxInput' => isset($scope->config['maxInput']) ? $scope->config['maxInput'] : null,
+        'step' => isset($step) ? $step : null,
+        'minInput' => isset($minInput) ? $minInput : null,
+        'maxInput' => isset($maxInput) ? $maxInput : null,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>
     <span class="filter-setting"><?= isset($minStr) && isset($maxStr) ? ($minStr . ' → ' . $maxStr) : e(trans('backend::lang.filter.number_all')) ?></span>
 </a>
+0

--- a/modules/backend/widgets/filter/partials/_scope_numberrange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_numberrange.htm
@@ -6,8 +6,8 @@
     data-scope-data="<?= e(json_encode([
         'numbers' =>  [isset($min) ? $min : null, isset($max) ? $max : null],
         'step' => isset($step) ? $step : null,
-        'minInput' => isset($minInput) ? $minInput : null,
-        'maxInput' => isset($maxInput) ? $maxInput : null,
+        'minValue' => isset($minValue) ? $minValue : null,
+        'maxValue' => isset($maxValue) ? $maxValue : null,
     ]))
     ?>">
     <span class="filter-label"><?= e(trans($scope->label)) ?>:</span>

--- a/modules/backend/widgets/filter/partials/_scope_numberrange.htm
+++ b/modules/backend/widgets/filter/partials/_scope_numberrange.htm
@@ -5,6 +5,7 @@
     data-scope-name="<?= $scope->scopeName ?>"
     data-scope-data="<?= e(json_encode([
         'numbers' =>  [isset($min) ? $min : null, isset($max) ? $max : null],
+        'step' => isset($scope->config['step']) ? $scope->config['step'] : null,
         'minInput' => isset($scope->config['minInput']) ? $scope->config['minInput'] : null,
         'maxInput' => isset($scope->config['maxInput']) ? $scope->config['maxInput'] : null,
     ]))

--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -301,7 +301,7 @@
                 dates[1] = dates[1] && dates[1].match(dateRegex) ? dates[1] : null
 
                 if(dates[0] || dates[1]) {
-                    var after = dates[0] ? moment.tz(dates[0], this.appTimezone).tz(this.timezone).format(dateFormat) : '∞',
+                    var after = dates[0] ? moment.tz(dates[0], this.appTimezone).tz(this.timezone).format(dateFormat) : '-∞',
                         before = dates[1] ? moment.tz(dates[1], this.appTimezone).tz(this.timezone).format(dateFormat) : '∞'
 
                     $setting.text(after + ' → ' + before)

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -242,6 +242,8 @@
             }
 
             numberinput.value = '' !== defaultValue ? defaultValue : '';
+            numberinput.min = scopeData.minInput;
+            numberinput.max = scopeData.maxInput;
         })
     }
 

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -243,9 +243,15 @@
 
             numberinput.value = '' !== defaultValue ? defaultValue : '';
 
-            if (scopeData.step) numberinput.step = scopeData.step;
-            if (scopeData.minInput) numberinput.min = scopeData.minInput;
-            if (scopeData.maxInput) numberinput.max = scopeData.maxInput;
+            if (scopeData.step) {
+                numberinput.step = scopeData.step
+            }
+            if (scopeData.minInput) {
+                numberinput.min = scopeData.minInput
+            }
+            if (scopeData.maxInput) {
+                numberinput.max = scopeData.maxInput
+            }
         })
     }
 

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -242,9 +242,10 @@
             }
 
             numberinput.value = '' !== defaultValue ? defaultValue : '';
-            numberinput.step = scopeData.step;
-            numberinput.min = scopeData.minInput;
-            numberinput.max = scopeData.maxInput;
+
+            if (scopeData.step) numberinput.step = scopeData.step;
+            if (scopeData.minInput) numberinput.min = scopeData.minInput;
+            if (scopeData.maxInput) numberinput.max = scopeData.maxInput;
         })
     }
 

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -242,6 +242,7 @@
             }
 
             numberinput.value = '' !== defaultValue ? defaultValue : '';
+            numberinput.step = scopeData.step;
             numberinput.min = scopeData.minInput;
             numberinput.max = scopeData.maxInput;
         })

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -246,11 +246,11 @@
             if (scopeData.step) {
                 numberinput.step = scopeData.step
             }
-            if (scopeData.minInput) {
-                numberinput.min = scopeData.minInput
+            if (scopeData.minValue) {
+                numberinput.min = scopeData.minValue
             }
-            if (scopeData.maxInput) {
-                numberinput.max = scopeData.maxInput
+            if (scopeData.maxValue) {
+                numberinput.max = scopeData.maxValue
             }
         })
     }

--- a/modules/system/assets/ui/js/filter.numbers.js
+++ b/modules/system/assets/ui/js/filter.numbers.js
@@ -260,7 +260,7 @@
                 numbers[1] = numbers[1] && numbers[1].match(numberRegex) ? numbers[1] : null
 
                 if(numbers[0] || numbers[1]) {
-                    var min = numbers[0] ? numbers[0] : '∞',
+                    var min = numbers[0] ? numbers[0] : '-∞',
                         max = numbers[1] ? numbers[1] : '∞'
 
                     $setting.text(min + ' → ' + max)


### PR DESCRIPTION
This PR adds support for specifying the `step`, `min`, and `max` attributes on the number inputs for the `number` and `numberrange` list filters. Useful for instances where the developer is aware of the appropriate values that can be used to filter records, thus making the UX less confusing for end users (e.g. specifing a minimum of `1` for a record ID filter, since your record IDs are positive integers). Tested with `number` and `numberrange` filters on integer and decimal column types. Shouldn't break existing feautures, since the changes are mostly cosmetic.

Documentation PR: octobercms/docs#509
