### PR TITLE
Fix column preview

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -15,6 +15,7 @@ use League\Csv\EscapeFormula as CsvEscapeFormula;
 use ApplicationException;
 use SplTempFileObject;
 use Exception;
+use League\Csv\Statement;
 
 /**
  * Adds features for importing and exporting data.
@@ -250,10 +251,13 @@ class ImportExportController extends ControllerBehavior
         $reader = $this->createCsvReader($path);
 
         if (post('first_row_titles')) {
-            $reader->setOffset(1);
+            $reader->setHeaderOffset(1);
         }
 
-        $result = $reader->setLimit(50)->fetchColumn((int) $columnId);
+        $result = (new Statement())
+            ->limit(50)
+            ->process($reader)
+            ->fetchColumn((int) $columnId);
         $data = iterator_to_array($result, false);
 
         /*


### PR DESCRIPTION
The interface for league/csv changed a bit for v9, see [documentation here](https://csv.thephpleague.com/9.0/reader/).

As the `october/rain` library v1.1 [depends on `league/csv` v9.1](https://github.com/octobercms/library/blob/8f06437ab772b48dd7ea7079c293f436438f867d/composer.json#L39), this change is required to make the column preview work again.