### PR TITLE
Fix setting ignoreTimezone for date filters 

### DIFF
--- a/modules/system/assets/ui/js/filter.dates.js
+++ b/modules/system/assets/ui/js/filter.dates.js
@@ -29,7 +29,13 @@
     FilterWidget.prototype.init = function () {
         overloaded_init.apply(this)
 
-        this.ignoreTimezone = this.$el.children().get(0).hasAttribute('data-ignore-timezone');
+        var self = this;
+        this.$el.children().each(function(key, $filter) {
+            if ($filter.hasAttribute('data-ignore-timezone')) {
+                self.ignoreTimezone = true;
+                return false;
+            }
+        });
 
         this.initRegion()
         this.initFilterDate()


### PR DESCRIPTION
Set ignoreTimezone to true if at least one of the filter has a data-ignore-timezone attribute