### PR TITLE
Dynamically configure per page options

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -145,6 +145,7 @@ class ListController extends ControllerBehavior
             'recordUrl',
             'recordOnClick',
             'recordsPerPage',
+            'perPageOptions',
             'showPageNumbers',
             'noRecordsMessage',
             'defaultSort',

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -62,6 +62,12 @@ class Lists extends WidgetBase
      * @var int Maximum rows to display for each page.
      */
     public $recordsPerPage;
+    
+    /**
+     * @var array Options for number of items per page.
+     */
+    public $perPageOptions;
+
 
     /**
      * @var bool Shows the sorting options for each column.
@@ -199,6 +205,7 @@ class Lists extends WidgetBase
             'noRecordsMessage',
             'showPageNumbers',
             'recordsPerPage',
+            'perPageOptions',
             'showSorting',
             'defaultSort',
             'showCheckboxes',
@@ -1689,7 +1696,7 @@ class Lists extends WidgetBase
      */
     protected function getSetupPerPageOptions()
     {
-        $perPageOptions = [20, 40, 80, 100, 120];
+        $perPageOptions = is_array($this->perPageOptions) ? $this->perPageOptions : [20, 40, 80, 100, 120];
         if (!in_array($this->recordsPerPage, $perPageOptions)) {
             $perPageOptions[] = $this->recordsPerPage;
         }


### PR DESCRIPTION
It is now possible to change the perPageOptions of a list dynamically according to the config_list.yaml file. This allows the user to be more flexible.