### PR TITLE
Prevent “Target class [cms.themes] does not exist” on page /system/market when the CMS module is disabled 

### DIFF
--- a/modules/cms/classes/ThemeManager.php
+++ b/modules/cms/classes/ThemeManager.php
@@ -39,7 +39,7 @@ class ThemeManager
      */
     public static function instance(): static
     {
-        return App::make('cms.themes');
+        return System::hasModule('Cms') ? App::make('cms.themes') : new static();
     }
 
     /**


### PR DESCRIPTION
## Issue
When the Cms module is removed from LOAD_MODULE, the binding `cms.themes` is never registered. Any call to ThemeManager::instance() therefore triggers these errors:
```logs
Next Illuminate\Contracts\Container\BindingResolutionException: Target class [cms.themes] does not exist. in /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Container.php:1019
...

#5 /var/www/html/modules/cms/classes/ThemeManager.php(42): Illuminate\Support\Facades\Facade::__callStatic()
```

## Testing & verification
Set `LOAD_MODULES="System,Backend"` on .env

