### PR TITLE
call controlUtils.disposeControls in popup.js

### DIFF
--- a/modules/system/assets/ui/js/popup.js
+++ b/modules/system/assets/ui/js/popup.js
@@ -145,6 +145,7 @@
 
         this.$modal.on('hidden.bs.modal', function(){
             self.triggerEvent('hidden.oc.popup')
+            $.oc.foundation.controlUtils.disposeControls(self.$container.get(0))
             self.$container.remove()
             $(document.body).removeClass('modal-open')
             self.dispose()


### PR DESCRIPTION
#5112 adds the necessary cleanup for the formwidget but 'dispose-control' listener is not triggered when a popup is closed
https://github.com/octobercms/october/blob/ea4ca1802bdbdb46ed20c127ae1c1a4e68a52a1c/modules/backend/widgets/form/assets/js/october.form.js#L41

This commit calls $.oc.foundation.controlUtils.disposeControls on the popup container, similar to popover.js and tab.js
https://github.com/octobercms/october/blob/ea4ca1802bdbdb46ed20c127ae1c1a4e68a52a1c/modules/system/assets/ui/js/popover.js#L39
https://github.com/octobercms/october/blob/ea4ca1802bdbdb46ed20c127ae1c1a4e68a52a1c/modules/system/assets/ui/js/tab.js#L220

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/octobercms/docs to update the documentation
-->