### PR TITLE
use current PHP rather than cli default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
         "post-create-project-cmd": [
-            "php artisan key:generate --ansi"
+            "@php artisan key:generate --ansi"
         ],
         "post-autoload-dump": [
             "System\\Console\\ComposerScript::postAutoloadDump"


### PR DESCRIPTION
When multiple versions of PHP are installed and the non-default PHP version is used to run `composer create-project`, this `post-create-project-cmd` script uses the cli default PHP version rather than the initiated PHP version.