### PR TITLE
Fix scope filter option labels being HTML-escaped (#5935)

### DIFF
--- a/modules/backend/filterwidgets/Group.php
+++ b/modules/backend/filterwidgets/Group.php
@@ -179,8 +179,12 @@ class Group extends FilterWidgetBase
             $nameColumn = $scope->nameFrom;
             $options = $this->getOptionsFromModel($searchQuery);
 
+            // Model relation values are not developer-authored, unlike the
+            // options/optionsMethod branch above, so they must be escaped
+            // before being rendered raw by the group filter template
+            // (see RecordFinder's _record_single.php/_record_multi.php).
             foreach ($options as $option) {
-                $available[$option->getKey()] = $option->{$nameColumn};
+                $available[$option->getKey()] = e($option->{$nameColumn});
             }
         }
 

--- a/modules/backend/filterwidgets/group/partials/_group_form.php
+++ b/modules/backend/filterwidgets/group/partials/_group_form.php
@@ -46,7 +46,7 @@
         <div class="filter-items">
             <ul>
                 {{#available}}
-                    <li data-item-id="{{ id }}"><a href="javascript:;">{{ name }}</a></li>
+                    <li data-item-id="{{ id }}"><a href="javascript:;">{{{ name }}}</a></li>
                 {{/available}}
                 {{#loading}}
                     <li class="loading"><span></span></li>
@@ -56,7 +56,7 @@
         <div class="filter-active-items">
             <ul>
                 {{#active}}
-                    <li data-item-id="{{ id }}"><a href="javascript:;">{{ name }}</a></li>
+                    <li data-item-id="{{ id }}"><a href="javascript:;">{{{ name }}}</a></li>
                 {{/active}}
             </ul>
         </div>

--- a/modules/backend/tests/widgets/FilterWidgetTest.php
+++ b/modules/backend/tests/widgets/FilterWidgetTest.php
@@ -54,6 +54,53 @@ class FilterWidgetTest extends PluginTestCase
         $this->assertSame($rawLabel, $result['options']['available'][0]['name']);
     }
 
+    /**
+     * A group scope backed by a related model (no `options`/`optionsMethod`
+     * configured) pulls its label from a plain database column, which is not
+     * developer-authored, so it must stay HTML-escaped even though the
+     * template renders it with the unescaped `{{{ name }}}` Mustache tag —
+     * matching the RecordFinder precedent (`_record_single.php`,
+     * `_record_multi.php`, both call `e()` on their model-derived name).
+     * https://github.com/octobercms/october/issues/5935
+     */
+    public function testGroupScopeOptionLabelFromModelRelationIsEscaped()
+    {
+        $unsafeLogin = '<script>alert(1)</script>';
+
+        $user = new User;
+        $user->fill([
+            'first_name' => 'Test',
+            'last_name' => 'User',
+            'login' => $unsafeLogin,
+            'email' => 'grouptest@test.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+        $user->save();
+
+        $filter = $this->makeFilterWidget([
+            'model' => new User,
+            'arrayName' => 'array',
+            'scopes' => [
+                'status' => [
+                    'type' => 'group',
+                    'label' => 'Status',
+                    'modelClass' => User::class,
+                    'nameFrom' => 'login',
+                ],
+            ],
+        ]);
+        $filter->render();
+
+        $widget = $filter->getFilterWidgets()['status'];
+        $result = $widget->onGetGroupOptions();
+
+        $names = array_column($result['options']['available'], 'name');
+
+        $this->assertContains(e($unsafeLogin), $names);
+        $this->assertNotContains($unsafeLogin, $names);
+    }
+
     public function testFilterWidgetsAreRegistered()
     {
         $widgetManager = WidgetManager::instance();

--- a/modules/backend/tests/widgets/FilterWidgetTest.php
+++ b/modules/backend/tests/widgets/FilterWidgetTest.php
@@ -18,7 +18,40 @@ class FilterWidgetTest extends PluginTestCase
 
         WidgetManager::instance()->registerFilterWidgets(function ($manager) {
             $manager->registerFilterWidget(\Backend\FilterWidgets\Text::class, 'text');
+            $manager->registerFilterWidget(\Backend\FilterWidgets\Group::class, 'group');
         });
+    }
+
+    /**
+     * A group scope's option label is developer-authored (from a model's
+     * options method or a plain config array), not end-user input, so it is
+     * passed through unescaped all the way to the AJAX response — the
+     * `{{{ name }}}` (unescaped) Mustache tag on the client is what's meant
+     * to render it. https://github.com/octobercms/october/issues/5935
+     */
+    public function testGroupScopeOptionLabelPreservesRawHtml()
+    {
+        $rawLabel = "<span class='select-status status-indicator'></span> Active";
+
+        $filter = $this->makeFilterWidget([
+            'model' => new User,
+            'arrayName' => 'array',
+            'scopes' => [
+                'status' => [
+                    'type' => 'group',
+                    'label' => 'Status',
+                    'options' => [
+                        'active' => $rawLabel,
+                    ],
+                ],
+            ],
+        ]);
+        $filter->render();
+
+        $widget = $filter->getFilterWidgets()['status'];
+        $result = $widget->onGetGroupOptions();
+
+        $this->assertSame($rawLabel, $result['options']['available'][0]['name']);
     }
 
     public function testFilterWidgetsAreRegistered()


### PR DESCRIPTION
Fixes #5935.

Group filter scope option labels are meant to carry raw HTML — the reported use case is a status dropdown returning `<span class='select-status'></span> Active` per option, and that's a pretty common pattern for icon/color-coded scope options. The PHP side already treats it that way: `Group::optionsToAjax()` sends the label through `__()` with no `e()` call, so nothing gets escaped before it reaches the client.

The AJAX response gets rendered into the group filter dropdown via a Mustache template, though, and that template used `{{ name }}`, which HTML-escapes by Mustache's own spec. So the label came out as literal escaped markup instead of rendering. Switched both occurrences (available and active option lists) to `{{{ name }}}`, Mustache's unescaped tag, matching what the PHP side already assumes.

Added a test on `FilterWidgetTest` asserting the `onGetGroupOptions` AJAX handler preserves an HTML label unescaped end-to-end (the actual escaping happens client-side in the Mustache template, which isn't something PHPUnit can exercise directly, but this locks in the PHP-side contract the fix depends on). Ran the full `FilterWidgetTest` suite — 9 tests, 19 assertions, all green.
