### PR TITLE
Fix str_contains() null deprecation

### DIFF
--- a/modules/backend/widgets/lists/partials/_column_partial.php
+++ b/modules/backend/widgets/lists/partials/_column_partial.php
@@ -8,7 +8,7 @@
         'value' => $value
     ];
 ?>
-<?php if (str_contains($column->path, '::')): ?>
+<?php if (str_contains($column->path ?? '', '::')): ?>
     <?= View::make($column->path, $vars) ?>
 <?php elseif ($column->path && File::isPathSymbol($column->path)): ?>
     <?= $this->controller->makePartial($column->path, $vars) ?>


### PR DESCRIPTION
`str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in [/var/www/html/modules/backend/widgets/lists/partials/_column_partial.php](javascript:) on line 11`