### PR TITLE
Fix: Respect user-defined admin password

### DIFF
--- a/modules/backend/database/seeds/DatabaseSeeder.php
+++ b/modules/backend/database/seeds/DatabaseSeeder.php
@@ -14,7 +14,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $adminPassword = (SeedSetupAdmin::$password === 'admin') ? Str::random(22) : SeedSetupAdmin::$password;
+        $shouldRandomizePassword = SeedSetupAdmin::$password === 'admin';
+        $adminPassword = $shouldRandomizePassword ? Str::random(22) : SeedSetupAdmin::$password;
 
         Eloquent::unguarded(function () use ($adminPassword) {
             // Generate a random password for the seeded admin account
@@ -25,7 +26,7 @@ class DatabaseSeeder extends Seeder
             $this->call($adminSeeder);
         });
 
-        return 'The following password has been automatically generated for the "admin" account: '
-            . "<fg=yellow;options=bold>${adminPassword}</>";
+        return $shouldRandomizePassword ? 'The following password has been automatically generated for the "admin" account: '
+            . "<fg=yellow;options=bold>${adminPassword}</>" : '';
     }
 }

--- a/modules/backend/database/seeds/DatabaseSeeder.php
+++ b/modules/backend/database/seeds/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 use Str;
 use Seeder;
 use Eloquent;
+use Backend\Database\Seeds\SeedSetupAdmin;
 
 class DatabaseSeeder extends Seeder
 {
@@ -13,7 +14,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $adminPassword = Str::random(22);
+        $adminPassword = (SeedSetupAdmin::$password == 'admin') ? Str::random(22) : SeedSetupAdmin::$password;
 
         Eloquent::unguarded(function () use ($adminPassword) {
             // Generate a random password for the seeded admin account

--- a/modules/backend/database/seeds/DatabaseSeeder.php
+++ b/modules/backend/database/seeds/DatabaseSeeder.php
@@ -14,7 +14,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $adminPassword = (SeedSetupAdmin::$password == 'admin') ? Str::random(22) : SeedSetupAdmin::$password;
+        $adminPassword = (SeedSetupAdmin::$password === 'admin') ? Str::random(22) : SeedSetupAdmin::$password;
 
         Eloquent::unguarded(function () use ($adminPassword) {
             // Generate a random password for the seeded admin account

--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -1034,7 +1034,7 @@ class UpdateManager
 
         if (is_string($message)) {
             $this->messages[$class][] = $message;
-        } else if (is_array($message)) {
+        } elseif (is_array($message)) {
             array_merge($this->messages[$class], $message);
         }
     }
@@ -1046,7 +1046,7 @@ class UpdateManager
      */
     protected function printMessages()
     {
-        if (!count($this->messages)) {
+        if (!count($this->messages) || empty(array_filter(array_flatten($this->messages)))) {
             return;
         }
 

--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -1025,6 +1025,10 @@ class UpdateManager
      */
     protected function addMessage($class, $message)
     {
+        if (empty($message)) {
+            return;
+        }
+
         if (is_object($class)) {
             $class = get_class($class);
         }
@@ -1046,7 +1050,7 @@ class UpdateManager
      */
     protected function printMessages()
     {
-        if (!count($this->messages) || empty(array_filter(array_flatten($this->messages)))) {
+        if (!count($this->messages)) {
             return;
         }
 


### PR DESCRIPTION
During the regular october install using october:install, the user-defined password is overwritten with the random generated string password. Instead, now it uses random password only if the user-defined password defaults to *admin* and if a user did set a custom password, that is used instead.