### PR TITLE
Extend .htaccess index.php rule to include website root

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,6 +27,8 @@
     ##
     ## Uncomment to redirect /index.php/path to /path
     ##
+    # RewriteCond %{THE_REQUEST} ^[A-Z]{3,}\s/index\.php\s
+    # RewriteRule ^index\.php$ / [R=301,L]
     # RewriteRule ^index\.php/(.*)$ /$1 [L,R=301]
 
     ##


### PR DESCRIPTION
This PR adds 2 new rules to the .htaccess file to ensure that not only /page/index.php is redirected to /page/, but also the website root: /index.php will redirect to /