### PR TITLE
Fix: Set default value for fields

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1129,7 +1129,7 @@ class Form extends WidgetBase
         if ($enableDefaults === false) {
             return false;
         }
-        return !$this->model->exists || $enableDefaults;
+        return $this->model->exists || $enableDefaults;
     }
 
     /**


### PR DESCRIPTION
    
    /**
     * Checks if default values should be taken from data.
     * This should be done when model exists or when explicitly configured
     */
    protected function shouldFetchDefaultValues()
    {
        $enableDefaults = object_get($this->config, 'enableDefaults');
        if ($enableDefaults === false) {
            return false;
        }
        return !$this->model->exists || $enableDefaults;
    }

Function should be done when model exists but function return FALSE when model exists. I remove "!" from line 1132.

Test with following configuration. works fine.

```
fields:
    field_text:
        label: field_text
        type: text
        default: default text
        span: left
    field_number:
        label: field_number
        type: number
        default: 123
        span: left
    field_radio:
        label: field_radio
        type: radio
        default: 2
        options:
            1: 1)
            2: 2)
            3: 3)
            4: 4)
            span: left
    field_dropdown:
        label: field_dropdown
        type: dropdown
        default: 3
        options:
            1: 1)
            2: 2)
            3: 3)
            4: 4)
        span: left
```

![image](https://user-images.githubusercontent.com/75523139/109513180-6a01eb00-7ad7-11eb-8450-362241b38f37.png)
