### PR TITLE
Add event to override recordUrl in Lists widget

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -578,7 +578,7 @@ class ListController extends ControllerBehavior
     /**
      * Override the record url for the given record
      * @param string $url The default url to override
-     * @param \October\Rain\Database\Model $record 
+     * @param \October\Rain\Database\Model $record
      * @param string|null $definition List definition (optional)
      * @return string|void New url
      */

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -195,6 +195,10 @@ class ListController extends ControllerBehavior
         $widget->bindEvent('list.overrideHeaderValue', function ($column, $value) use ($definition) {
             return $this->controller->listOverrideHeaderValue($column->columnName, $definition);
         });
+        
+        $widget->bindEvent('list.overrideRecordUrl', function ($url, $record) use ($definition) {
+            return $this->controller->listOverrideRecordUrl($url, $record, $definition);
+        });
 
         $widget->bindToController();
 
@@ -568,6 +572,17 @@ class ListController extends ControllerBehavior
      * @return string|void HTML view
      */
     public function listOverrideHeaderValue($columnName, $definition = null)
+    {
+    }
+    
+    /**
+     * Override the record url for the given record
+     * @param string $url The default url to override
+     * @param \October\Rain\Database\Model $record 
+     * @param string|null $definition List definition (optional)
+     * @return string|void New url
+     */
+    public function listOverrideRecordUrl($url, $record, $definition = null)
     {
     }
 

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -685,6 +685,34 @@ class Lists extends WidgetBase
         }
 
         $url = RouterHelper::replaceParameters($record, $this->recordUrl);
+
+        /**
+         * @event backend.list.overrideRecordUrl
+         * Overrides the record url in a list widget.
+         *
+         * If a value is returned from this event, it will be used as the url for the provided record.
+         * $url contains the default url and $record is a reference to the model instance.
+         * Example usage:
+         *
+         *     Event::listen('backend.list.overrideRecordUrl', function ($listWidget, $url, $record) {
+         *         if($record->user_id !== BackendAuth::getUser()->id) {
+         *             return 'acme/blog/posts/preview/' . $record->id;
+         *         }
+         *     });
+         *
+         * Or
+         *
+         *     $listWidget->bindEvent('list.overrideRecordUrl', function ($url, $record) {
+         *         if($record->user_id !== BackendAuth::getUser()->id) {
+         *             return 'acme/blog/posts/preview/' . $record->id;
+         *         }
+         *     });
+         *
+         */
+        if ($event = $this->fireSystemEvent('backend.list.overrideRecordUrl', [$url, $record])) {
+            $url = $event;
+        }
+
         return Backend::url($url);
     }
 


### PR DESCRIPTION
The use case should be clear from the example in code.

Basically, in my controller I want to be able to decide if I want to preview or update a record based on some custom logic:

```php
public function listOverrideRecordUrl($url, $model)
    {
        if($model->user_id !== BackendAuth::getUser()->id) {
            return 'acme/test/services/preview/' . $model->id;
        }
    }
```