### PR TITLE
feat(mail): add live HTML preview tab to mail templates, layouts

### DIFF
--- a/modules/system/assets/js/pages/mailformpreview.js
+++ b/modules/system/assets/js/pages/mailformpreview.js
@@ -1,0 +1,61 @@
+'use strict';
+
+oc.registerControl('mailformpreview', class extends oc.ControlBase {
+    connect() {
+        this.iframe = null;
+        this.handler = this.config.handler || 'onPreviewTemplate';
+
+        this.createIframe();
+        this.loadPreview();
+
+        this.boundOnSaveSuccess = this.proxy(this.onSaveSuccess);
+        $(document).on('ajaxSuccess', this.boundOnSaveSuccess);
+    }
+
+    disconnect() {
+        $(document).off('ajaxSuccess', this.boundOnSaveSuccess);
+    }
+
+    createIframe() {
+        this.iframe = document.createElement('iframe');
+        this.iframe.style.width = '100%';
+        this.iframe.style.border = '0';
+        this.iframe.style.minHeight = '400px';
+        this.iframe.setAttribute('frameborder', 0);
+        this.iframe.onload = this.proxy(this.adjustHeight);
+        this.element.appendChild(this.iframe);
+    }
+
+    onSaveSuccess(event, context) {
+        if (context && context.handler && context.handler.indexOf('onSave') !== -1) {
+            this.loadPreview();
+        }
+    }
+
+    loadPreview() {
+        const self = this;
+        $('#Form').request(this.handler, {
+            success: function(data) {
+                if (data.previewHtml !== undefined) {
+                    self.setContent(data.previewHtml);
+                }
+            }
+        });
+    }
+
+    setContent(html) {
+        'srcdoc' in this.iframe
+            ? this.iframe.srcdoc = html
+            : this.iframe.src = 'data:text/html;charset=UTF-8,' + encodeURIComponent(html);
+    }
+
+    adjustHeight() {
+        try {
+            const body = this.iframe.contentWindow.document.body;
+            if (body && body.scrollHeight > 0) {
+                this.iframe.style.height = (body.scrollHeight + 20) + 'px';
+            }
+        }
+        catch (e) {}
+    }
+});

--- a/modules/system/controllers/MailLayouts.php
+++ b/modules/system/controllers/MailLayouts.php
@@ -2,10 +2,13 @@
 
 use Lang;
 use Flash;
+use Config;
 use Redirect;
 use BackendMenu;
 use Backend\Classes\Controller;
 use System\Classes\SettingsManager;
+use System\Classes\MailManager;
+use System\Models\MailTemplate;
 
 /**
  * Mail layouts controller
@@ -41,6 +44,39 @@ class MailLayouts extends Controller
 
         BackendMenu::setContext('October.System', 'system', 'settings');
         SettingsManager::setContext('October.System', 'mail_templates');
+    }
+
+    /**
+     * update
+     */
+    public function update($recordId = null)
+    {
+        $this->addJs('/modules/system/assets/js/pages/mailformpreview.js');
+        return $this->asExtension('FormController')->update($recordId);
+    }
+
+    /**
+     * onPreviewLayout
+     */
+    public function onPreviewLayout($recordId = null): array
+    {
+        $layout = $this->formFindModelObject($recordId);
+        $this->asExtension('FormController')->initForm($layout);
+        $this->formGetWidget()->setFormValues();
+
+        $saveData = $this->formGetWidget()->getSaveData();
+        $layout->fill($saveData);
+
+        $template = new MailTemplate;
+        $template->layout = $layout;
+
+        $data = [
+            'subject' => Config::get('app.name'),
+            'appName' => Config::get('app.name'),
+            'texts' => Lang::get('system::lang.mail_brand.sample_template'),
+        ];
+
+        return ['previewHtml' => MailManager::instance()->renderTemplate($template, $data)];
     }
 
     /**

--- a/modules/system/controllers/MailTemplates.php
+++ b/modules/system/controllers/MailTemplates.php
@@ -6,6 +6,7 @@ use BackendMenu;
 use Backend\Classes\Controller;
 use System\Models\MailTemplate;
 use System\Classes\SettingsManager;
+use System\Classes\MailManager;
 use ApplicationException;
 use Throwable;
 
@@ -65,6 +66,34 @@ class MailTemplates extends Controller
         $this->bodyClass = 'compact-container';
 
         $this->vars['activeTab'] = $tab ?: 'templates';
+    }
+
+    /**
+     * update
+     */
+    public function update($recordId = null)
+    {
+        $this->addJs('/modules/system/assets/js/pages/mailformpreview.js');
+        return $this->asExtension('FormController')->update($recordId);
+    }
+
+    /**
+     * onPreviewTemplate
+     */
+    public function onPreviewTemplate($recordId = null)
+    {
+        $model = $this->formFindModelObject($recordId);
+        $this->asExtension('FormController')->initForm($model);
+        $this->formGetWidget()->setFormValues();
+
+        $saveData = $this->formGetWidget()->getSaveData();
+        $model->fill($saveData);
+
+        if (isset($saveData['layout_id'])) {
+            $model->setRelation('layout', \System\Models\MailLayout::find($saveData['layout_id']));
+        }
+
+        return ['previewHtml' => MailManager::instance()->renderTemplate($model, [])];
     }
 
     /**

--- a/modules/system/models/maillayout/_field_preview.php
+++ b/modules/system/models/maillayout/_field_preview.php
@@ -1,0 +1,5 @@
+<div
+    data-control="mailformpreview"
+    data-handler="onPreviewLayout"
+    style="padding: 10px 0">
+</div>

--- a/modules/system/models/maillayout/fields.yaml
+++ b/modules/system/models/maillayout/fields.yaml
@@ -49,3 +49,8 @@ secondaryTabs:
             type: checkbox
             tab: "Options"
             default: false
+
+        _preview:
+            type: partial
+            path: ~/modules/system/models/maillayout/_field_preview.php
+            tab: "Preview"

--- a/modules/system/models/mailtemplate/_field_preview.php
+++ b/modules/system/models/mailtemplate/_field_preview.php
@@ -1,0 +1,5 @@
+<div
+    data-control="mailformpreview"
+    data-handler="onPreviewTemplate"
+    style="padding: 10px 0">
+</div>

--- a/modules/system/models/mailtemplate/fields.yaml
+++ b/modules/system/models/mailtemplate/fields.yaml
@@ -41,3 +41,8 @@ secondaryTabs:
             size: giant
             tab: "Plaintext"
             stretch: true
+
+        _preview:
+            type: partial
+            path: ~/modules/system/models/mailtemplate/_field_preview.php
+            tab: "Preview"


### PR DESCRIPTION
Hello,
we always in team had this problem when modifying layout. we can't preview the changes immediately and instead have to send an email to the administrator, which is inefficient.

## Before:
<img width="1583" height="995" alt="image" src="https://github.com/user-attachments/assets/a09e4c6d-3c9f-4cfc-a4af-402eea9e7ec4" />

## After:
<img width="1588" height="989" alt="image" src="https://github.com/user-attachments/assets/5d5e85b5-e411-4fc7-9543-e64138af7aab" />
