### PR TITLE
Fix Twig deprecation warning in GetAttrNode

### DIFF
--- a/modules/cms/twig/GetAttrAdjuster.php
+++ b/modules/cms/twig/GetAttrAdjuster.php
@@ -4,6 +4,7 @@ use Twig\Node\Node;
 use Twig\Environment;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\NodeVisitor\NodeVisitorInterface;
+use Twig\Node\Expression\SupportDefinedTestInterface;
 
 /**
  * GetAttrAdjuster tweaks the get attribute functionality.
@@ -30,7 +31,6 @@ class GetAttrAdjuster implements NodeVisitorInterface
 
         $attributes = [
             'type' => $node->getAttribute('type'),
-            'is_defined_test' => $node->getAttribute('is_defined_test'),
             'ignore_strict_check' => $node->getAttribute('ignore_strict_check'),
             'optimizable' => $node->getAttribute('optimizable'),
         ];

--- a/modules/cms/twig/GetAttrNode.php
+++ b/modules/cms/twig/GetAttrNode.php
@@ -8,13 +8,17 @@ use Twig\Environment;
 use Twig\Extension\SandboxExtension;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Extension\CoreExtension;
+use Twig\Node\Expression\SupportDefinedTestInterface;
+use Twig\Node\Expression\SupportDefinedTestTrait;
 
 /**
  * GetAttrNode compiles a custom get attribute node.
  * Carbon copy of the parent class with custom get attribute logic.
  */
-class GetAttrNode extends GetAttrExpression
+class GetAttrNode extends GetAttrExpression implements SupportDefinedTestInterface
 {
+    use SupportDefinedTestTrait;
+
     /**
      * @inheritdoc
      */
@@ -35,7 +39,7 @@ class GetAttrNode extends GetAttrExpression
         if (
             $this->getAttribute('optimizable')
             && (!$env->isStrictVariables() || $this->getAttribute('ignore_strict_check'))
-            && !$this->getAttribute('is_defined_test')
+            && !$this->isDefinedTestEnabled()
             && Template::ARRAY_CALL === $this->getAttribute('type')
         ) {
             $var = '$'.$compiler->getVarName();
@@ -78,7 +82,7 @@ class GetAttrNode extends GetAttrExpression
 
         $compiler->raw(', ')
             ->repr($this->getAttribute('type'))
-            ->raw(', ')->repr($this->getAttribute('is_defined_test'))
+            ->raw(', ')->repr($this->isDefinedTestEnabled())
             ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
             ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
             ->raw(', ')->repr($this->getNode('node')->getTemplateLine())


### PR DESCRIPTION
![Screenshot 2025-06-19 at 1 54 45 PM](https://github.com/user-attachments/assets/01d79485-e61b-4686-803d-17eeac677a8f)
