### PR TITLE
Fix richeditor duplicate image drop showing generic error

### DIFF
--- a/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
+++ b/modules/backend/formwidgets/richeditor/assets/js/richeditor.js
@@ -210,6 +210,7 @@
         this.$textarea.on('froalaEditor.contentChanged', this.proxy(this.onChange));
         this.$textarea.on('froalaEditor.html.get', this.proxy(this.onSyncContent));
         this.$textarea.on('froalaEditor.html.set', this.proxy(this.onSetContent));
+        this.$textarea.on('froalaEditor.image.uploaded', this.proxy(this.onImageUploaded));
         this.$form.on('oc.beforeRequest', this.proxy(this.onFormBeforeRequest));
 
         this.$textarea.froalaEditor(froalaOptions);
@@ -252,6 +253,7 @@
         this.$textarea.off('froalaEditor.contentChanged', this.proxy(this.onChange));
         this.$textarea.off('froalaEditor.html.get', this.proxy(this.onSyncContent));
         this.$textarea.off('froalaEditor.html.set', this.proxy(this.onSetContent));
+        this.$textarea.off('froalaEditor.image.uploaded', this.proxy(this.onImageUploaded));
         this.$form.off('oc.beforeRequest', this.proxy(this.onFormBeforeRequest));
 
         $(window).off('resize', this.proxy(this.updateLayout));
@@ -397,6 +399,20 @@
 
     RichEditor.prototype.onChange = function(ev) {
         this.$form.trigger('change');
+    };
+
+    RichEditor.prototype.onImageUploaded = function(ev, editor, response) {
+        try {
+            var data = JSON.parse(response);
+            if (data.error) {
+                $.oc.flashMsg({ text: data.error, class: 'error' });
+                editor.image.hideProgressBar(true);
+                editor.image.remove();
+                editor.edit.on();
+                return false;
+            }
+        }
+        catch (e) {}
     };
 
     /*

--- a/modules/backend/vuecomponents/richeditor/assets/js/richeditor.js
+++ b/modules/backend/vuecomponents/richeditor/assets/js/richeditor.js
@@ -148,6 +148,7 @@ oc.Modules.register('backend.component.richeditor', function () {
         $textarea.on('froalaEditor.contentChanged.richeditor', component.onChange);
         $textarea.on('froalaEditor.focus.richeditor', component.onFocus);
         $textarea.on('froalaEditor.blur.richeditor', component.onBlur);
+        $textarea.on('froalaEditor.image.uploaded.richeditor', component.onImageUploaded);
         $textarea.closest('form').on('oc.beforeRequest', component.onFormBeforeRequest);
         $(document).on('vue.beforeRequest', component.onVueFormBeforeRequest);
         // $textarea.on('froalaEditor.html.get.richeditor', this.proxy(this.onSyncContent));
@@ -231,6 +232,20 @@ oc.Modules.register('backend.component.richeditor', function () {
 
             onVueFormBeforeRequest: function onVueFormBeforeRequest() {
                 this.onChange();
+            },
+
+            onImageUploaded: function onImageUploaded(ev, editor, response) {
+                try {
+                    var data = JSON.parse(response);
+                    if (data.error) {
+                        $.oc.flashMsg({ text: data.error, class: 'error' });
+                        editor.image.hideProgressBar(true);
+                        editor.image.remove();
+                        editor.edit.on();
+                        return false;
+                    }
+                }
+                catch (e) {}
             }
         },
         mounted: function onMounted() {

--- a/modules/media/widgets/MediaManager.php
+++ b/modules/media/widgets/MediaManager.php
@@ -1554,6 +1554,10 @@ class MediaManager extends WidgetBase
             return;
         }
 
+        // Set locale early since this runs in the widget constructor,
+        // before the controller applies the user's locale preference
+        \Backend\Models\Preference::setAppLocale();
+
         if (!$this->checkHasPermission('mediaCreate')) {
             throw new ForbiddenException;
         }
@@ -1615,19 +1619,43 @@ class MediaManager extends WidgetBase
                 ? $uploadedFile->getPath() . DIRECTORY_SEPARATOR . $uploadedFile->getFileName()
                 : $uploadedFile->getRealPath();
 
-            // Cannot overwrite files without permission or confirmation
-            $forceOverwrite = (bool) post('force_overwrite', false);
-            $canOverwrite = $this->checkHasPermission('mediaDelete');
-            if (MediaLibrary::instance()->has($filePath) && (!$canOverwrite || !$forceOverwrite)) {
-                throw new ApplicationException(__('A media file already exists at this location, please upload using a different filename.'));
-            }
-
             // Check and clean vector files
             // @todo use streaming like file objects
             $contents = File::get($realPath);
             if ($extension === 'svg' && Config::get('media.clean_vectors', true)) {
                 // @todo File::cleanVector() helper might be helpful here to clean temporary file in place
                 $contents = \Html::cleanVector($contents);
+            }
+
+            // Handle duplicate files
+            $forceOverwrite = (bool) post('force_overwrite', false);
+            $canOverwrite = $this->checkHasPermission('mediaDelete');
+            if (MediaLibrary::instance()->has($filePath)) {
+                if ($quickMode) {
+                    // Compare content: if identical, reuse the existing file
+                    $existingContent = MediaLibrary::instance()->get($filePath);
+                    if (md5($contents) === md5($existingContent)) {
+                        $response = Response::make([
+                            'link' => MediaLibrary::url($filePath),
+                            'result' => 'success'
+                        ]);
+                        $this->controller->setResponse($response);
+                        return;
+                    }
+
+                    // Different content with same filename: return error as
+                    // HTTP 200 JSON so Froala's image.uploaded event can
+                    // intercept and show a meaningful message to the user
+                    $response = Response::make([
+                        'error' => Lang::get('backend::lang.media.folder_or_file_exist')
+                    ]);
+                    $this->controller->setResponse($response);
+                    return;
+                }
+
+                if (!$canOverwrite || !$forceOverwrite) {
+                    throw new ApplicationException(__('A media file already exists at this location, please upload using a different filename.'));
+                }
             }
 
             // Write file to disk


### PR DESCRIPTION
## Problem

When dropping the same image into a `richeditor` twice (e.g. reusing an image across French/English fields side by side), the second drop fails with Froala's generic **"Something went wrong. Please try again."** message.

The quick-upload handler in `MediaManager::checkUploadPostback()` throws an `ApplicationException` when a file already exists. The richeditor's Froala integration never sends `force_overwrite`, so the second upload of the same filename always fails with HTTP 400 — and Froala swallows the real error message.

## Steps to Reproduce

1. Install the [test plugin](https://github.com/octobercms/test-plugin)
2. Navigate to `/backend/october/test/posts/update/1#secondarytab-rich-editor`
3. Drag and drop `ImageA.png` into the first richeditor — works fine
4. Drag and drop the same `ImageA.png` into the second richeditor — generic error

## Expected Behavior

| Scenario | Result |
|---|---|
| Drop `img.png` (first time) | Uploads normally |
| Drop `img.png` again (identical content) | Reuses existing URL silently, no error |
| Drop `img.png` (different image, same name) | Shows a translated "file already exists" flash message |
| Full Media Manager upload | Unchanged behavior |

## Changes (3 files)

1. **`modules/media/widgets/MediaManager.php`** — In quick mode: compare content hashes before rejecting duplicates. Identical files reuse the existing URL. Different files return a JSON error (HTTP 200) so Froala can display it. Also sets locale early so error messages are properly translated.
2. **`modules/backend/formwidgets/richeditor/assets/js/richeditor.js`** — Intercept Froala's `image.uploaded` event to parse server errors and show a flash message instead of the generic popup (legacy mode).
3. **`modules/backend/vuecomponents/richeditor/assets/js/richeditor.js`** — Same as above (Vue mode).

## Considerations

- **Full Media Manager overwrite** — The existing full Media Manager already allows replacing a file if the user has delete permission and confirms the overwrite dialog. This means `img.png` could be replaced with completely different content, affecting every page that references it. This is pre-existing behavior and out of scope for this PR, but worth noting as a potential follow-up discussion.
- **Content comparison cost** — In quick mode, when a duplicate filename is detected, we read the existing file from storage to compare md5 hashes. For very large files this adds a read operation, but in practice richeditor image drops are typically small images where this is negligible.
- **Locale timing** — `setAppLocale()` was added early in `checkUploadPostback()` because this method runs in the widget constructor, before the controller sets the user's locale. Without this, the "file already exists" message would always display in English regardless of the user's preference.
