### PR TITLE
Fix partial name parameter conflict

### DIFF
--- a/modules/cms/twig/PartialNode.php
+++ b/modules/cms/twig/PartialNode.php
@@ -58,7 +58,7 @@ class PartialNode extends TwigNode
         if ($options['isAjax']) {
             $compiler
                 ->write("yield '<div data-ajax-partial=\"'.")
-                ->subcompile($this->getNode('name'))
+                ->subcompile($this->getNode('_partial_name'))
                 ->write(".'\">';\n");
         }
 
@@ -70,7 +70,7 @@ class PartialNode extends TwigNode
             // Render Partial
             $compiler
                 ->write("yield \$this->env->getExtension(\Cms\Twig\Extension::class)->partialFunction(")
-                ->subcompile($this->getNode('name'));
+                ->subcompile($this->getNode('_partial_name'));
 
             if ($options['hasOnly']) {
                 $compiler->write(", array_merge(['__cms_partial_params' => \$cmsPartialParams], \$cmsPartialParams)");

--- a/modules/cms/twig/PartialTokenParser.php
+++ b/modules/cms/twig/PartialTokenParser.php
@@ -34,8 +34,8 @@ class PartialTokenParser extends TwigTokenParser
 
         $isAjax = $this->getTag() === 'ajaxPartial';
 
-        // Parse partial name (first argument)
-        $nodes['name'] = $this->parser->parseExpression();
+        // Parse partial name (first argument) - use unique key
+        $nodes['_partial_name'] = $this->parser->parseExpression();
 
         // Parse optional parameters
         while (!$stream->test(TwigToken::BLOCK_END_TYPE)) {


### PR DESCRIPTION
## Description
Fixes a conflict when using `name` as a parameter in partial tags.

## Problem
When using `{% partial 'test' name='value' %}`, the `name` parameter conflicts with the internal storage of the partial name, causing the partial to fail to load.

## Solution
- Changed internal partial name storage from `'name'` to `'_partial_name'`
- Updated both `PartialTokenParser` and `PartialNode` classes
- Maintains full backward compatibility

## Testing
- [x] Tested with `{% partial 'test' name='123' %}` - works correctly
- [x] Tested with other parameters - works correctly  
- [x] Tested existing functionality - no regressions

## Example

Before (broken):

```twig
{% partial 'sidebar' name='John' %}
```

After (working):

```twig
{% partial 'sidebar' name='John' %}
```