### PR TITLE
Add storage/framework/testing/.gitignore

### DIFF
--- a/storage/framework/testing/.gitignore
+++ b/storage/framework/testing/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- Adds `storage/framework/testing/.gitignore` with the standard Laravel pattern (`*` + `!.gitignore`) so that fake-disk artifacts created by `Storage::fake()` in tests don't show up as untracked files.

## Why
The Laravel skeleton (`laravel/laravel`) ships this file for exactly this reason: `Illuminate\Filesystem\FilesystemManager::fake()` writes test artifacts to `storage/framework/testing/disks/{disk}[_test_{parallelToken}]/` and never cleans them up afterward. Without a gitignore, every plugin or app that uses `Storage::fake()` in its test suite ends up with leftover CSV/file output appearing as untracked in `git status`.

Sibling directories under `storage/framework/` (`cache`, `sessions`, `views`) already have their own `.gitignore`. This adds the missing one for `testing/`.

## Reference
- Laravel's equivalent file: https://github.com/laravel/laravel/blob/12.x/storage/framework/testing/.gitignore