### PR TITLE
Remove misleading @return self from NoteMaker setNotesOutput phpdoc

### DIFF
--- a/modules/system/traits/NoteMaker.php
+++ b/modules/system/traits/NoteMaker.php
@@ -35,7 +35,6 @@ trait NoteMaker
     /**
      * setNotesOutput sets an output stream for writing notes.
      * @param  \Illuminate\Console\OutputStyle $output
-     * @return self
      */
     public function setNotesOutput($output)
     {


### PR DESCRIPTION
Removes a misleading `@return self` phpdoc from `NoteMaker::setNotesOutput()`.

When extending `System\Classes\UpdateManager`, the annotation resolves to the base
class and breaks fluent chaining of subclass methods in static analysis tools.
Runtime behavior is unchanged.