### PR TITLE
Add new buttons to mediafinder

### DIFF
--- a/modules/media/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/media/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -18,6 +18,7 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         this.$el = $(this.element);
         this.instanceNumber = this.constructor.instanceCounter;
 
+        
         if (this.config.isMulti === undefined) {
             this.config.isMulti = this.$el.hasClass('is-multi');
         }
@@ -41,6 +42,7 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         this.previewTemplate = $(this.config.template).html();
         this.$filesContainer = $('.mediafinder-files-container:first', this.$el);
         this.$dataLocker = $('[data-data-locker]', this.$el);
+        this.$navigationClipboard = this.initNavigationClipboard();
     }
 
     connect() {
@@ -57,6 +59,12 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         this.listen('click', 'input[data-record-selector]', this.onClickCheckbox);
         this.listen('change', 'input[data-record-selector]', this.onSelectionChanged);
 
+        if(this.config.isMulti) {
+            this.listen('click', '.toolbar-select-all', this.onSelectAllClick);
+            this.listen('click', '.toolbar-copy-selected', this.onCopySelectedClick);
+            this.listen('click', '.toolbar-paste-items', this.onPasteItemsClick);
+        }
+
         if (this.config.isSortable) {
             this.bindSortable();
         }
@@ -65,6 +73,7 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         setTimeout(() => {
             this.initToolbarExtensionPoint();
             this.mountExternalToolbarEventBusEvents();
+            this.updateButtonsState();
             this.extendExternalToolbar();
         }, 0);
     }
@@ -175,6 +184,7 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         this.evalIsPopulated();
         this.evalIsMaxReached();
         this.updateDeleteSelectedState();
+        this.updateButtonsState();
         this.extendExternalToolbar();
 
         ev.stopPropagation();
@@ -187,6 +197,7 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         $object.toggleClass('selected', ev.target.checked);
 
         this.updateDeleteSelectedState();
+        this.updateButtonsState();
         this.extendExternalToolbar();
     }
 
@@ -320,6 +331,52 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         this.extendExternalToolbar();
     }
 
+    updateButtonsState() {
+        var selectAllButton = this.$el.find('.toolbar-select-all');
+        var copySelectedButton = this.$el.find('.toolbar-copy-selected');
+        var pasteItemsButton = this.$el.find('.toolbar-paste-items');
+        
+        // remove focus
+        selectAllButton.blur();
+        copySelectedButton.blur();
+        pasteItemsButton.blur();
+
+        var hasItems = this.$el.find('.item-object').length > 0;
+        var selectedCount = this.$el.find('input[data-record-selector]:checked').length;
+        var hasSelection = selectedCount > 0;
+
+        // unselect button if no items
+        selectAllButton.prop('disabled', !hasItems);
+
+        // change text if all items are selected
+        var checkboxes = this.$el.find('input[data-record-selector]');
+        var allChecked = hasItems && checkboxes.filter(':checked').length === checkboxes.length;
+
+        selectAllButton.find('.button-label').text(allChecked ? oc.lang.get('mediafinder.deselect_all') : oc.lang.get('mediafinder.select_all'));
+        selectAllButton.find('i').attr('class', allChecked ? 'icon-square-o' : 'icon-check-square');
+
+        // Copy button : enabled if there is a selection
+        copySelectedButton.prop('disabled', !hasSelection);
+        copySelectedButton.find('.button-label > span').text(hasSelection ? '(' + selectedCount + ')' : '');
+
+        // Paste button : enabled if there are items in the clipboard
+        var canPaste = this.$navigationClipboard.hasItems('mediafinder');
+
+        if (canPaste && this.config.maxItems !== null && this.config.maxItems !== undefined) {
+            var currentCount = this.$el.find('.item-object').length;
+            var totalAfterPaste = currentCount + this.$navigationClipboard.count('mediafinder');
+            canPaste = totalAfterPaste <= this.config.maxItems;
+        }
+        
+        pasteItemsButton.prop('disabled', !canPaste);
+
+        if (this.$navigationClipboard.hasItems('mediafinder')) {
+            pasteItemsButton.find('.button-label > span').text('(' + this.$navigationClipboard.count('mediafinder') + ')');
+        }        else {
+            pasteItemsButton.find('.button-label > span').text('');
+        }
+    }
+
     onClickRemoveButton(ev) {
         this.$filesContainer.empty();
         this.setValue();
@@ -382,9 +439,131 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         });
     }
 
+    onSelectAllClick(ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+
+        var checkboxes = this.$el.find('input[data-record-selector]');
+        var allChecked = checkboxes.filter(':checked').length === checkboxes.length;
+
+        checkboxes.prop('checked', !allChecked).each(function() {
+            $(this).closest('.item-object').toggleClass('selected', !allChecked);
+        });
+
+        this.updateDeleteSelectedState();
+        this.updateButtonsState();
+
+        if (this.extendExternalToolbar){
+            this.extendExternalToolbar();
+        }
+    }
+
+    onCopySelectedClick(ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+
+        var items = [];
+        var selectedObjects = this.$el.find('.item-object:has(input[data-record-selector]:checked)');
+
+        selectedObjects.each(function() {
+            var item = $(this);
+
+            var itemData = {
+                path: item.attr('data-path'),
+                folder: item.attr('data-folder') || ''
+            };
+
+            var publicUrlEl = item.find('[data-public-url]');
+            var thumbUrlEl = item.find('[data-thumb-url]');
+            var titleEl = item.find('[data-title]');
+
+            if(publicUrlEl.length) {
+                itemData.publicUrl = publicUrlEl.attr('src') || publicUrlEl.attr('data-public-url');
+            }
+
+            if(thumbUrlEl.length) {
+                itemData.thumbUrl = thumbUrlEl.attr('src') || thumbUrlEl.attr('data-thumb-url');
+            }
+
+            if(titleEl.length) {
+                itemData.title = titleEl.text() || titleEl.attr('data-title');
+            } else {
+                itemData.title = itemData.path ? itemData.path.split('/').pop() : '';
+            }
+            
+            var docType = item.find('[data-document-type]');
+            if(docType.length) {
+                itemData.documentType = docType.attr('data-document-type');
+            }
+
+            items.push(itemData);
+        });
+
+        if (items.length === 0) {
+            return;
+        }
+
+        this.$navigationClipboard.copy(items, 'mediafinder');
+        
+        $.oc.flashMsg({
+            text: items.length + oc.lang.get('mediafinder.items_copied_to_clipboard'),
+            class: 'success',
+            interval: 3
+        });
+
+        this.evalIsPopulated();
+        this.evalIsMaxReached();
+        this.updateButtonsState();
+
+        if (this.extendExternalToolbar){
+            this.extendExternalToolbar();
+        }
+    }
+
+    onPasteItemsClick(ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+
+        if(!this.$navigationClipboard.hasItems('mediafinder')) {
+            return;
+        }
+
+        var items = this.$navigationClipboard.paste('mediafinder');
+
+        if (this.config.maxItems !== null && this.config.maxItems !== undefined) {
+            var currentCount = this.$el.find('.item-object').length;
+            var totalAfterPaste = currentCount + items.length;
+
+            if (totalAfterPaste > this.config.maxItems) {
+                $.oc.flashMsg({
+                    text: oc.lang.get('mediafinder.cannot_paste_items_maximum_limit_exceeded', { maxItems: this.config.maxItems }),
+                    class: 'error',
+                    interval: 5
+                });
+                return;
+            }
+        }
+
+        var self = this;
+
+        this.addItems(items);
+
+        this.setValue();
+        this.evalIsPopulated();
+        this.evalIsMaxReached();
+        this.updateButtonsState();
+
+        $.oc.flashMsg({
+            text: itemsToAdd.length + oc.lang.get('mediafinder.items_pasted_successfully'),
+            class: 'success',
+            interval: 3
+        });
+    }
+
     evalIsPopulated() {
         var isPopulated = !!$('>.item-object', this.$filesContainer).length;
         this.$el.toggleClass('is-populated', isPopulated);
+        this.updateButtonsState();
         this.extendExternalToolbar();
     }
 
@@ -396,6 +575,7 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         }
 
         this.$el.toggleClass('is-max-reached', isMaxReached);
+        this.updateButtonsState();
         this.extendExternalToolbar();
     }
 
@@ -438,5 +618,75 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
 
     onSortAttachments() {
         this.setValue();
+    }
+
+    initNavigationClipboard() {
+        var $clipboard = {
+            storageKey: 'oc.mediafinder.navigationClipboard',
+            // Load from localStorage
+            load: function() {
+                try {
+                    var data = localStorage.getItem(this.storageKey);
+                    if (data) {
+                        return JSON.parse(data);
+                    }
+                } catch (e) {
+                    console.error('Error loading clipboard from localStorage:', e);
+                }
+                return { items: [], type: null };
+            },
+
+            // Save to localStorage
+            save: function(items, type) {
+                try {
+                    localStorage.setItem(this.storageKey, JSON.stringify({
+                        items: items,
+                        type: type
+                    }));
+                } catch (e) {
+                    console.error('Error saving clipboard to localStorage:', e);
+                }
+            },
+
+            copy: function(items, type) {
+                this.save(items.slice(), type || null);
+            },
+
+            paste: function(type) {
+                var data = this.load();
+                // If type is specified, only return items if they match the type
+                if (type && data.type !== type) {
+                    return [];
+                }
+                return data.items.slice();
+            },
+
+            hasItems: function(type) {
+                var data = this.load();
+                // If type is specified, check if clipboard has items of that type
+                if (type) {
+                    return data.items.length > 0 && data.type === type;
+                }
+                return data.items.length > 0;
+            },
+
+            clear: function() {
+                try {
+                    localStorage.removeItem(this.storageKey);
+                } catch (e) {
+                    console.error('Error clearing clipboard from localStorage:', e);
+                }
+            },
+
+            count: function(type) {
+                var data = this.load();
+                // If type is specified, only count if items match the type
+                if (type && data.type !== type) {
+                    return 0;
+                }
+                return data.items.length;
+            }
+        };
+        return $clipboard;
     }
 });

--- a/modules/media/formwidgets/mediafinder/partials/_file_multi.php
+++ b/modules/media/formwidgets/mediafinder/partials/_file_multi.php
@@ -14,19 +14,45 @@
 
     <div class="mediafinder-control-container <?= $externalToolbarAppState ? 'external-toolbar' : null ?>">
         <div class="mediafinder-control-toolbar">
-            <a href="javascript:;" class="backend-toolbar-button control-button toolbar-find-button">
-                <i class="icon-common-file-star"></i>
-                <span class="button-label"><?= __("Select") ?></span>
-            </a>
+            <div data-control="toolbar">
+                <a href="javascript:;" class="backend-toolbar-button control-button toolbar-find-button">
+                    <i class="icon-common-file-star"></i>
+                    <span class="button-label"><?= __("Select") ?></span>
+                </a>
 
-            <button
-                type="button"
-                class="backend-toolbar-button control-button toolbar-delete-selected populated-only"
-                disabled
-            >
-                <i class="icon-common-file-remove"></i>
-                <span class="button-label"><?= __("Delete Selected") ?> <span></span></span>
-            </button>
+                <button
+                    type="button"
+                    class="backend-toolbar-button control-button toolbar-delete-selected populated-only"
+                    disabled
+                >
+                    <i class="icon-common-file-remove"></i>
+                    <span class="button-label"><?= __("Delete Selected") ?> <span></span></span>
+                </button>
+
+                <button
+                    class="backend-toolbar-button control-button toolbar-select-all populated-only"
+                    disabled
+                >
+                    <i class="icon-check-square"></i>
+                    <span class="button-label"><?= __("Select All") ?> <span></span></span>
+                </button>
+
+                <button
+                    class="backend-toolbar-button control-button toolbar-copy-selected populated-only"
+                    disabled
+                >
+                    <i class="icon-copy"></i>
+                    <span class="button-label"><?= __("Copy Selected") ?> <span></span></span>
+                </button>
+
+                <button
+                    class="backend-toolbar-button control-button toolbar-paste-items"
+                    disabled
+                >
+                    <i class="icon-paste"></i>
+                    <span class="button-label"><?= __("Paste") ?> <span></span></span>
+                </button>
+            </div>
         </div>
 
         <!-- Existing file -->

--- a/modules/media/formwidgets/mediafinder/partials/_image_multi.php
+++ b/modules/media/formwidgets/mediafinder/partials/_image_multi.php
@@ -16,19 +16,45 @@
 
     <div class="mediafinder-control-container <?= $externalToolbarAppState ? 'external-toolbar' : null ?>">
         <div class="mediafinder-control-toolbar">
-            <a href="javascript:;" class="backend-toolbar-button control-button toolbar-find-button">
-                <i class="icon-common-file-star"></i>
-                <span class="button-label"><?= __("Select") ?></span>
-            </a>
+            <div data-control="toolbar">
+                <a href="javascript:;" class="backend-toolbar-button control-button toolbar-find-button">
+                    <i class="icon-common-file-star"></i>
+                    <span class="button-label"><?= __("Select") ?></span>
+                </a>
 
-            <button
-                type="button"
-                class="backend-toolbar-button control-button toolbar-delete-selected populated-only"
-                disabled
-            >
-                <i class="icon-common-file-remove"></i>
-                <span class="button-label"><?= __("Remove Selected") ?> <span></span></span>
-            </button>
+                <button
+                    type="button"
+                    class="backend-toolbar-button control-button toolbar-delete-selected populated-only"
+                    disabled
+                >
+                    <i class="icon-common-file-remove"></i>
+                    <span class="button-label"><?= __("Remove Selected") ?> <span></span></span>
+                </button>
+
+                <button
+                    class="backend-toolbar-button control-button toolbar-select-all populated-only"
+                    disabled
+                >
+                    <i class="icon-check-square"></i>
+                    <span class="button-label"><?= __("Select All") ?> <span></span></span>
+                </button>
+
+                <button
+                    class="backend-toolbar-button control-button toolbar-copy-selected populated-only"
+                    disabled
+                >
+                    <i class="icon-copy"></i>
+                    <span class="button-label"><?= __("Copy Selected") ?> <span></span></span>
+                </button>
+
+                <button
+                    class="backend-toolbar-button control-button toolbar-paste-items"
+                    disabled
+                >
+                    <i class="icon-paste"></i>
+                    <span class="button-label"><?= __("Paste") ?> <span></span></span>
+                </button>
+            </div>
         </div>
 
         <!-- Existing files -->

--- a/modules/system/assets/js/lang/lang.en.js
+++ b/modules/system/assets/js/lang/lang.en.js
@@ -49,6 +49,14 @@ window.oc.langMessages['en'] = $.extend(
         "invalid_video_empty_insert": "Please select a video file to insert.",
         "invalid_audio_empty_insert": "Please select an audio file to insert."
     },
+    "mediafinder": {
+        "select_all": "Select All",
+        "deselect_all": "Deselect All",
+        "items_copied_to_clipboard": " item(s) copied to clipboard.",
+        "cannot_paste_items_maximum_limit_exceeded": "Cannot paste items: maximum item ({{maxItems}}) limit will be exceeded.",
+        "no_new_items_to_paste": "No new items to paste.",
+        "items_pasted_successfully": " item(s) pasted successfully."
+    },  
     "alert": {
         "error": "Error",
         "confirm": "Confirm",

--- a/modules/system/assets/js/lang/lang.en.js
+++ b/modules/system/assets/js/lang/lang.en.js
@@ -48,15 +48,7 @@ window.oc.langMessages['en'] = $.extend(
         "invalid_image_empty_insert": "Please select image(s) to insert.",
         "invalid_video_empty_insert": "Please select a video file to insert.",
         "invalid_audio_empty_insert": "Please select an audio file to insert."
-    },
-    "mediafinder": {
-        "select_all": "Select All",
-        "deselect_all": "Deselect All",
-        "items_copied_to_clipboard": " item(s) copied to clipboard.",
-        "cannot_paste_items_maximum_limit_exceeded": "Cannot paste items: maximum item ({{maxItems}}) limit will be exceeded.",
-        "no_new_items_to_paste": "No new items to paste.",
-        "items_pasted_successfully": " item(s) pasted successfully."
-    },  
+    }, 
     "alert": {
         "error": "Error",
         "confirm": "Confirm",

--- a/modules/system/assets/js/lang/lang.en.js
+++ b/modules/system/assets/js/lang/lang.en.js
@@ -48,7 +48,7 @@ window.oc.langMessages['en'] = $.extend(
         "invalid_image_empty_insert": "Please select image(s) to insert.",
         "invalid_video_empty_insert": "Please select a video file to insert.",
         "invalid_audio_empty_insert": "Please select an audio file to insert."
-    }, 
+    },
     "alert": {
         "error": "Error",
         "confirm": "Confirm",

--- a/modules/system/lang/en/client.php
+++ b/modules/system/lang/en/client.php
@@ -49,6 +49,14 @@ return [
         'invalid_video_empty_insert' => 'Please select a video file to insert.',
         'invalid_audio_empty_insert' => 'Please select an audio file to insert.',
     ],
+    'mediafinder' => [
+        'select_all' => 'Select All',
+        'deselect_all' => 'Deselect All',
+        'items_copied_to_clipboard' => ' item(s) copied to clipboard.',
+        'cannot_paste_items_maximum_limit_exceeded' => 'Cannot paste items: maximum item ({{maxItems}}) limit will be exceeded.',
+        'no_new_items_to_paste' => 'No new items to paste.',
+        'items_pasted_successfully' => ' item(s) pasted successfully.',
+    ],
     'alert' => [
         'error' => 'Error',
         'confirm' => 'Confirm',

--- a/modules/system/lang/fr/client.php
+++ b/modules/system/lang/fr/client.php
@@ -49,6 +49,14 @@ return [
         'invalid_video_empty_insert' => "Veuillez sélectionner une vidéo à insérer.",
         'invalid_audio_empty_insert' => "Veuillez sélectionner un document audio à insérer.",
     ],
+    'mediafinder' => [
+        'select_all' => 'Tout sélectionner',
+        'deselect_all' => 'Tout désélectionner',
+        'items_copied_to_clipboard' => ' élément(s) copié(s) dans le presse-papier.',
+        'cannot_paste_items_maximum_limit_exceeded' => 'Impossible de coller les éléments : la limite maximale d\'éléments ({{maxItems}}) sera dépassée.',
+        'no_new_items_to_paste' => 'Aucun nouvel élément à coller.',
+        'items_pasted_successfully' => ' élément(s) collé(s) avec succès.',
+    ],
     'alert' => [
         'error' => 'Erreur',
         'confirm' => 'Confirmer',


### PR DESCRIPTION
For multi mode Mediafinder form widget, adds new buttons :
- Select / Deselect all
- Copy selected
- Paste

<img width="770" height="123" alt="image" src="https://github.com/user-attachments/assets/5519ccd0-8724-4156-8a7c-1a67197a4f6a" />

<img width="834" height="280" alt="image" src="https://github.com/user-attachments/assets/b8feb103-1348-485b-9c32-2e394ad80783" />

<img width="1030" height="485" alt="image" src="https://github.com/user-attachments/assets/b399e386-d48b-4890-8beb-0fc18b1bf01a" />

- - - 
I was not sure about Lang so i just created EN and FR version on files, let me know if you want that i change other files ... :)


UPDATE : i think i will add a Storage Event to be able to update buttons based on changes made on local storage key. 
 