### PR TITLE
Use Storage facade for file model

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -46,7 +46,7 @@ return [
         'local' => [
             'driver' => 'local',
             'root'   => storage_path('app'),
-            'url'    => env('APP_URL'),
+            'url'    => '/storage/app',
         ],
 
         's3' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -46,7 +46,7 @@ return [
         'local' => [
             'driver' => 'local',
             'root'   => storage_path('app'),
-            'url'    => '/storage/app',
+            'url'    => env('APP_URL'),
         ],
 
         's3' => [

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -71,9 +71,15 @@ class File extends FileBase
      */
     public function getPublicPath()
     {
-        $uploadsPath = Config::get('cms.storage.uploads.path', '/storage/app/uploads');
+        $uploadsFolder = Config::get('cms.storage.uploads.folder', 'uploads');
 
-        return $this->getDisk()->url($uploadsPath . ($this->isPublic() ? '/public/' : '/protected/'));
+        $path = $this->getDisk()->url('/'. $uploadsFolder . ($this->isPublic() ? '/public/' : '/protected/'));
+
+        if (Config::get('cms.linkPolicy') === 'force') {
+            return Url::asset($path);
+        }
+
+        return $path;
     }
 
     /**

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -71,13 +71,13 @@ class File extends FileBase
      */
     public function getPublicPath()
     {
-        $uploadsFolder = Config::get('cms.storage.uploads.folder', 'uploads');
+        $uploadsFolder = Config::get('cms.storage.uploads.path', '/storage/app/uploads');
 
         if ($this->isPublic()) {
-            return $this->getDisk()->url('/'. $uploadsFolder . '/public/');
+            return $this->getDisk()->url($uploadsFolder . '/public/');
         }
         else {
-            return $this->getDisk()->url('/'. $uploadsFolder . '/protected/');
+            return $this->getDisk()->url($uploadsFolder . '/protected/');
         }
     }
 

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -73,12 +73,7 @@ class File extends FileBase
     {
         $uploadsPath = Config::get('cms.storage.uploads.path', '/storage/app/uploads');
 
-        if ($this->isPublic()) {
-            return $this->getDisk()->url($uploadsPath . '/public/');
-        }
-        else {
-            return $this->getDisk()->url($uploadsPath . '/protected/');
-        }
+        return $this->getDisk()->url($uploadsPath . ($this->isPublic() ? '/public/' : '/protected/'));
     }
 
     /**

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -80,7 +80,7 @@ class File extends FileBase
             $uploadsPath .= '/protected';
         }
 
-        return Url::asset($uploadsPath) . '/';
+        return Storage::url($uploadsPath) . '/';
     }
 
     /**

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -71,16 +71,12 @@ class File extends FileBase
      */
     public function getPublicPath()
     {
-        $uploadsPath = Config::get('cms.storage.uploads.path', '/storage/app/uploads');
-
         if ($this->isPublic()) {
-            $uploadsPath .= '/public';
+            return $this->getDisk()->url('/uploads/public/');
         }
         else {
-            $uploadsPath .= '/protected';
+            return $this->getDisk()->url('/uploads/protected/');
         }
-
-        return Storage::url($uploadsPath) . '/';
     }
 
     /**

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -71,11 +71,13 @@ class File extends FileBase
      */
     public function getPublicPath()
     {
+        $uploadsFolder = Config::get('cms.storage.uploads.folder', 'uploads');
+
         if ($this->isPublic()) {
-            return $this->getDisk()->url('/uploads/public/');
+            return $this->getDisk()->url('/'. $uploadsFolder . '/public/');
         }
         else {
-            return $this->getDisk()->url('/uploads/protected/');
+            return $this->getDisk()->url('/'. $uploadsFolder . '/protected/');
         }
     }
 

--- a/modules/system/models/File.php
+++ b/modules/system/models/File.php
@@ -71,13 +71,13 @@ class File extends FileBase
      */
     public function getPublicPath()
     {
-        $uploadsFolder = Config::get('cms.storage.uploads.path', '/storage/app/uploads');
+        $uploadsPath = Config::get('cms.storage.uploads.path', '/storage/app/uploads');
 
         if ($this->isPublic()) {
-            return $this->getDisk()->url($uploadsFolder . '/public/');
+            return $this->getDisk()->url($uploadsPath . '/public/');
         }
         else {
-            return $this->getDisk()->url($uploadsFolder . '/protected/');
+            return $this->getDisk()->url($uploadsPath . '/protected/');
         }
     }
 


### PR DESCRIPTION
Laravel has the ability to change the storage host url in the filesystem.php: https://laravel.com/docs/6.x/filesystem#file-urls
not sure why Url::assets is there, isn't that suppose to lead to an assets folder or was changed to accommodate the cms module? If so what would be the best way to detect if the cms module is disabled that way it can switch to the Storage facade (in any case I just need the benefit of being able to change the url)

filesystem.php has been altered because `/storage/app` gets appended twice when using the `Storage` facade. I'm not sure how you would want to test this.