### PR TITLE
fix ua and ru auto-translation errors

### DIFF
--- a/modules/tailor/lang/ru.json
+++ b/modules/tailor/lang/ru.json
@@ -24,11 +24,11 @@
   "Hidden": "Скрытый",
   "Draft": "Черновик",
   "Deleted": "Удалено",
-  "Slug": "Ссылка",
+  "Slug": "Слаг",
   "Enabled": "Включено",
   "Schedule publish date": "Запланировать дату публикации",
   "Set expiry date": "Дата снятии с публикации",
-  "View full slug": "Посмотреть полную ссылку",
+  "View full slug": "Посмотреть полный слаг",
   "Apply this Draft": "Сделать этот черновик основной записью",
   "Remove": "Удалить",
   "Drafts are not visible on the website until they are applied.": "Черновики не видны на сайте до тех пор пока они не опубликованы.",
@@ -62,6 +62,6 @@
   "Specify the slug used to find the primary record.": "Укажите слаг, используемый для поиска основной записи.",
   "Default View": "Вид по умолчанию",
   "Used as default entry point when previewing the record.": "Используется как точка входа по умолчанию при предварительном просмотре записи.",
-  "Full Slug": "Полный слизняк",
+  "Full Slug": "Полный слаг",
   "Use the full slug when looking up the record.": "Используйте полный слаг при поиске записи."
 }

--- a/modules/tailor/lang/uk.json
+++ b/modules/tailor/lang/uk.json
@@ -24,12 +24,12 @@
   "Hidden": "Прихований",
   "Draft": "Чернетка",
   "Deleted": "Видалено",
-  "Slug": "Слимак",
+  "Slug": "Слаг",
   "Enabled": "Увімкнено",
   "Schedule publish date": "Запланувати дату публікації",
   "Set expiry date": "Встановіть термін придатності",
-  "View full slug": "Переглянути повний слизень",
-  "Apply this Draft": "Застосувати цей проект",
+  "View full slug": "Переглянути повний слаг",
+  "Apply this Draft": "Застосувати цю чернетку",
   "Remove": "видалити",
   "Drafts are not visible on the website until they are applied.": "Чернетки не відображаються на веб-сайті, доки їх не буде застосовано.",
   "Save Draft": "Зберегти чернетку",
@@ -62,6 +62,6 @@
   "Specify the slug used to find the primary record.": "Укажіть слаг, який використовується для пошуку основного запису.",
   "Default View": "Перегляд за умовчанням",
   "Used as default entry point when previewing the record.": "Використовується як точка входу за умовчанням під час попереднього перегляду запису.",
-  "Full Slug": "Повний Слизень",
+  "Full Slug": "Повний слаг",
   "Use the full slug when looking up the record.": "Використовуйте повний слаг під час пошуку запису."
 }


### PR DESCRIPTION
In this PR I fixed auto-translation errors for ua and ru languages for the tailor module.
The word "slug" was auto-translated literally. The Ukrainian and Russian language don't have their own word for slug. 
We use the English word and write it the way it sounds.