### PR TITLE
Allow dashboards with dashes in code to be accessed

### DIFF
--- a/modules/backend/classes/BackendController.php
+++ b/modules/backend/classes/BackendController.php
@@ -82,15 +82,24 @@ class BackendController extends ControllerBase
         $controller = $params[1] ?? 'index';
         $isApp = strtolower($module) === 'app';
 
-        self::$action = $action = isset($params[2]) ? $this->parseAction($params[2]) : 'index';
-        self::$params = $controllerParams = array_slice($params, 3);
         $controllerClass = "{$module}\\Controllers\\{$controller}";
         $controllerBase = $isApp ? base_path() : base_path('modules');
-        if ($controllerObj = $this->findController(
-            $controllerClass,
-            $action,
-            $controllerBase
-        )) {
+
+        // Try finding the controller first with the original action
+        $originalAction = $params[2] ?? 'index';
+        $controllerObj = $this->findController($controllerClass, $originalAction, $controllerBase);
+
+        // Use the original action for WildcardController, otherwise transform the action
+        $action = $originalAction;
+        if (!($controllerObj instanceof WildcardController)) {
+            $action = $this->parseAction($originalAction);
+            $controllerObj = $this->findController($controllerClass, $action, $controllerBase);
+        }
+
+        self::$action = $action;
+        self::$params = $controllerParams = array_slice($params, 3);
+
+        if ($controllerObj) {
             if (!$isApp && !System::hasModule(ucfirst($module))) {
                 return Response::make(View::make('backend::404'), 404);
             }


### PR DESCRIPTION
Currently, dashboards with codes containing dashes (`abc-123`) are inaccessible because `BackendController::run` transforms the action using `parseAction`, removing dashes (`abc123`).

This PR updates the `run` method to:

- Keep the original action for `WildcardController`.
- Apply `parseAction` only for regular controllers.

This ensures dashboards with dashed codes are correctly loaded without affecting other controllers.

Related issue: [octobercms/october#5987](https://github.com/octobercms/october/issues/5987)