### PR TITLE
Fix default backend branding configuration options

### DIFF
--- a/config/backend.php
+++ b/config/backend.php
@@ -36,7 +36,7 @@ return [
     | - menu_mode: inline, text, tile, collapse, icons, left
     | - color_mode: light, dark, auto
     | - color_palette: default, classic, oxford, console, valentino, punch
-    | - login_background_type: color, wallpaper, october_ai_images
+    | - login_background_type: color, wallpaper, gradient, ai_images
     | - login_background_wallpaper_size: auto, cover
     | - login_image_type: autumn_images, custom
     |


### PR DESCRIPTION
This PR updates the default backend branding configuration for login background types.

Previously, the configuration did not include all supported options. This update ensures that the following option is correctly listed:

- login_background_type: color, wallpaper, gradient, ai_images

No functionality changes are introduced; this is purely a configuration correction to align the default settings with the supported options.