### PR TITLE
Avoid treating theme form as a database dependency

### DIFF
--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -463,6 +463,26 @@ class Theme implements CallsMethods
     }
 
     /**
+     * hasAssetVariables returns true if the theme form defines combiner `assetVar` fields
+     */
+    public function hasAssetVariables(): bool
+    {
+        $config = $this->getFormConfig();
+
+        $fields = (array) array_get($config, 'fields') +
+            (array) array_get($config, 'tabs.fields') +
+            (array) array_get($config, 'secondaryTabs.fields');
+
+        foreach ($fields as $field) {
+            if (is_array($field) && array_get($field, 'assetVar')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * getCustomData returns data specific to this theme
      */
     public function getCustomData(): ThemeData
@@ -475,11 +495,13 @@ class Theme implements CallsMethods
      */
     public function removeCustomData(): bool
     {
-        if ($this->hasCustomData()) {
-            return $this->getCustomData()->delete();
+        $themeData = $this->getCustomData();
+
+        if (!$themeData->exists) {
+            return true;
         }
 
-        return true;
+        return (bool) $themeData->delete();
     }
 
     /**
@@ -682,7 +704,8 @@ class Theme implements CallsMethods
             'getConfigArray',
             'getPreviewImageUrl',
             'getCustomData',
-            'hasCustomData'
+            'hasCustomData',
+            'hasAssetVariables'
         ];
     }
 }

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -57,6 +57,14 @@ class ThemeOptions extends Controller
     }
 
     /**
+     * formFindModelObject
+     */
+    public function formFindModelObject($recordId)
+    {
+        return $this->getThemeData($this->getDirName($recordId));
+    }
+
+    /**
      * update
      */
     public function update($dirName = null)
@@ -64,9 +72,7 @@ class ThemeOptions extends Controller
         $dirName = $this->getDirName($dirName);
 
         try {
-            $model = $this->getThemeData($dirName);
-
-            $this->asExtension('FormController')->update($model->id);
+            $this->asExtension('FormController')->update($dirName);
 
             $this->vars['hasCustomData'] = $this->hasThemeData($dirName);
         }
@@ -80,8 +86,7 @@ class ThemeOptions extends Controller
      */
     public function update_onSave($dirName = null)
     {
-        $model = $this->getThemeData($this->getDirName($dirName));
-        $result = $this->asExtension('FormController')->update_onSave($model->id);
+        $result = $this->asExtension('FormController')->update_onSave($this->getDirName($dirName));
 
         // Redirect close requests to the settings index when user doesn't have access
         // to go back to the theme selection page
@@ -98,7 +103,9 @@ class ThemeOptions extends Controller
     public function update_onResetDefault($dirName = null)
     {
         $model = $this->getThemeData($this->getDirName($dirName));
-        $model->delete();
+        if ($model->exists) {
+            $model->delete();
+        }
 
         return Backend::redirect('cms/themeoptions/update/'.$dirName);
     }

--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -1,6 +1,5 @@
 <?php namespace Cms\Models;
 
-use Lang;
 use Model;
 use Event;
 use October\Rain\Html\Helper as HtmlHelper;
@@ -8,7 +7,6 @@ use Cms\Classes\Theme as CmsTheme;
 use System\Classes\CombineAssets;
 use System\Models\File;
 use Exception;
-use PhpParser\Node\Stmt\Else_;
 
 /**
  * ThemeData for theme customization
@@ -94,7 +92,18 @@ class ThemeData extends Model
     }
 
     /**
-     * forTheme returns a cached version of this model, based on a Theme object
+     * afterDelete drops the per-request cache so a missing row is not reused
+     */
+    public function afterDelete()
+    {
+        if ($this->theme) {
+            unset(self::$instances[$this->theme]);
+        }
+    }
+
+    /**
+     * forTheme returns a cached version of this model, based on a Theme object.
+     * A missing row is an unsaved model with yaml defaults, not an insert.
      */
     public static function forTheme(CmsTheme $theme): ThemeData
     {
@@ -104,16 +113,27 @@ class ThemeData extends Model
         }
 
         try {
-            $themeData = static::createThemeDataModel()->firstOrCreate(['theme' => $dirName]);
+            $themeData = static::createThemeDataModel()->firstWhere('theme', $dirName);
         }
         catch (Exception $ex) {
-            // Database failed
-            $themeData = static::createThemeDataModel(['theme' => $dirName]);
+            $themeData = null;
         }
 
-        $themeData->initFormFields();
+        if (!$themeData) {
+            $themeData = static::createThemeDataModel(['theme' => $dirName]);
+            $themeData->initFormFields();
+            $themeData->setDefaultValues();
+        }
 
         return self::$instances[$dirName] = $themeData;
+    }
+
+    /**
+     * clearInternalCache of model instances
+     */
+    public static function clearInternalCache()
+    {
+        self::$instances = [];
     }
 
     /**
@@ -138,12 +158,18 @@ class ThemeData extends Model
     }
 
     /**
-     * beforeValidate set the default values.
+     * beforeValidate set the default values for attributes that were not provided.
      */
     public function beforeValidate()
     {
-        if (!$this->exists) {
-            $this->setDefaultValues();
+        if ($this->exists) {
+            return;
+        }
+
+        foreach ($this->getDefaultValues() as $attribute => $value) {
+            if ($this->{$attribute} === null) {
+                $this->{$attribute} = $value;
+            }
         }
     }
 
@@ -257,7 +283,7 @@ class ThemeData extends Model
     {
         $theme = CmsTheme::getActiveTheme();
 
-        if (!$theme || !$theme->hasCustomData()) {
+        if (!$theme || !$theme->hasAssetVariables()) {
             return;
         }
 
@@ -279,7 +305,7 @@ class ThemeData extends Model
     {
         $theme = CmsTheme::getActiveTheme();
 
-        if (!$theme || !$theme->hasCustomData()) {
+        if (!$theme || !$theme->hasAssetVariables()) {
             return '';
         }
 

--- a/modules/cms/tests/classes/ThemeDataTest.php
+++ b/modules/cms/tests/classes/ThemeDataTest.php
@@ -1,9 +1,36 @@
 <?php
 
 use Cms\Classes\Theme;
+use Cms\Models\ThemeData;
+use October\Rain\Database\Schema\Blueprint;
 
 class ThemeDataTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        ThemeData::flushEventListeners();
+        ThemeData::clearInternalCache();
+
+        if (!Schema::hasTable('cms_theme_data')) {
+            Schema::create('cms_theme_data', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('theme')->nullable()->index();
+                $table->mediumText('data')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function tearDown(): void
+    {
+        ThemeData::whereIn('theme', ['test', 'formonlytest'])->delete();
+        ThemeData::clearInternalCache();
+
+        parent::tearDown();
+    }
+
     /**
      * testAutoJsonable
      */
@@ -14,5 +41,85 @@ class ThemeDataTest extends TestCase
         $this->assertTrue($theme->isJsonable('nestedform'));
         $this->assertTrue($theme->isJsonable('breakdown'));
         $this->assertTrue($theme->isJsonable('nested'));
+    }
+
+    public function testForThemeDoesNotCreateRow()
+    {
+        $this->assertNull(ThemeData::where('theme', 'test')->first());
+
+        $themeData = Theme::load('test')->getCustomData();
+
+        $this->assertFalse($themeData->exists);
+        $this->assertEquals('test', $themeData->theme);
+        $this->assertNull(ThemeData::where('theme', 'test')->first());
+    }
+
+    public function testForThemeUsesYamlDefaultsWhenUnsaved()
+    {
+        $themeData = Theme::load('formonlytest')->getCustomData();
+
+        $this->assertFalse($themeData->exists);
+        $this->assertEquals('October', $themeData->site_name);
+        $this->assertNull(ThemeData::where('theme', 'formonlytest')->first());
+    }
+
+    public function testForThemeReturnsSavedRow()
+    {
+        $saved = Theme::load('formonlytest')->getCustomData();
+        $saved->site_name = 'Custom';
+        $saved->save();
+
+        $this->assertTrue($saved->exists);
+        ThemeData::clearInternalCache();
+
+        $themeData = Theme::load('formonlytest')->getCustomData();
+
+        $this->assertTrue($themeData->exists);
+        $this->assertEquals('Custom', $themeData->site_name);
+    }
+
+    public function testCombinerSkipsThemesWithoutAssetVariables()
+    {
+        Config::set('cms.active_theme', 'formonlytest');
+        Event::forget('cms.theme.getActiveTheme');
+        Theme::resetCache();
+
+        $this->assertSame('', ThemeData::getCombinerCacheKey());
+        ThemeData::applyAssetVariablesToCombinerFilters([]);
+
+        $this->assertNull(ThemeData::where('theme', 'formonlytest')->first());
+    }
+
+    public function testCombinerCacheKeyUsesSavedUpdatedAt()
+    {
+        Config::set('cms.active_theme', 'test');
+        Event::forget('cms.theme.getActiveTheme');
+        Theme::resetCache();
+
+        $this->assertSame('', ThemeData::getCombinerCacheKey());
+        $this->assertNull(ThemeData::where('theme', 'test')->first());
+
+        $saved = Theme::load('test')->getCustomData();
+        $saved->position = 'left';
+        $saved->save();
+
+        ThemeData::clearInternalCache();
+
+        $this->assertEquals((string) $saved->updated_at, ThemeData::getCombinerCacheKey());
+    }
+
+    public function testDeleteDoesNotRecreateRow()
+    {
+        $saved = Theme::load('formonlytest')->getCustomData();
+        $saved->site_name = 'Custom';
+        $saved->save();
+
+        $this->assertTrue((bool) $saved->delete());
+        $this->assertNull(ThemeData::where('theme', 'formonlytest')->first());
+
+        $reloaded = Theme::load('formonlytest')->getCustomData();
+
+        $this->assertFalse($reloaded->exists);
+        $this->assertEquals('October', $reloaded->site_name);
     }
 }

--- a/modules/cms/tests/classes/ThemeTest.php
+++ b/modules/cms/tests/classes/ThemeTest.php
@@ -95,4 +95,31 @@ class ThemeTest extends TestCase
         $this->assertNotNull($activeTheme);
         $this->assertEquals('apitest', $activeTheme->getDirName());
     }
+
+    public function testHasAssetVariables()
+    {
+        $this->assertTrue(Theme::load('test')->hasAssetVariables());
+        $this->assertTrue(Theme::load('test')->hasCustomData());
+
+        $this->assertFalse(Theme::load('formonlytest')->hasAssetVariables());
+        $this->assertTrue(Theme::load('formonlytest')->hasCustomData());
+
+        $this->assertFalse(Theme::load('parenttest')->hasAssetVariables());
+        $this->assertFalse(Theme::load('parenttest')->hasCustomData());
+    }
+
+    public function testHasAssetVariablesInheritsParentForm()
+    {
+        Event::listen('cms.theme.extendFormConfig', function ($themeCode, &$config) {
+            if ($themeCode === 'parenttest') {
+                $config['fields']['header_color'] = [
+                    'label' => 'Header Colour',
+                    'assetVar' => 'header-bg',
+                ];
+            }
+        });
+
+        $this->assertTrue(Theme::load('parenttest')->hasAssetVariables());
+        $this->assertTrue(Theme::load('childtest')->hasAssetVariables());
+    }
 }

--- a/modules/cms/tests/fixtures/themes/formonlytest/theme.yaml
+++ b/modules/cms/tests/fixtures/themes/formonlytest/theme.yaml
@@ -1,0 +1,12 @@
+name: Form Only Test
+description: 'Theme fixture with a customization form and no assetVar fields.'
+author: October CMS
+homepage: 'https://octobercms.com'
+code: ''
+
+form:
+    fields:
+        site_name:
+            label: Site Name
+            type: text
+            default: October


### PR DESCRIPTION
Adding `form:` to `theme.yaml` makes `Theme::hasCustomData()` true. Frontend combiner listeners treat that as “load `cms_theme_data`”:

- `cms.combiner.getCacheKey` → `ThemeData::getCombinerCacheKey()`
- `cms.combiner.beforePrepare` → `ThemeData::applyAssetVariablesToCombinerFilters()`

Both call `Theme::getCustomData()` → `ThemeData::forTheme()`, which `firstOrCreate`s by theme dirname. A page view therefore hits (or creates) a `cms_theme_data` row whenever the theme has a customization form.

### What the frontend actually needs

| Caller | Needs DB? |
|---|---|
| Combiner presets | Only if the form has `assetVar` fields, and only saved overrides |
| Combiner cache key | Only a version token (`updated_at`) when those vars exist |
| Twig `this.theme.foo` | Only when a template reads custom data |
| Theme Options | Yes, create on save |

Yaml already has the schema. Defaults live on the fields. A missing row means “use defaults,” not “insert.”

### Fix

1. **Gate the combiner on `assetVar`, not `form:`**  
   Add `Theme::hasAssetVariables()` that scans `getFormConfig()` (and the parent theme). If false, both combiner listeners return immediately

2. **Make the read path `first()`, not `firstOrCreate()`.**  
   `forTheme()` / `getCustomData()` should return an unsaved model with yaml defaults when no row exists. Create the row when Theme Options saves