### PR TITLE
[DOCKER] Use detect link policy for local devcontainers

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,7 +8,6 @@ cd /var/www/html
 
 sed -i 's/^DB_CONNECTION=.*/DB_CONNECTION=sqlite/' .env
 sed -i 's|^DB_DATABASE=.*|DB_DATABASE=/var/www/html/database/database.sqlite|' .env
-sed -i 's|^LINK_POLICY=.*|LINK_POLICY=force|' .env
 
 # Create directories not tracked by git
 mkdir -p \

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -12,11 +12,16 @@ forwarding_domain="${forwarding_domain#.}"
 # APP_URL from the environment or .env — it is often still http://localhost.
 if [[ -n "${CODESPACE_NAME:-}" ]]; then
     app_url="https://${CODESPACE_NAME}-80.${forwarding_domain}"
+    link_policy=force
 else
-    app_url="http://127.0.0.1"
+    # Local dev (Docker Desktop, OrbStack, Podman, etc.): generate URLs from the
+    # hostname you actually visit — localhost, *.orb.local, or a custom domain.
+    link_policy=detect
+    app_url="${DEVCONTAINER_PUBLIC_URL:-http://127.0.0.1}"
 fi
 
 sed -i "s|^APP_URL=.*|APP_URL=${app_url}|" .env
+sed -i "s|^LINK_POLICY=.*|LINK_POLICY=${link_policy}|" .env
 
 # Pick up the new APP_URL — config:cache avoids stale values on subsequent requests.
 php artisan config:clear --quiet 2>/dev/null || true
@@ -45,3 +50,7 @@ until curl -fsS http://127.0.0.1/_health >/dev/null 2>&1; do
 done
 
 echo "October CMS is running at ${app_url}"
+
+if [[ -z "${CODESPACE_NAME:-}" && "${app_url}" == "http://127.0.0.1" ]]; then
+    echo "Open http://localhost (port 80 is forwarded by the devcontainer)"
+fi


### PR DESCRIPTION
This enables local devcontainers, and remains compatible with GitHub Codespaces.

Most IDEs support devcontainers nowadays, so local dev is now just a matter of installing Docker Desktop, OrbStack, Podman, etc... then open your repo and go! 🚀 

Here is a demo with OrbStack + Cursor. Codespaces are nice, but working locally is obviously a much smoother experience 🙂

[october-devcontainer.webm](https://github.com/user-attachments/assets/9e35328c-6a2f-410c-a93a-a6905865241c)
