### PR TITLE
Fix showInterval not applied on initial YAML load for dashboards

### DIFF
--- a/modules/dashboard/models/Dashboard.php
+++ b/modules/dashboard/models/Dashboard.php
@@ -184,6 +184,7 @@ class Dashboard extends Model
             $dashboard->code = $field;
             $dashboard->name = $definition['name'] ?? 'Unknown';
             $dashboard->icon = $definition['icon'] ?? 'icon-globe';
+            $dashboard->is_interval_hidden = !($definition['showInterval'] ?? 1) ? 1 : 0;
             $dashboard->forceSave();
         }
     }


### PR DESCRIPTION
### Description:

This pull request fixes an issue where the `showInterval` option defined in the dashboard YAML (`config_dash.yaml`) **was not applied when creating dashboards in the database for the first time**, during the initial load when the `dashboard_dashboards` table is empty.

Currently, only `name` and `icon` are imported from the YAML during the first creation. The `is_interval_hidden` column remained `0`, ignoring the `showInterval` value.

### How to reproduce

1. Remove any existing dashboard entries from the `dashboard_dashboards` table.
2. Add a dashboard in `config_dash.yaml` with `showInterval: false`:
```
system:
    name: System Dashboard
    icon: ph ph-globe
    showInterval: true
    reports:
        cms_information:
            row: 2
            width: 4
            type: indicator
            icon: ph ph-power
            title: Manage Status
            linkText: Manage Status
            dimension: indicator@cms_information
            dataSource: Dashboard\Classes\CmsStatusDataSource
```
3. Load the backend for the first time.
4. Check the `dashboard_dashboards` table: the `is_interval_hidden` column will be `0` instead of `1`.

### Solution

In the `Dashboard::syncAll()` method, we added the inline initialization of `is_interval_hidden`, similar to `name` and `icon`:
```
$dashboard->is_interval_hidden = !($definition['showInterval'] ?? 1) ? 1 : 0;

```