### PR TITLE
Fix role based peer management check before User is saved

### DIFF
--- a/modules/backend/controllers/Users.php
+++ b/modules/backend/controllers/Users.php
@@ -181,8 +181,8 @@ class Users extends SettingsController
             !$this->user->isSuperUser() &&
             ($role = UserRole::find(post('User[role]'))) &&
             ($this->allowPeerManagement()
-                ? $role->sort_order <= $this->user->role->sort_order
-                : $role->sort_order < $this->user->role->sort_order)
+                ? $role->sort_order < $this->user->role->sort_order
+                : $role->sort_order <= $this->user->role->sort_order)
         ) {
             throw new ForbiddenException;
         }


### PR DESCRIPTION
An administrator without super user access can't give a user the same role as itself while user peer management is enabled. This change fixes that.