### PR TITLE
Update parameter types to support both int and string in Repeater to support ULIDs and UUIDs

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -310,12 +310,12 @@ class Repeater extends FormWidgetBase
 
     /**
      * makeItemFormWidget creates a form widget based on a field index and optional group code
-     * @param int $index
+     * @param int|string $index
      * @param string $groupCode
-     * @param int $fromIndex
+     * @param int|string $fromIndex
      * @return \Backend\Widgets\Form
      */
-    protected function makeItemFormWidget($index = 0, $groupCode = null, $fromIndex = null)
+    protected function makeItemFormWidget(int|string $index = 0, $groupCode = null, int|string $fromIndex = null)
     {
         $configDefinition = $this->useGroups
             ? $this->getGroupFormFieldConfig($groupCode)
@@ -381,7 +381,7 @@ class Repeater extends FormWidgetBase
     /**
      * getValueFromIndex returns the data at a given index
      */
-    protected function getValueFromIndex($index)
+    protected function getValueFromIndex(int|string $index)
     {
         $data = $this->getLoadValue();
 
@@ -587,9 +587,9 @@ class Repeater extends FormWidgetBase
 
     /**
      * getGroupCodeFromIndex returns a field group code from its index
-     * @param $index int
+     * @param int|string $index
      */
-    public function getGroupCodeFromIndex($index): string
+    public function getGroupCodeFromIndex(int|string $index): string
     {
         return (string) array_get($this->indexMeta, $index.'.groupCode');
     }

--- a/modules/backend/formwidgets/repeater/HasRelationStore.php
+++ b/modules/backend/formwidgets/repeater/HasRelationStore.php
@@ -25,7 +25,7 @@ trait HasRelationStore
     /**
      * getModelFromIndex returns the model at a given index
      */
-    protected function getModelFromIndex(int $index)
+    protected function getModelFromIndex(int|string $index)
     {
         return $this->getLoadValueFromRelation()[$index] ?? $this->getRelationModel();
     }
@@ -103,7 +103,7 @@ trait HasRelationStore
     /**
      * duplicateRelationAtIndex
      */
-    protected function duplicateRelationAtIndex(int $fromIndex, ?string $groupCode = null)
+    protected function duplicateRelationAtIndex(int|string $fromIndex, ?string $groupCode = null)
     {
         $model = $this->getModelFromIndex($fromIndex)->replicateWithRelations();
 
@@ -123,7 +123,7 @@ trait HasRelationStore
     /**
      * deleteRelationAtIndex
      */
-    protected function deleteRelationAtIndex(int $index)
+    protected function deleteRelationAtIndex(int|string $index)
     {
         $model = $this->getModelFromIndex($index);
         if (!$model->exists) {


### PR DESCRIPTION
**Summary of the Changes:**
- Updated parameter types in the Repeater component to support both `int` and `string` values.
- This allows Repeater field keys to handle not only auto-increment integer IDs (the previous default) but also string-based identifiers such as ULIDs and UUIDs.

**Solution Implemented:**
- Modified the codebase where the Repeater expects field keys, updating type hints and value handling logic so IDs can be integers or strings.

**Why:**
- Modern applications increasingly use string-based unique identifiers (ULIDs, UUIDs) for scalability and uniqueness, especially in distributed systems.
- Supporting both identifier types enables developers to integrate the Repeater widget with systems or databases that use non-integer keys.

**Backward Compatibility:**
- The changes are designed to be backward compatible: existing Repeater fields that use integer IDs will continue to work without modification.
- No breaking change for sites relying on integer-based keys.