### PR TITLE
Fix strlen() null deprecation in TrafficLogger.php

### DIFF
--- a/modules/dashboard/classes/TrafficLogger.php
+++ b/modules/dashboard/classes/TrafficLogger.php
@@ -51,7 +51,7 @@ class TrafficLogger
     {
         $retention = DashboardSetting::instance()->traffic_stats_retention;
 
-        if (strlen($retention) && is_int($retention)) {
+        if ($retention && strlen($retention) && is_int($retention)) {
             return (int) $retention;
         }
 


### PR DESCRIPTION
`strlen(): Passing null to parameter #1 ($string) of type string is deprecated in [/var/www/.../modules/dashboard/classes/TrafficLogger.php](javascript:) on line 54`