### PR TITLE
Permanent Composer 2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "october/backend": "1.1.*",
         "october/cms": "1.1.*",
         "laravel/framework": "~6.0",
-        "wikimedia/composer-merge-plugin": "2.0.1"
+        "wikimedia/composer-merge-plugin": "~2.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.3.3",

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,6 @@
         "docs": "https://octobercms.com/docs/",
         "source": "https://github.com/octobercms/october"
     },
-    "repositories": [
-        {
-            "type":"vcs",
-            "url":"https://github.com/octoberrain/composer-merge-plugin"
-        }
-    ],
     "require": {
         "php": ">=7.2",
         "october/rain": "1.1.*",
@@ -43,7 +37,7 @@
         "october/backend": "1.1.*",
         "october/cms": "1.1.*",
         "laravel/framework": "~6.0",
-        "wikimedia/composer-merge-plugin": "dev-feature/composer-v2 as 1.5.0"
+        "wikimedia/composer-merge-plugin": "2.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.3.3",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "source": "https://github.com/octobercms/october"
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.2.9",
         "october/rain": "1.1.*",
         "october/system": "1.1.*",
         "october/backend": "1.1.*",
@@ -76,10 +76,7 @@
         ]
     },
     "config": {
-        "preferred-install": "dist",
-        "platform": {
-            "php": "7.2.5"
-        }
+        "preferred-install": "dist"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
https://github.com/wikimedia/composer-merge-plugin/pull/189 has been merged in master and we can use regular "wikimedia/composer-merge-plugin": "~1.5.0" to provide Composer 2.0 compatible  and we can drop repository introduced in https://github.com/octobercms/october/commit/a095c1e54526c64c70c0af85900d64de3924b4bd#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34

Closes https://github.com/octobercms/october/issues/5033

