### PR TITLE
Do not match ignored columns

### DIFF
--- a/modules/backend/behaviors/importexportcontroller/assets/js/october.import.js
+++ b/modules/backend/behaviors/importexportcontroller/assets/js/october.import.js
@@ -119,6 +119,10 @@
                 dbColumnName = $dbItem.data('column-name'),
                 $dbItemMatchInput = $('[data-column-match-input]', $dbItem);
 
+            if ($fileItem.hasClass('is-ignored')) {
+                return;
+            }
+
             this.toggleMatchState($fileItem);
 
             $dbItem.data('column-matched-id', matchColumnId);


### PR DESCRIPTION
When using the [Import feature](https://docs.octobercms.com/4.x/extend/importexport/importexport-controller.html), a user can ignore a file column by clicking the ignore icon on that row (which calls $.oc.importBehavior.ignoreFileColumn(this)). However, if the user then clicks the Auto-match columns button, the ignored columns get matched anyway and are passed to the import model.

Fix: Skip columns marked as ignored during auto-matching so they are not passed to the import model.

This issue also applies to OctoberCMS 3.6 and 3.7. I haven't tested the older ones.
