### PR TITLE
Plugins can now define custom validation rules

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -577,7 +577,7 @@ class ServiceProvider extends ModuleServiceProvider
                 return strtr($message, [':values' => implode(', ', $parameters)]);
             });
 
-            $plugins = PluginManager::instance()->getRegistrationMethodValues('registerValidators');
+            $plugins = PluginManager::instance()->getRegistrationMethodValues('registerValidationRules');
             foreach ($plugins as $validators) {
                 foreach ($validators as $name => $validator) {
                     if (is_callable($validator)) {

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -10,6 +10,7 @@ use Request;
 use Validator;
 use BackendMenu;
 use BackendAuth;
+use SystemException;
 use Backend\Models\UserRole;
 use Twig\Extension\SandboxExtension;
 use Twig\Environment as TwigEnvironment;
@@ -582,6 +583,15 @@ class ServiceProvider extends ModuleServiceProvider
                 foreach ($validators as $name => $validator) {
                     if (is_callable($validator)) {
                         Validator::extend($name, $validator);
+                    } elseif (class_exists($validator)) {
+                        if (is_subclass_of($validator, 'October\Rain\Validation\Rule')) {
+                            Validator::extend($name, $validator);
+                        } else {
+                            throw new SystemException(sprintf(
+                                'Class "%s" must extend "October\Rain\Validation\Rule"',
+                                $validator
+                            ));
+                        }
                     }
                 }
             }

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -7,6 +7,7 @@ use Event;
 use Config;
 use Backend;
 use Request;
+use Validator;
 use BackendMenu;
 use BackendAuth;
 use Backend\Models\UserRole;
@@ -575,6 +576,15 @@ class ServiceProvider extends ModuleServiceProvider
             $validator->replacer('extensions', function ($message, $attribute, $rule, $parameters) {
                 return strtr($message, [':values' => implode(', ', $parameters)]);
             });
+
+            $plugins = PluginManager::instance()->getRegistrationMethodValues('registerValidator');
+            foreach ($plugins as $validators) {
+                foreach ($validators as $name => $validator) {
+                    if (is_callable($validator)) {
+                        Validator::extend($name, $validator);
+                    }
+                }
+            }
         });
     }
 

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -577,7 +577,7 @@ class ServiceProvider extends ModuleServiceProvider
                 return strtr($message, [':values' => implode(', ', $parameters)]);
             });
 
-            $plugins = PluginManager::instance()->getRegistrationMethodValues('registerValidator');
+            $plugins = PluginManager::instance()->getRegistrationMethodValues('registerValidators');
             foreach ($plugins as $validators) {
                 foreach ($validators as $name => $validator) {
                     if (is_callable($validator)) {

--- a/tests/fixtures/plugins/october/tester/Plugin.php
+++ b/tests/fixtures/plugins/october/tester/Plugin.php
@@ -68,7 +68,7 @@ class Plugin extends PluginBase
             'uppercase' => function ($attribute, $value, $parameters, $validator) {
                 return strtoupper($value) === $value;
             },
-            'be_like_bob' => \October\Tester\Rules\BeLikeBobRule::class
+            'be_like_bob' => \October\Tester\Rules\BeLikeBobRule::class,
         ];
     }
 }

--- a/tests/fixtures/plugins/october/tester/Plugin.php
+++ b/tests/fixtures/plugins/october/tester/Plugin.php
@@ -66,7 +66,7 @@ class Plugin extends PluginBase
     {
         return [
             'uppercase' => function ($attribute, $value, $parameters, $validator) {
-                return strtoupper($value) == $value;
+                return strtoupper($value) === $value;
             },
             'be_like_bob' => \October\Tester\Rules\BeLikeBobRule::class
         ];

--- a/tests/fixtures/plugins/october/tester/Plugin.php
+++ b/tests/fixtures/plugins/october/tester/Plugin.php
@@ -61,4 +61,14 @@ class Plugin extends PluginBase
             ]
         ];
     }
+
+    public function registerValidationRules()
+    {
+        return [
+            'uppercase' => function ($attribute, $value, $parameters, $validator) {
+                return strtoupper($value) == $value;
+            },
+            'be_like_bob' => \October\Tester\Rules\BeLikeBobRule::class
+        ];
+    }
 }

--- a/tests/fixtures/plugins/october/tester/rules/BeLikeBobRule.php
+++ b/tests/fixtures/plugins/october/tester/rules/BeLikeBobRule.php
@@ -1,0 +1,41 @@
+<?php namespace October\Tester\Rules;
+
+use October\Rain\Validation\Rule;
+
+class BeLikeBobRule extends Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return $value == 'bob';
+    }
+
+    /**
+     * Validation callback method.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $params
+     * @return bool
+     */
+    public function validate($attribute, $value, $params)
+    {
+        return $this->passes($attribute, $value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'You must be like bob';
+    }
+}

--- a/tests/fixtures/plugins/october/tester/rules/BeLikeBobRule.php
+++ b/tests/fixtures/plugins/october/tester/rules/BeLikeBobRule.php
@@ -13,7 +13,7 @@ class BeLikeBobRule extends Rule
      */
     public function passes($attribute, $value)
     {
-        return $value == 'bob';
+        return $value === 'bob';
     }
 
     /**

--- a/tests/unit/plugins/system/CustomValidatorRulesTest.php
+++ b/tests/unit/plugins/system/CustomValidatorRulesTest.php
@@ -7,7 +7,7 @@ class CustomValidatorRulesTest extends PluginTestCase
         parent::setUp();
 
         include_once base_path() . '/tests/fixtures/plugins/october/tester/rules/BeLikeBobRule.php';
-        include_once base_path().'/tests/fixtures/plugins/october/tester/Plugin.php';
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/Plugin.php';
 
         $this->runPluginRefreshCommand('October.Tester');
     }

--- a/tests/unit/plugins/system/CustomValidatorRulesTest.php
+++ b/tests/unit/plugins/system/CustomValidatorRulesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+class CustomValidatorRulesTest extends PluginTestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        include_once base_path() . '/tests/fixtures/plugins/october/tester/rules/BeLikeBobRule.php';
+        include_once base_path().'/tests/fixtures/plugins/october/tester/Plugin.php';
+
+        $this->runPluginRefreshCommand('October.Tester');
+    }
+
+    public function testValidationUsingClosure()
+    {
+        $validData = [
+            'company' => 'ACME'
+        ];
+
+        $invalidData = [
+            'company' => 'Acme'
+        ];
+
+        $rules = [
+            'company' => 'uppercase'
+        ];
+
+        $validationWithValidData = Validator::make($validData, $rules);
+        $validationWithInvalidData = Validator::make($invalidData, $rules);
+
+        $this->assertFalse($validationWithValidData->fails());
+        $this->assertTrue($validationWithInvalidData->fails());
+    }
+    
+    public function testValidationUsingRuleObject()
+    {
+        $validData = [
+            'name' => 'bob'
+        ];
+
+        $invalidData = [
+            'name' => 'karen'
+        ];
+
+        $rules = [
+            'name' => 'be_like_bob'
+        ];
+
+        $validationWithValidData = Validator::make($validData, $rules);
+        $validationWithInvalidData = Validator::make($invalidData, $rules);
+
+        $this->assertFalse($validationWithValidData->fails());
+        $this->assertTrue($validationWithInvalidData->fails());
+        $this->assertEquals($validationWithInvalidData->errors()->first(), 'You must be like bob');
+    }
+}


### PR DESCRIPTION
Added a new feature by which plugins can now define custom validators. For example, the Responsiv.Currency plugin can now declare a new validation for currency by adding a code block like:
```php
/**
 * Register any new validators
 * @return array
 */
public function registerValidator()
{
    return [
        'currency' => function ($attribute, $value, $parameter, $validator) {
            // return true if $value is valid currency format
        }
    ];
}
```