### PR TITLE
Fix twig deprecated get expression parser

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -253,7 +253,7 @@ class FormController extends ControllerBehavior
             throw new ForbiddenException;
         }
 
-        $this->context = strlen($context) ? $context : $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
+        $this->context = $context ?: $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
 
         $model = $this->controller->formCreateModelObject();
         $model = $this->controller->formExtendModel($model) ?: $model;
@@ -294,7 +294,7 @@ class FormController extends ControllerBehavior
      */
     public function create_onCancel($context = null)
     {
-        $this->context = strlen($context) ? $context : $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
+        $this->context = $context ?: $this->getConfig('create[context]', FormField::CONTEXT_CREATE);
 
         $model = $this->controller->formCreateModelObject();
         $model = $this->controller->formExtendModel($model) ?: $model;
@@ -331,7 +331,7 @@ class FormController extends ControllerBehavior
         }
 
         try {
-            $this->context = strlen($context) ? $context : $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
+            $this->context = $context ?: $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
             $this->controller->bodyClass ??= $this->getDesignBodyClass();
             $this->controller->pageSize ??= $this->getDesignFormSize();
             $this->controller->pageTitle ??= $this->getLang('update[title]', 'backend::lang.form.update_title');
@@ -371,7 +371,7 @@ class FormController extends ControllerBehavior
             throw new ForbiddenException;
         }
 
-        $this->context = strlen($context) ? $context : $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
+        $this->context = $context ?: $this->getConfig('update[context]', FormField::CONTEXT_UPDATE);
         $model = $this->controller->formFindModelObject($recordId);
         $this->initForm($model);
 
@@ -476,7 +476,7 @@ class FormController extends ControllerBehavior
         }
 
         try {
-            $this->context = strlen($context) ? $context : $this->getConfig('preview[context]', FormField::CONTEXT_PREVIEW);
+            $this->context = $context ?: $this->getConfig('preview[context]', FormField::CONTEXT_PREVIEW);
             $this->controller->bodyClass ??= $this->getDesignBodyClass();
             $this->controller->pageSize ??= $this->getDesignFormSize();
             $this->controller->pageTitle ??= $this->getLang('preview[title]', 'backend::lang.form.preview_title');
@@ -705,8 +705,8 @@ class FormController extends ControllerBehavior
         $name = $this->getConfig($name, $default);
 
         $vars = $extras + [
-            'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
-        ];
+                'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
+            ];
 
         return Lang::get($name, $vars);
     }
@@ -741,8 +741,8 @@ class FormController extends ControllerBehavior
         }
 
         $vars = $extras + [
-            'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
-        ];
+                'name' => Lang::get($this->getConfig('name', 'backend::lang.model.name'))
+            ];
 
         return Lang::get($foundKey, $vars);
     }

--- a/modules/cms/twig/ComponentTokenParser.php
+++ b/modules/cms/twig/ComponentTokenParser.php
@@ -28,7 +28,7 @@ class ComponentTokenParser extends TwigTokenParser
         $paramNames = [];
 
         // Parse component name
-        $nodes['name'] = $this->parser->getExpressionParser()->parseExpression();
+        $nodes['name'] = $this->parser->parseExpression();
 
         // Parse parameters
         while (!$stream->test(TwigToken::BLOCK_END_TYPE)) {
@@ -37,7 +37,7 @@ class ComponentTokenParser extends TwigTokenParser
             if ($current->test(TwigToken::NAME_TYPE)) {
                 $paramName = $current->getValue();
                 $stream->expect(TwigToken::OPERATOR_TYPE, '=');
-                $nodes[$paramName] = $this->parser->getExpressionParser()->parseExpression();
+                $nodes[$paramName] = $this->parser->parseExpression();
                 $paramNames[] = $paramName;
             }
             else {

--- a/modules/cms/twig/ContentTokenParser.php
+++ b/modules/cms/twig/ContentTokenParser.php
@@ -31,7 +31,7 @@ class ContentTokenParser extends TwigTokenParser
         $paramNames = [];
 
         // Parse content name (first argument)
-        $nodes['name'] = $this->parser->getExpressionParser()->parseExpression();
+        $nodes['name'] = $this->parser->parseExpression();
 
         // Parse optional parameters
         while (!$stream->test(TwigToken::BLOCK_END_TYPE)) {
@@ -40,7 +40,7 @@ class ContentTokenParser extends TwigTokenParser
             if ($current->test(TwigToken::NAME_TYPE)) {
                 $paramName = $current->getValue();
                 $stream->expect(TwigToken::OPERATOR_TYPE, '=');
-                $nodes[$paramName] = $this->parser->getExpressionParser()->parseExpression();
+                $nodes[$paramName] = $this->parser->parseExpression();
                 $paramNames[] = $paramName;
             }
             else {

--- a/modules/cms/twig/GetAttrAdjuster.php
+++ b/modules/cms/twig/GetAttrAdjuster.php
@@ -4,6 +4,7 @@ use Twig\Node\Node;
 use Twig\Environment;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\NodeVisitor\NodeVisitorInterface;
+use Twig\Node\Expression\SupportDefinedTestInterface;
 
 /**
  * GetAttrAdjuster tweaks the get attribute functionality.
@@ -30,7 +31,6 @@ class GetAttrAdjuster implements NodeVisitorInterface
 
         $attributes = [
             'type' => $node->getAttribute('type'),
-            'is_defined_test' => $node->getAttribute('is_defined_test'),
             'ignore_strict_check' => $node->getAttribute('ignore_strict_check'),
             'optimizable' => $node->getAttribute('optimizable'),
         ];

--- a/modules/cms/twig/GetAttrNode.php
+++ b/modules/cms/twig/GetAttrNode.php
@@ -8,13 +8,17 @@ use Twig\Environment;
 use Twig\Extension\SandboxExtension;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Extension\CoreExtension;
+use Twig\Node\Expression\SupportDefinedTestInterface;
+use Twig\Node\Expression\SupportDefinedTestTrait;
 
 /**
  * GetAttrNode compiles a custom get attribute node.
  * Carbon copy of the parent class with custom get attribute logic.
  */
-class GetAttrNode extends GetAttrExpression
+class GetAttrNode extends GetAttrExpression implements SupportDefinedTestInterface
 {
+    use SupportDefinedTestTrait;
+
     /**
      * @inheritdoc
      */
@@ -35,7 +39,7 @@ class GetAttrNode extends GetAttrExpression
         if (
             $this->getAttribute('optimizable')
             && (!$env->isStrictVariables() || $this->getAttribute('ignore_strict_check'))
-            && !$this->getAttribute('is_defined_test')
+            && !$this->isDefinedTestEnabled()
             && Template::ARRAY_CALL === $this->getAttribute('type')
         ) {
             $var = '$'.$compiler->getVarName();
@@ -78,7 +82,7 @@ class GetAttrNode extends GetAttrExpression
 
         $compiler->raw(', ')
             ->repr($this->getAttribute('type'))
-            ->raw(', ')->repr($this->getAttribute('is_defined_test'))
+            ->raw(', ')->repr($this->isDefinedTestEnabled())
             ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
             ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
             ->raw(', ')->repr($this->getNode('node')->getTemplateLine())

--- a/modules/cms/twig/PartialTokenParser.php
+++ b/modules/cms/twig/PartialTokenParser.php
@@ -35,7 +35,7 @@ class PartialTokenParser extends TwigTokenParser
         $isAjax = $this->getTag() === 'ajaxPartial';
 
         // Parse partial name (first argument)
-        $nodes['name'] = $this->parser->getExpressionParser()->parseExpression();
+        $nodes['name'] = $this->parser->parseExpression();
 
         // Parse optional parameters
         while (!$stream->test(TwigToken::BLOCK_END_TYPE)) {
@@ -66,7 +66,7 @@ class PartialTokenParser extends TwigTokenParser
             if ($current->test(TwigToken::NAME_TYPE)) {
                 $paramName = $current->getValue();
                 $stream->expect(TwigToken::OPERATOR_TYPE, '=');
-                $nodes[$paramName] = $this->parser->getExpressionParser()->parseExpression();
+                $nodes[$paramName] = $this->parser->parseExpression();
                 $paramNames[] = $paramName;
             }
             else {

--- a/modules/system/twig/MailPartialTokenParser.php
+++ b/modules/system/twig/MailPartialTokenParser.php
@@ -1,8 +1,9 @@
-<?php namespace System\Twig;
+<?php namespace October\twig;
 
+use System\Twig\MailPartialNode;
+use Twig\Error\SyntaxError as TwigErrorSyntax;
 use Twig\Token as TwigToken;
 use Twig\TokenParser\AbstractTokenParser as TwigTokenParser;
-use Twig\Error\SyntaxError as TwigErrorSyntax;
 
 /**
  * MailPartialTokenParser for the `{% partial %}` Twig tag.
@@ -33,7 +34,7 @@ class MailPartialTokenParser extends TwigTokenParser
         $body = null;
 
         // Parse partial name (first argument)
-        $nodes['name'] = $this->parser->getExpressionParser()->parseExpression();
+        $nodes['name'] = $this->parser->parseExpression();
 
         // Parse optional parameters
         while (!$stream->test(TwigToken::BLOCK_END_TYPE)) {
@@ -47,7 +48,7 @@ class MailPartialTokenParser extends TwigTokenParser
             if ($current->test(TwigToken::NAME_TYPE)) {
                 $paramName = $current->getValue();
                 $stream->expect(TwigToken::OPERATOR_TYPE, '=');
-                $nodes[$paramName] = $this->parser->getExpressionParser()->parseExpression();
+                $nodes[$paramName] = $this->parser->parseExpression();
                 $paramNames[] = $paramName;
             } else {
                 throw new TwigErrorSyntax(


### PR DESCRIPTION
`Since twig/twig 3.21: Method "Twig\Parser::getExpressionParser()" is deprecated, use "parseExpression()" instead. in /var/www/html/vendor/symfony/deprecation-contracts[/function.php](javascript:) on line 25`