### PR TITLE
Change Url to Storage facade

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -46,7 +46,7 @@ return [
         'local' => [
             'driver' => 'local',
             'root'   => storage_path('app'),
-            'url'    => '/storage/app',
+            'url'    => '',
         ],
 
         's3' => [

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -80,7 +80,7 @@ class File extends FileBase
             $uploadsPath .= '/protected';
         }
 
-        return Url::asset($uploadsPath) . '/';
+        return Storage::url($uploadsPath) . '/';
     }
 
     /**


### PR DESCRIPTION
Laravel has the ability to change the storage host url in the filesystem.php: https://laravel.com/docs/6.x/filesystem#file-urls
not sure why `Url::assets` is there, isn't that suppose to lead to an assets folder or was changed to accommodate the cms module? If so what would be the best way to detect if the cms module is disabled that way it can switch to the Storage facade (in any case I just need the benefit of being able to change the url)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->