### PR TITLE
Update lang.php - groups_comment in french

### DIFF
--- a/modules/backend/lang/fr/lang.php
+++ b/modules/backend/lang/fr/lang.php
@@ -119,7 +119,7 @@ return [
         'role_field' => 'Rôle',
         'role_comment' => 'Les rôles définissent les permissions de l\'utilisateur, elles peuvent être écrasés au niveau de l\'utilisateur dans l\'onglet "Permissions".',
         'groups' => 'Groupes',
-        'groups_comment' => 'Préciser les groupes auxquels ce compte doit appartenir. Les groupes définissent les permissions des utilisateurs, qui peuvent être surchargées au niveau de l’utilisateur, dans l’onglet Permissions.',
+        'groups_comment' => 'Préciser les groupes auxquels ce compte doit appartenir.',
         'avatar' => 'Avatar',
         'password' => 'Mot de passe',
         'password_confirmation' => 'Confirmer le mot de passe',


### PR DESCRIPTION
Wrong comment on groups_comment in french. Missuse with role comment. Groups can't be changed granuraly in user permission.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->