### PR TITLE
Backend Form: hide locale indicator for `ruler` field (align with `section`/`hint`)

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1065,7 +1065,7 @@ class Form extends WidgetBase implements FormElement
      */
     protected function showFieldLabels(FormField $field): bool
     {
-        if (in_array($field->type, ['checkbox', 'switch', 'section', 'hint', 'rule'])) {
+        if (in_array($field->type, ['checkbox', 'switch', 'section', 'hint', 'ruler'])) {
             return false;
         }
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1065,7 +1065,7 @@ class Form extends WidgetBase implements FormElement
      */
     protected function showFieldLabels(FormField $field): bool
     {
-        if (in_array($field->type, ['checkbox', 'switch', 'section', 'hint'])) {
+        if (in_array($field->type, ['checkbox', 'switch', 'section', 'hint', 'rule'])) {
             return false;
         }
 

--- a/modules/backend/widgets/form/partials/_field_ruler.php
+++ b/modules/backend/widgets/form/partials/_field_ruler.php
@@ -5,7 +5,7 @@
     </label>
 <?php endif ?>
 <div class="field-horizontalrule">
-    <hr>
+    <hr />
 </div>
 <?php if ($field->comment): ?>
     <p class="form-text">

--- a/modules/backend/widgets/form/partials/_field_ruler.php
+++ b/modules/backend/widgets/form/partials/_field_ruler.php
@@ -1,4 +1,14 @@
-<!-- Horizontal Rule -->
-<div class="field-horizontalrule">
-    <hr />
+<!-- Rule -->
+<?php if ($field->label): ?>
+    <label for="<?= $field->getId() ?>" class="form-label">
+        <?= e(__($field->label)) ?>
+    </label>
+<?php endif ?>
+<div class="field-rule">
+    <hr>
 </div>
+<?php if ($field->comment): ?>
+    <p class="form-text">
+        <?= $field->commentHtml ? trans($field->comment) : e(__($field->comment)) ?>
+    </p>
+<?php endif ?>

--- a/modules/backend/widgets/form/partials/_field_ruler.php
+++ b/modules/backend/widgets/form/partials/_field_ruler.php
@@ -1,10 +1,10 @@
-<!-- Rule -->
+<!-- Horizontal Rule -->
 <?php if ($field->label): ?>
     <label for="<?= $field->getId() ?>" class="form-label">
         <?= e(__($field->label)) ?>
     </label>
 <?php endif ?>
-<div class="field-rule">
+<div class="field-horizontalrule">
     <hr>
 </div>
 <?php if ($field->comment): ?>


### PR DESCRIPTION
**Problem:** In a translatable context (e.g., Tailor with `multisite: sync`), the `ruler` field shows a locale badge next to its generic label, even though it’s a structural (non-data) field. `section` and `hint` don’t show the badge because they render their own headers in their partials.

**Solution:** Make `ruler` behave like `section`/`hint`:

* Don’t render the generic label for `ruler` (so the locale badge doesn’t appear).
* If `label`/`comment` are set, render them inside `field_ruler.htm` (local to the field, no locale badge).

**Changes:**

1. `modules/backend/widgets/Form.php` — add `ruler` to the exclusions in `showFieldLabels()` (generic label not rendered).
2. `modules/backend/widgets/form/partials/field_ruler.htm` — render:

   * `<label for="…"
     class="form-label">…</label>` when `label` is provided;
   * `<hr>`;
   * `<p class="form-text">…</p>` when `comment` is provided (respects `commentHtml`).

**Why:** `ruler` is structural; showing a translation badge is misleading. This aligns UI with existing `section`/`hint` behavior. No data/schema/save logic is affected.

**Reproduction (before fix):**

1. Blueprint with `multisite: sync`.
2. Field:

   ```yaml
   _r:
     type: ruler
     label: TEST
   ```
3. Locale badge appears next to the label.

**Expected (after fix):** No locale badge for `ruler`; `label`/`comment` render correctly inside the field’s partial.

**Backward compatibility:** No changes for regular input fields; UI-only adjustment for the structural `ruler` field.
