### PR TITLE
Add system.updater.beforeUpdate event

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -84,6 +84,29 @@ class UpdateManager
     }
 
     /**
+     * fireBeforeUpdate triggers the before update event.
+     */
+    public function fireBeforeUpdate(): mixed
+    {
+        /**
+         * @event system.updater.beforeUpdate
+         * Called before the software update process begins from the backend.
+         *
+         * A non-null return value stops the update and is used as the AJAX
+         * response. Throwing an exception will halt the update with an error.
+         *
+         * Example usage:
+         *
+         *     Event::listen('system.updater.beforeUpdate', function () {
+         *         Flash::success('Update started');
+         *         return Redirect::refresh();
+         *     });
+         *
+         */
+        return Event::fire('system.updater.beforeUpdate', [], true);
+    }
+
+    /**
      * update creates the migration table and updates.
      */
     public function update()

--- a/modules/system/widgets/Updater.php
+++ b/modules/system/widgets/Updater.php
@@ -207,6 +207,12 @@ class Updater extends WidgetBase
     public function onApplyUpdates()
     {
         try {
+            $beforeUpdate = UpdateManager::instance()->fireBeforeUpdate();
+
+            if ($beforeUpdate !== null) {
+                return $beforeUpdate;
+            }
+
             $updateSteps = [
                 [
                     'code' => 'updateComposer',


### PR DESCRIPTION
Create a `system.updater.beforeUpdate` event that plugins can use to intercept update calls from the backend. This is necessary when working with ephemeral or read-only file systems [like the one described here](https://www.reddit.com/r/octobercms/comments/1v1p5bd/october_cloud_preview/).

Once intercepted, we can use `php artisan october:update` for more fine-grained control of the update.

```php
Event::listen('system.updater.beforeUpdate', function (string $context) {
    Flash::success('Update started!');

    // trigger custom update workflow

    return Redirect::refresh();
});
```

Similarly, a plugin can now disable backend updates entirely by throwing an exception.

```php
Event::listen('system.updater.beforeUpdate', function (string $context) {
    throw new Exception("Backend updates are disabled, use 'php artisan october:update'");
});
```