### PR TITLE
Fix Twig 3.21 deprecation warning in GetAttrNode

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -253,7 +253,7 @@ class FormController extends ControllerBehavior
             throw new ForbiddenException;
         }
 
-        $this->context = strlen($context) ? $context : $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
+        $this->context = $context ?: $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
 
         $model = $this->controller->formCreateModelObject();
         $model = $this->controller->formExtendModel($model) ?: $model;
@@ -294,7 +294,7 @@ class FormController extends ControllerBehavior
      */
     public function create_onCancel($context = null)
     {
-        $this->context = strlen($context) ? $context : $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
+        $this->context = $context ?: $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
 
         $model = $this->controller->formCreateModelObject();
         $model = $this->controller->formExtendModel($model) ?: $model;
@@ -331,7 +331,7 @@ class FormController extends ControllerBehavior
         }
 
         try {
-            $this->context = strlen($context) ? $context : $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
+            $this->context = $context ?: $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
             $this->controller->bodyClass ??= $this->getDesignBodyClass();
             $this->controller->pageSize ??= $this->getDesignFormSize();
             $this->controller->pageTitle ??= $this->getLang('update[title]', 'backend::lang.form.update_title');
@@ -371,7 +371,7 @@ class FormController extends ControllerBehavior
             throw new ForbiddenException;
         }
 
-        $this->context = strlen($context) ? $context : $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
+        $this->context = $context ?: $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
         $model = $this->controller->formFindModelObject($recordId);
         $this->initForm($model);
 
@@ -476,7 +476,7 @@ class FormController extends ControllerBehavior
         }
 
         try {
-            $this->context = strlen($context) ? $context : $this->getConfig('preview[context]', FormField::CONTEXT_PREVIEW);
+            $this->context = $context ?: $this->getConfig('preview[context]', FormField::CONTEXT_PREVIEW);
             $this->controller->bodyClass ??= $this->getDesignBodyClass();
             $this->controller->pageSize ??= $this->getDesignFormSize();
             $this->controller->pageTitle ??= $this->getLang('preview[title]', 'backend::lang.form.preview_title');
@@ -705,8 +705,8 @@ class FormController extends ControllerBehavior
         $name = $this->getConfig($name, $default);
 
         $vars = $extras + [
-            'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
-        ];
+                'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
+            ];
 
         return Lang::get($name, $vars);
     }
@@ -741,8 +741,8 @@ class FormController extends ControllerBehavior
         }
 
         $vars = $extras + [
-            'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
-        ];
+                'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
+            ];
 
         return Lang::get($foundKey, $vars);
     }

--- a/modules/cms/twig/GetAttrAdjuster.php
+++ b/modules/cms/twig/GetAttrAdjuster.php
@@ -4,6 +4,7 @@ use Twig\Node\Node;
 use Twig\Environment;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\NodeVisitor\NodeVisitorInterface;
+use Twig\Node\Expression\SupportDefinedTestInterface;
 
 /**
  * GetAttrAdjuster tweaks the get attribute functionality.
@@ -30,7 +31,6 @@ class GetAttrAdjuster implements NodeVisitorInterface
 
         $attributes = [
             'type' => $node->getAttribute('type'),
-            'is_defined_test' => $node->getAttribute('is_defined_test'),
             'ignore_strict_check' => $node->getAttribute('ignore_strict_check'),
             'optimizable' => $node->getAttribute('optimizable'),
         ];

--- a/modules/cms/twig/GetAttrNode.php
+++ b/modules/cms/twig/GetAttrNode.php
@@ -8,13 +8,17 @@ use Twig\Environment;
 use Twig\Extension\SandboxExtension;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Extension\CoreExtension;
+use Twig\Node\Expression\SupportDefinedTestInterface;
+use Twig\Node\Expression\SupportDefinedTestTrait;
 
 /**
  * GetAttrNode compiles a custom get attribute node.
  * Carbon copy of the parent class with custom get attribute logic.
  */
-class GetAttrNode extends GetAttrExpression
+class GetAttrNode extends GetAttrExpression implements SupportDefinedTestInterface
 {
+    use SupportDefinedTestTrait;
+
     /**
      * @inheritdoc
      */
@@ -35,7 +39,7 @@ class GetAttrNode extends GetAttrExpression
         if (
             $this->getAttribute('optimizable')
             && (!$env->isStrictVariables() || $this->getAttribute('ignore_strict_check'))
-            && !$this->getAttribute('is_defined_test')
+            && !$this->isDefinedTestEnabled()
             && Template::ARRAY_CALL === $this->getAttribute('type')
         ) {
             $var = '$'.$compiler->getVarName();
@@ -78,7 +82,7 @@ class GetAttrNode extends GetAttrExpression
 
         $compiler->raw(', ')
             ->repr($this->getAttribute('type'))
-            ->raw(', ')->repr($this->getAttribute('is_defined_test'))
+            ->raw(', ')->repr($this->isDefinedTestEnabled())
             ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
             ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
             ->raw(', ')->repr($this->getNode('node')->getTemplateLine())


### PR DESCRIPTION
![Screenshot 2025-06-19 at 1 54 45 PM](https://github.com/user-attachments/assets/610f706d-6b36-493d-b0d9-48c0bd7e42aa)
