### PR TITLE
Add exception handling in addComponent to reset state on init failure

### DIFF
--- a/modules/cms/classes/controller/HasComponentHelpers.php
+++ b/modules/cms/classes/controller/HasComponentHelpers.php
@@ -6,6 +6,7 @@ use Cms\Classes\ComponentManager;
 use Cms\Classes\CmsException;
 use Cms\Classes\ComponentPartial;
 use Cms\Classes\ComponentBase;
+use Throwable;
 
 /**
  * HasComponentHelpers

--- a/modules/cms/classes/controller/HasComponentHelpers.php
+++ b/modules/cms/classes/controller/HasComponentHelpers.php
@@ -58,7 +58,19 @@ trait HasComponentHelpers
 
         $this->parseRouteParamsOnComponent($componentObj, $this->router->getParameters());
 
-        $componentObj->init();
+        try {
+            $componentObj->init();
+        } catch (Throwable $e) {
+            $this->vars[$alias];
+
+            if ($addToLayout) {
+                unset($this->layout->components[$alias]);
+            } else {
+                unset($this->page->components[$alias]);
+            }
+
+            throw $e;
+        }
 
         return $componentObj;
     }


### PR DESCRIPTION
**Problem**

When manually registering a component from within another component, an exception thrown in the init method is currently caught and interpreted as meaning that the component is not available (e.g. due to a permission check). The expectation was that by catching this exception, the component would not be rendered on the page.

However, the current implementation first registers the component on the page or layout, and only afterwards calls init. Because of this, even if init throws an exception, the onRun method is still invoked later on. As a result, components that fail during init remain registered on the page/layout, and their lifecycle continues.

**How to reproduce**

1. Create two test components:

ExampleComponent
- Call `$this->getController()->addComponent(FooComponent::class, 'fooComponent')` inside `init()` method.
- Wrap the call in a try/catch block that ignores exceptions.

FooComponent
- In `init()`, throw a `RuntimeException("Thou shall not pass")`.
- In `onRun()`, try to access an uninitialized property (to demonstrate that lifecycle continues if the component remains registered).

2. Add ExampleComponent to a CMS page.
3. Open that page in the browser.

**Change**

This PR introduces exception handling around the init call in
\Cms\Classes\Controller\HasComponentHelpers::addComponent.

If init fails, the component is removed from:

`$this->vars[$alias]`

`$this->layout->components[$alias] or $this->page->components[$alias]`

After cleanup, the original exception is re-thrown. This ensures that components which cannot initialize properly do not remain registered and do not continue their lifecycle (onRun etc.), preventing inconsistent or unexpected behavior.