### PR TITLE
Fix trim() null deprecation in HasAjaxRequests.php

### DIFF
--- a/modules/cms/classes/controller/HasAjaxRequests.php
+++ b/modules/cms/classes/controller/HasAjaxRequests.php
@@ -84,7 +84,9 @@ trait HasAjaxRequests
      */
     protected function getAjaxHandlerPartialList(): array
     {
-        if ($partialList = trim(Request::header('X_OCTOBER_REQUEST_PARTIALS'))) {
+        $partialList = Request::header('X_OCTOBER_REQUEST_PARTIALS');
+
+        if ($partialList && ($partialList = trim($partialList))) {
             $partials = explode('&', $partialList);
 
             foreach ($partials as $partial) {


### PR DESCRIPTION
`trim(): Passing null to parameter #1 ($string) of type string is deprecated in [/var/www/.../modules/cms/classes/controller/HasAjaxRequests.php](javascript:) on line 87`