### PR TITLE
Adds ReportMetric::AGGREGATE_NONE, Fix ReportMetric::AGGREGATE_COUNT_DISTINCT_NOT_NULL

### DIFF
--- a/modules/dashboard/classes/ReportDataQueryBuilder.php
+++ b/modules/dashboard/classes/ReportDataQueryBuilder.php
@@ -387,6 +387,9 @@ class ReportDataQueryBuilder
             case ReportMetric::AGGREGATE_COUNT_DISTINCT_NOT_NULL:
                 return 'count(distinct case when %1$s is not null then %1\$s end';
                 break;
+            case ReportMetric::AGGREGATE_NONE:
+                return '%1$s';
+                break;
             default:
                 throw new SystemException('Invalid aggregate function: ' . $function);
         }

--- a/modules/dashboard/classes/ReportDataQueryBuilder.php
+++ b/modules/dashboard/classes/ReportDataQueryBuilder.php
@@ -385,7 +385,7 @@ class ReportDataQueryBuilder
                 return 'count(distinct %1$s)';
                 break;
             case ReportMetric::AGGREGATE_COUNT_DISTINCT_NOT_NULL:
-                return 'count(distinct case when %1$s is not null then %1\$s end';
+                return 'count(distinct case when %1$s is not null then %1$s end)';
                 break;
             case ReportMetric::AGGREGATE_NONE:
                 return '%1$s';


### PR DESCRIPTION
Adds `ReportMetric::AGGREGATE_NONE` and fixes `ReportMetric::AGGREGATE_COUNT_DISTINCT_NOT_NULL.`

See #5924 .

Theoretically I would also like to reduce `validateDbObjectName()` to just the `trim` to allow SQL methods like `CAST` or `TIMESTAMPDIFF`. To what extend is removing or opening up the regex a risk?