### PR TITLE
Tailor: translate content group names in Entry Type dropdown

### DIFF
--- a/modules/tailor/classes/blueprint/EntryBlueprint.php
+++ b/modules/tailor/classes/blueprint/EntryBlueprint.php
@@ -204,7 +204,7 @@ class EntryBlueprint extends Blueprint
         $options = [];
 
         foreach ($this->groups as $handle => $entry) {
-            $options[$handle] = $entry['name'] ?? $handle;
+            $options[$handle] = trans($entry['name'] ?? $handle);
         }
 
         return $options;


### PR DESCRIPTION
Wrap name with trans() in EntryBlueprint::getEntryTypeOptions() so the Entry Type selector shows translated labels.
Ref: https://talk.octobercms.com/t/how-do-i-set-a-translation-for-a-content-group/2685/5
