### PR TITLE
Cache theme data between requests

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -163,7 +163,7 @@ return [
     |
     */
 
-    'enable_data_cache' => env('CMS_DATA_CACHE', false),
+    'enable_theme_data_cache' => env('CMS_THEME_DATA_CACHE', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/cms.php
+++ b/config/cms.php
@@ -152,6 +152,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Determines if the theme data caching is enabled.
+    |--------------------------------------------------------------------------
+    |
+    | If the caching is enabled, theme customization records are cached between
+    | requests. Saving or deleting theme options busts that cache. Changes to
+    | form field definitions in theme.yaml are not invalidated automatically;
+    | use the clear cache command. It is recommended to disable the caching
+    | during the development, and enable it in the production mode.
+    |
+    */
+
+    'enable_data_cache' => env('CMS_DATA_CACHE', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Determines if the asset minification is enabled.
     |--------------------------------------------------------------------------
     |

--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -112,7 +112,7 @@ class ThemeData extends Model
             return $themeData;
         }
 
-        $cacheEnabled = Config::get('cms.enable_data_cache');
+        $cacheEnabled = Config::get('cms.enable_theme_data_cache');
         $cacheKey = static::getCacheKey($dirName);
 
         if ($cacheEnabled && is_array($cacheData = Cache::get($cacheKey))) {

--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -70,9 +70,7 @@ class ThemeData extends Model
      */
     public function afterDelete()
     {
-        if ($dirName = $this->theme) {
-            $this->clearCache($dirName);
-        }
+        $this->clearCache($this->theme);
     }
 
     /**
@@ -97,9 +95,7 @@ class ThemeData extends Model
     public function afterSave()
     {
         try {
-            if ($dirName = $this->theme) {
-                $this->clearCache($dirName);
-            }
+            $this->clearCache($this->theme);
             CombineAssets::resetCache();
         }
         catch (Exception $ex) {
@@ -116,11 +112,11 @@ class ThemeData extends Model
             return $themeData;
         }
 
-        $enableDataCache = Config::get('cms.enable_data_cache');
+        $cacheEnabled = Config::get('cms.enable_data_cache');
         $cacheKey = static::getCacheKey($dirName);
 
-        if ($enableDataCache && is_array($cached = Cache::get($cacheKey))) {
-            return self::$instances[$dirName] = static::newFromCache($cached);
+        if ($cacheEnabled && is_array($cacheData = Cache::get($cacheKey))) {
+            return self::$instances[$dirName] = static::newFromCache($cacheData);
         }
 
         try {
@@ -135,7 +131,7 @@ class ThemeData extends Model
 
         self::$instances[$dirName] = $themeData;
 
-        if ($enableDataCache && $themeData->exists) {
+        if ($cacheEnabled && $themeData->exists) {
             Cache::put($cacheKey, static::getCacheableAttributes($themeData), now()->addMinutes(1440));
         }
 

--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -1,6 +1,7 @@
 <?php namespace Cms\Models;
 
-use Lang;
+use Cache;
+use Config;
 use Model;
 use Event;
 use October\Rain\Html\Helper as HtmlHelper;
@@ -8,7 +9,6 @@ use Cms\Classes\Theme as CmsTheme;
 use System\Classes\CombineAssets;
 use System\Models\File;
 use Exception;
-use PhpParser\Node\Stmt\Else_;
 
 /**
  * ThemeData for theme customization
@@ -66,6 +66,16 @@ class ThemeData extends Model
     protected static $instances = [];
 
     /**
+     * clear cached theme data when the record is removed.
+     */
+    public function afterDelete()
+    {
+        if ($dirName = $this->theme) {
+            $this->clearCache($dirName);
+        }
+    }
+
+    /**
      * beforeSave the model, strip dynamic attributes applied from config.
      */
     public function beforeSave()
@@ -87,6 +97,9 @@ class ThemeData extends Model
     public function afterSave()
     {
         try {
+            if ($dirName = $this->theme) {
+                $this->clearCache($dirName);
+            }
             CombineAssets::resetCache();
         }
         catch (Exception $ex) {
@@ -103,6 +116,13 @@ class ThemeData extends Model
             return $themeData;
         }
 
+        $enableDataCache = Config::get('cms.enable_data_cache');
+        $cacheKey = static::getCacheKey($dirName);
+
+        if ($enableDataCache && is_array($cached = Cache::get($cacheKey))) {
+            return self::$instances[$dirName] = static::newFromCache($cached);
+        }
+
         try {
             $themeData = static::createThemeDataModel()->firstOrCreate(['theme' => $dirName]);
         }
@@ -113,7 +133,41 @@ class ThemeData extends Model
 
         $themeData->initFormFields();
 
-        return self::$instances[$dirName] = $themeData;
+        self::$instances[$dirName] = $themeData;
+
+        if ($enableDataCache && $themeData->exists) {
+            Cache::put($cacheKey, static::getCacheableAttributes($themeData), now()->addMinutes(1440));
+        }
+
+        return $themeData;
+    }
+
+    /**
+     * getCacheableAttributes returns the persisted columns stored in cache
+     */
+    protected static function getCacheableAttributes(ThemeData $themeData): array
+    {
+        $data = $themeData->getOriginal('data') ?? $themeData->data;
+
+        if (is_string($data)) {
+            $data = json_decode($data, true) ?: [];
+        }
+
+        return [
+            'id' => $themeData->getOriginal('id') ?? $themeData->getKey(),
+            'theme' => $themeData->getOriginal('theme') ?? $themeData->theme,
+            'data' => (array) $data,
+            'created_at' => (string) ($themeData->getOriginal('created_at') ?? $themeData->created_at),
+            'updated_at' => (string) ($themeData->getOriginal('updated_at') ?? $themeData->updated_at),
+        ];
+    }
+
+    /**
+     * newFromCache rehydrates a model from cached row attributes
+     */
+    protected static function newFromCache(array $attributes): ThemeData
+    {
+        return static::createThemeDataModel()->newFromBuilder($attributes);
     }
 
     /**
@@ -135,6 +189,14 @@ class ThemeData extends Model
         }
 
         $this->setRawAttributes((array) $this->getAttributes() + $data, true);
+    }
+
+    /**
+     * clearCache forgets the stored query result
+     */
+    public function clearCache($dirName)
+    {
+        Cache::forget(static::getCacheKey($dirName));
     }
 
     /**
@@ -268,6 +330,14 @@ class ThemeData extends Model
                 $filter->setPresets($assetVars);
             }
         }
+    }
+
+    /**
+     * getCacheKey returns a cache key for this theme data record
+     */
+    public static function getCacheKey(string $theme): string
+    {
+        return 'cms.theme.data.'.$theme;
     }
 
     /**

--- a/modules/cms/tests/classes/ThemeDataTest.php
+++ b/modules/cms/tests/classes/ThemeDataTest.php
@@ -1,9 +1,34 @@
 <?php
 
+use Cache;
 use Cms\Classes\Theme;
+use Cms\Models\ThemeData;
+use Illuminate\Support\Facades\Schema;
+use October\Rain\Database\Schema\Blueprint;
 
 class ThemeDataTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cms.active_theme', 'test');
+        Config::set('cms.enable_data_cache', false);
+        Event::forget('cms.theme.getActiveTheme');
+        Theme::resetCache();
+
+        $this->resetThemeDataInstances();
+        $this->createThemeDataTable();
+    }
+
+    public function tearDown(): void
+    {
+        $this->resetThemeDataInstances();
+        Schema::dropIfExists('cms_theme_data');
+
+        parent::tearDown();
+    }
+
     /**
      * testAutoJsonable
      */
@@ -14,5 +39,132 @@ class ThemeDataTest extends TestCase
         $this->assertTrue($theme->isJsonable('nestedform'));
         $this->assertTrue($theme->isJsonable('breakdown'));
         $this->assertTrue($theme->isJsonable('nested'));
+    }
+
+    public function testForThemeDoesNotCacheWhenDisabled()
+    {
+        Config::set('cms.enable_data_cache', false);
+
+        ThemeData::forTheme(Theme::load('test'));
+
+        $this->assertNull(Cache::get(ThemeData::getCacheKey('test')));
+    }
+
+    public function testForThemeStoresRowAttributesWhenEnabled()
+    {
+        Config::set('cms.enable_data_cache', true);
+
+        $themeData = ThemeData::forTheme(Theme::load('test'));
+        $cached = Cache::get(ThemeData::getCacheKey('test'));
+
+        $this->assertIsArray($cached);
+        $this->assertSame($themeData->id, $cached['id']);
+        $this->assertSame('test', $cached['theme']);
+        $this->assertIsArray($cached['data']);
+        $this->assertArrayHasKey('created_at', $cached);
+        $this->assertArrayHasKey('updated_at', $cached);
+    }
+
+    public function testForThemeRehydratesFromCache()
+    {
+        Config::set('cms.enable_data_cache', true);
+
+        $theme = Theme::load('test');
+        $themeData = ThemeData::forTheme($theme);
+        $themeData->position = 'top';
+        $themeData->save();
+
+        $this->resetThemeDataInstances();
+        $warmed = ThemeData::forTheme($theme);
+        $this->assertEquals('top', $warmed->position);
+        $this->assertTrue($warmed->isJsonable('nestedform'));
+
+        ThemeData::where('theme', 'test')->update([
+            'data' => json_encode(['position' => 'left'])
+        ]);
+
+        $this->resetThemeDataInstances();
+        $fromCache = ThemeData::forTheme($theme);
+
+        $this->assertEquals('top', $fromCache->position);
+        $this->assertTrue($fromCache->exists);
+        $this->assertEquals($warmed->id, $fromCache->id);
+    }
+
+    public function testSaveBustsThemeDataCache()
+    {
+        Config::set('cms.enable_data_cache', true);
+
+        $theme = Theme::load('test');
+        $themeData = ThemeData::forTheme($theme);
+        $themeData->position = 'top';
+        $themeData->save();
+
+        $this->resetThemeDataInstances();
+        ThemeData::forTheme($theme);
+        $this->assertNotNull(Cache::get(ThemeData::getCacheKey('test')));
+
+        $themeData->position = 'left';
+        $themeData->save();
+
+        $this->assertNull(Cache::get(ThemeData::getCacheKey('test')));
+
+        $this->resetThemeDataInstances();
+        $reloaded = ThemeData::forTheme($theme);
+        $this->assertEquals('left', $reloaded->position);
+    }
+
+    public function testDeleteBustsThemeDataCache()
+    {
+        Config::set('cms.enable_data_cache', true);
+
+        $theme = Theme::load('test');
+        $themeData = ThemeData::forTheme($theme);
+        $themeData->position = 'top';
+        $themeData->save();
+
+        $this->resetThemeDataInstances();
+        ThemeData::forTheme($theme);
+        $this->assertNotNull(Cache::get(ThemeData::getCacheKey('test')));
+
+        $themeData->delete();
+
+        $this->assertNull(Cache::get(ThemeData::getCacheKey('test')));
+    }
+
+    public function testLegacyCachedModelIsIgnored()
+    {
+        Config::set('cms.enable_data_cache', true);
+
+        $theme = Theme::load('test');
+        $themeData = ThemeData::forTheme($theme);
+        $themeData->position = 'top';
+        $themeData->save();
+
+        $this->resetThemeDataInstances();
+        Cache::put(ThemeData::getCacheKey('test'), $themeData, now()->addMinutes(1440));
+
+        $fromDatabase = ThemeData::forTheme($theme);
+
+        $this->assertInstanceOf(ThemeData::class, $fromDatabase);
+        $this->assertEquals('top', $fromDatabase->position);
+        $this->assertIsArray(Cache::get(ThemeData::getCacheKey('test')));
+    }
+
+    protected function resetThemeDataInstances(): void
+    {
+        self::setProtectedProperty(new ThemeData, 'instances', []);
+    }
+
+    protected function createThemeDataTable(): void
+    {
+        Schema::dropIfExists('cms_theme_data');
+
+        Schema::create('cms_theme_data', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('theme')->nullable()->index();
+            $table->mediumText('data')->nullable();
+            $table->timestamps();
+        });
     }
 }


### PR DESCRIPTION
Adds a `CMS_THEME_DATA_CACHE` environment variable that caches theme data between requests.

Currently it's only cached in memory, so that data is lost on the next request and causes a database hit. The in memory data is still preferred, so when a cache hit occurs it places the value there, as if it had been fetched normally.

There are no user facing behavior changes.