### PR TITLE
Run docker pull when rebuilding containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "October CMS",
   "image": "ghcr.io/octobercms/runtime-dev:latest",
+  "initializeCommand": "docker pull ghcr.io/octobercms/runtime-dev:latest",
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/html,type=bind,consistency=cached",
   "workspaceFolder": "/var/www/html",
   "overrideCommand": true,


### PR DESCRIPTION
While testing the media manager, I noticed our base runtime was missing webp file support. That was fixed in [`02a2c1a`](https://github.com/octobercms/runtimes/commit/02a2c1a64f1cfb0f487995521c389a9acde75f6e).

Since I had already pulled `latest` though, my devcontainer would rebuild with the cached version. This change ensures new containers are always built from a fresh copy.

We also publish `YYYY.MM.DD` and `YYYY.MM.DD-<commit>` versions, so if anyone truly wanted an older image they could explicitly pin it to the desired version.