### PR TITLE
Fix "undefined method formBeforeSave()" when saving a translatable fi…

### DIFF
--- a/modules/backend/widgets/form/HasTranslatable.php
+++ b/modules/backend/widgets/form/HasTranslatable.php
@@ -67,14 +67,20 @@ trait HasTranslatable
             $siteModel = $this->getTranslatableSiteModel($model, $site);
             $formWidget = $this->makeTranslateFormWidget($field, $siteModel, $site);
             $saveData = $formWidget->getSaveData();
-            $this->controller->formBeforeSave($model);
+
+            if ($this->controller->methodExists('formBeforeSave')) {
+                $this->controller->formBeforeSave($model);
+            }
 
             $formWidget->performSaveOnModel($siteModel, $saveData, [
                 'sessionKey' => $formWidget->getSessionKey(),
                 'force' => true
             ]);
 
-            $this->controller->formAfterSave($model);
+            if ($this->controller->methodExists('formAfterSave')) {
+                $this->controller->formAfterSave($model);
+            }
+
         });
     }
 


### PR DESCRIPTION
…eld on a controller without FormController

### Problem

Saving a single locale's value via the translatable globe popup throws a fatal error on any backend page whose controller does not implement the `FormController` behavior — most notably the Settings page:

Call to undefined method System\Controllers\Settings::formBeforeSave()


### Steps to reproduce

1. Multisite with two sites using different locales.
2. A settings model that is translatable (e.g. `System.Behaviors.SettingsModel` + a translatable field), so the form fields show the globe icon.
3. Open the settings page, click the globe on a translatable field, pick the other site and save the popup.
4. Fatal error — the main "Save" button works fine, only the per-field translate popup crashes.

### Root cause

`Backend\Widgets\Form\HasTranslatable::onSaveTranslateField()` calls `$this->controller->formBeforeSave($model)` and `formAfterSave($model)` unconditionally. These are extension-point hooks provided by the `FormController` behavior (`Backend\Behaviors\FormController\HasOverrides`). The Form widget can be bound to controllers that do not implement `FormController` (such as `System\Controllers\Settings`), which therefore do not define these methods.

### Fix

Guard both calls with `methodExists()`, so the hooks fire when the controller provides them and are skipped otherwise. This matches the optional nature of these extension points.

No behavior change for controllers that implement `FormController`.