### PR TITLE
Fix MediaFinder paste button not updating across fields on the same page

### DIFF
--- a/modules/media/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/media/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -63,6 +63,10 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
             this.listen('click', '.toolbar-select-all', this.onSelectAllClick);
             this.listen('click', '.toolbar-copy-selected', this.onCopySelectedClick);
             this.listen('click', '.toolbar-paste-items', this.onPasteItemsClick);
+
+            // Other MediaFinder instances on the same page need to refresh their
+            // paste button state whenever any instance copies items to the clipboard.
+            oc.Events.on(document, 'oc.mediafinder.clipboardUpdated', this.proxy(this.updateButtonsState));
         }
 
         if (this.config.isSortable) {
@@ -80,6 +84,10 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
 
     disconnect() {
         this.unmountExternalToolbarEventBusEvents();
+
+        if (this.config.isMulti && this.config.useCopyPaste) {
+            oc.Events.off(document, 'oc.mediafinder.clipboardUpdated', this.proxy(this.updateButtonsState));
+        }
 
         this.sortable = null;
         this.$dataLocker = null;
@@ -518,6 +526,7 @@ oc.registerControl('mediafinder', class extends oc.ControlBase {
         }
 
         this.$navigationClipboard.copy(items, 'mediafinder');
+        oc.Events.dispatch('oc.mediafinder.clipboardUpdated');
 
         $.oc.flashMsg({
             text: items.length + oc.lang.get('mediafinder.items_copied_to_clipboard'),


### PR DESCRIPTION
Closes #6103

Copying items from one MediaFinder field and pasting into another MediaFinder field on the same page doesn't work until the page is reloaded. The paste button in the second field stays disabled right after the copy, even though the clipboard now has items it could paste.

Each MediaFinder instance keeps its own toolbar button state and only recalculates it on its own DOM events, so when instance A writes to the shared `localStorage` clipboard, instance B never re-runs `updateButtonsState()` to notice. This patch dispatches a document-level `oc.mediafinder.clipboardUpdated` event after a copy and has every multi/copy-paste-enabled instance listen for it and refresh its own button state, mirroring the `oc.Events` pub/sub pattern already used by other form widgets like colorpicker and paletteeditor.

Tested with two MediaFinder fields on the same form: copying in one now immediately enables the paste button (with the correct new-item count) in the other, without a reload.
