### PR TITLE
fixbug: add schema grammar initialization in Fieldset::getContentColumnNames

### DIFF
--- a/modules/tailor/classes/Fieldset.php
+++ b/modules/tailor/classes/Fieldset.php
@@ -190,6 +190,9 @@ class Fieldset extends FieldsetDefinition
     {
         $columnNames = [];
 
+        // Lazy load the grammar
+        Db::connection()->getSchemaBuilder();
+
         $table = new DbBlueprint(Db::connection(), 'temp');
         foreach ($this->getAllFields() as $name => $fieldObj) {
             if (!str_starts_with($name, '_')) {


### PR DESCRIPTION
`TypeError: Cannot assign null to property Illuminate\Database\Schema\Blueprint::$grammar of type Illuminate\Database\Schema\Grammars\Grammar in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Schema/Blueprint.php:103`

Here is issue — https://github.com/octobercms/october/issues/5900