### PR TITLE
Add a configuration to enable a non-strict role hierarchy.

### DIFF
--- a/config/backend.php
+++ b/config/backend.php
@@ -158,6 +158,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Strict Role hierarchy
+    |--------------------------------------------------------------------------
+    |
+    | Defines if the backend should enforce a strict role hierarchy.
+    |
+    | If set to false, users with the 'admins.manage' permission will be able
+    | to see and manage users with the same role
+    |
+    */
+
+    'strict_role_hierarchy' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Avatar
     |--------------------------------------------------------------------------
     |

--- a/modules/backend/controllers/UserRoles.php
+++ b/modules/backend/controllers/UserRoles.php
@@ -3,6 +3,7 @@
 use Backend;
 use BackendAuth;
 use Backend\Classes\SettingsController;
+use Config;
 use ForbiddenException;
 
 /**
@@ -89,6 +90,13 @@ class UserRoles extends SettingsController
             return;
         }
 
-        $query->where('sort_order', '>', $userRole->sort_order);
+        $comparaison = $this->verifyStrictRoles() ? '>' : '>=';
+
+        $query->where('sort_order', $comparaison, $userRole->sort_order);
+    }
+
+    public function verifyStrictRoles(): bool
+    {
+        return Config::get('backend.strict_role_hierarchy', true);
     }
 }


### PR DESCRIPTION
Here is my proposition to add a config option to make roles have a non-strict hierarchy (as it was in OCv1 and 2).

In some cases, our customers need to be able to manage each other's accounts without resorting to a shared admin account.

closes #5876