### PR TITLE
Fix lost changes in $result due to wrong variable in str_replace

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1550,7 +1550,7 @@ class Lists extends WidgetBase implements ListElement
         $result = str_replace(' <', '<', $result);
 
         // Add natural spacing between HTML nodes
-        $result = str_replace("><", '> <', $value);
+        $result = str_replace("><", '> <', $result);
 
         // Strip HTML
         $result = $original = trim(Html::strip($result));


### PR DESCRIPTION
@daftspunk found a bug in the original code — https://github.com/octobercms/october/blob/8a1c7546af2d496239117b3e689e87a7caa440b9/modules/backend/widgets/Lists.php#L1547C9-L1556C58

```php
...

$result = $value;
$result = str_replace(' <', '<', $result);

// Add natural spacing between HTML nodes
$result = str_replace("><", '> <', $value); // should use $result instead of $value

// Strip HTML
$result = $original = trim(Html::strip($result));

...
```