### PR TITLE
Add resized to White listed folders

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -36,6 +36,7 @@
     RewriteCond %{REQUEST_FILENAME} -f
     RewriteCond %{REQUEST_FILENAME} !/.well-known/*
     RewriteCond %{REQUEST_FILENAME} !/storage/app/media/.*
+    RewriteCond %{REQUEST_FILENAME} !/storage/app/resized/.*
     RewriteCond %{REQUEST_FILENAME} !/storage/app/resources/.*
     RewriteCond %{REQUEST_FILENAME} !/storage/app/uploads/public/.*
     RewriteCond %{REQUEST_FILENAME} !/storage/temp/public/.*


### PR DESCRIPTION
Resizer adds images to `storage/app/resized` directory, but this directory is not whitelisted