### PR TITLE
Set default title for static dashboard widgets from loaded properties

### DIFF
--- a/modules/dashboard/vuecomponents/dashboard/assets/js/widget-static.js
+++ b/modules/dashboard/vuecomponents/dashboard/assets/js/widget-static.js
@@ -23,7 +23,18 @@ Vue.component('dashboard-component-dashboard-widget-static', {
         },
 
         makeDefaultConfigAndData: function () {
-            Vue.set(this.widget.configuration, 'title', 'My Custom Widget');
+            let defaultTitle = 'My Custom Widget';
+
+            if (this.loadedValue && this.loadedValue.properties) {
+                const titleProp = this.loadedValue.properties.find((p) => p.property === 'title');
+
+                // Apply the default title from loaded properties if it exists
+                if (titleProp && titleProp.default) {
+                    defaultTitle = titleProp.default;
+                }
+            }
+
+            Vue.set(this.widget.configuration, 'title', defaultTitle);
         },
 
         getSettingsConfiguration: function () {


### PR DESCRIPTION
This PR improves the handling of the `default` title for static dashboard widgets.

Previously, the widget would always initialize with a hardcoded title ("**My Custom Widget**"), ignoring any default value provided in the widget's properties. This PR updates the `makeDefaultConfigAndData` method to:

- Check if `loadedValue.properties` contains a `title` property with a `default` value.
- Use the `default` from properties if available.
- Fall back to "**My Custom Widget**" only if no default is provided.

This ensures that any default titles defined in widget data are respected, improving user experience and consistency with other widgets.

Related issue: [Report Widgets: title property default value is not used #5977](https://github.com/octobercms/october/issues/5977)