### PR TITLE
Forget the intended URL to prevent redirecting to the wrong host

### DIFF
--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -353,6 +353,9 @@ class Auth extends Controller
         $user = UserModel::createDefaultAdmin(post());
         BackendAuth::login($user);
 
+        // Forget the intended URL to prevent redirecting to the wrong host
+        session()->forget('url.intended');
+
         // Redirect
         Flash::success(__('Welcome to your Administration Area, :name', ['name' => e(post('first_name'))]));
         return Backend::redirectIntended('backend');


### PR DESCRIPTION
Initial setup has a two-step redirect that breaks if the browser URL and `APP_URL` are of different origins. Forgetting the stale value is the simplest way to resolve the issue.

[More info here &rarr;](https://gist.github.com/scottbedard/85e03024eda85374732292fc01c462eb)
